### PR TITLE
Set vector tile API key in Java code

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -8,6 +8,7 @@
     <suppress checks="MemberName" files=".*src/test/java/*" />
     <suppress checks="MagicNumberCheck" files=".*src/test/java/*" />
     <suppress checks="JavadocMethod" files=".*src/test/java/*" />
+    <suppress checks="JavadocMethod" files="DependencyInjector.java" />
     <suppress checks="JavadocType" files=".*src/test/java/*" />
     <suppress checks="JavadocStyle" files=".*src/test/java/*" />
 </suppressions>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -66,6 +66,7 @@
         -->
         <module name="JavadocStyle">
             <property name="checkEmptyJavadoc" value="true" />
+            <property name="checkHtml" value="false" />
         </module>
 
         <!-- Checks for Naming Conventions.                  -->

--- a/library/src/main/java/com/mapzen/android/MapFragment.java
+++ b/library/src/main/java/com/mapzen/android/MapFragment.java
@@ -30,6 +30,14 @@ public class MapFragment extends Fragment {
     }
 
     /**
+     * Asynchronously creates the map and configures the vector tiles API key using the given
+     * string parameter. Uses default stylesheet (bubble wrap).
+     */
+    public void getMapAsync(final MapView.OnMapReadyCallback callback, final String key) {
+        mapView.getMapAsync(callback, key);
+    }
+
+    /**
      * Synchronously creates map manager for interaction with map and location manager.
      *
      * @return newly created {@link MapManager} instance or existing instance

--- a/library/src/main/java/com/mapzen/android/MapInitializer.java
+++ b/library/src/main/java/com/mapzen/android/MapInitializer.java
@@ -1,29 +1,23 @@
 package com.mapzen.android;
 
+import com.mapzen.android.dagger.DI;
 import com.mapzen.tangram.MapController;
-
-import android.content.Context;
-import android.content.res.Resources;
 
 import javax.inject.Inject;
 
 /**
  * Class responsible for initializing the map.
  */
-class MapInitializer {
+public class MapInitializer {
     private static final String DEFAULT_SCENE_FILE = "style/bubble-wrap.yaml";
-    private static final String API_KEY_RES_NAME = "vector_tiles_key";
-    private static final String API_KEY_RES_TYPE = "string";
 
-    private final Context context;
-    private final Resources res;
+    @Inject TileHttpHandler httpHandler;
 
     /**
      * Creates a new instance.
      */
-    @Inject MapInitializer(Context context, Resources res) {
-        this.context = context;
-        this.res = res;
+    @Inject MapInitializer() {
+        DI.component().inject(this);
     }
 
     /**
@@ -31,13 +25,22 @@ class MapInitializer {
      * {@link MapView.OnMapReadyCallback}.
      */
     public void init(final MapView mapView, final MapView.OnMapReadyCallback callback) {
-        final String packageName = context.getPackageName();
-        final int apiKeyId = res.getIdentifier(API_KEY_RES_NAME, API_KEY_RES_TYPE, packageName);
-        final String apiKey = res.getString(apiKeyId);
+        loadMap(mapView, callback);
+    }
 
+    /**
+     * Initialize map for the current {@link MapView} with given API key and notify via
+     * {@link MapView.OnMapReadyCallback}.
+     */
+    public void init(final MapView mapView, final MapView.OnMapReadyCallback callback, String key) {
+        httpHandler.setApiKey(key);
+        loadMap(mapView, callback);
+    }
+
+    private void loadMap(final MapView mapView, final MapView.OnMapReadyCallback callback) {
         mapView.getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
             @Override public void onMapReady(MapController mapController) {
-                mapController.setHttpHandler(new TileHttpHandler(apiKey));
+                mapController.setHttpHandler(httpHandler);
                 mapView.mapController = mapController;
                 callback.onMapReady(mapController);
             }

--- a/library/src/main/java/com/mapzen/android/MapView.java
+++ b/library/src/main/java/com/mapzen/android/MapView.java
@@ -39,10 +39,23 @@ public class MapView extends com.mapzen.tangram.MapView {
     }
 
     /**
-     * Load map asynchronously.
+     * Load map asynchronously using APK key declared in XML resources. For example:
+     * {@code <string name="vector_tiles_key">[YOUR_VECTOR_TILES_KEY]</string>}
+     *
+     * @param callback listener to be invoked when map is initialized and ready to use.
      */
     public void getMapAsync(@NonNull OnMapReadyCallback callback) {
         mapInitializer.init(this, callback);
+    }
+
+    /**
+     * Load map asynchronously using given API key.
+     *
+     * @param callback listener to be invoked when map is initialized and ready to use.
+     * @param key vector tiles API key that should be used to load map tiles.
+     */
+    public void getMapAsync(@NonNull OnMapReadyCallback callback, @NonNull String key) {
+        mapInitializer.init(this, callback, key);
     }
 
     /**

--- a/library/src/main/java/com/mapzen/android/TileHttpHandler.java
+++ b/library/src/main/java/com/mapzen/android/TileHttpHandler.java
@@ -8,16 +8,16 @@ import com.squareup.okhttp.Request;
 /**
  * A handler responsible for appending an API key to vector tile requests.
  */
-class TileHttpHandler extends HttpHandler {
+public class TileHttpHandler extends HttpHandler {
     static final String PARAM_API_KEY = "?api_key=";
 
-    private final String apiKey;
+    private String apiKey;
 
     /**
      * Creates a new HTTP handler.
      * @param apiKey key to append to all requests.
      */
-    TileHttpHandler(String apiKey) {
+    public TileHttpHandler(String apiKey) {
         this.apiKey = apiKey;
     }
 
@@ -39,5 +39,13 @@ class TileHttpHandler extends HttpHandler {
     @Override public void onCancel(String url) {
         final String urlWithKey = url + PARAM_API_KEY + apiKey;
         super.onCancel(urlWithKey);
+    }
+
+    void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    String getApiKey() {
+        return apiKey;
     }
 }

--- a/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
+++ b/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.dagger;
 
+import com.mapzen.android.TileHttpHandler;
+
 import android.content.Context;
 import android.content.res.Resources;
 
@@ -13,6 +15,9 @@ import dagger.Provides;
  */
 @Module
 public class AndroidModule {
+    private static final String API_KEY_RES_NAME = "vector_tiles_key";
+    private static final String API_KEY_RES_TYPE = "string";
+
     private final Context context;
 
     /**
@@ -33,9 +38,19 @@ public class AndroidModule {
     }
 
     /**
-     * Provide Android application resources.
+     * Provides Android application resources.
      */
     @Provides @Singleton public Resources provideResources() {
         return context.getResources();
+    }
+
+    /**
+     * Provides HTTP handler to append API key to outgoing vector tile requests.
+     */
+    @Provides @Singleton public TileHttpHandler provideTileHttpHandler(Resources res) {
+        final String packageName = context.getPackageName();
+        final int apiKeyId = res.getIdentifier(API_KEY_RES_NAME, API_KEY_RES_TYPE, packageName);
+        final String apiKey = res.getString(apiKeyId);
+        return new TileHttpHandler(apiKey);
     }
 }

--- a/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
+++ b/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.dagger;
 
+import com.mapzen.android.MapInitializer;
 import com.mapzen.android.MapView;
 
 import android.content.Context;
@@ -18,10 +19,8 @@ class DependencyInjector {
     @Singleton
     @Component(modules = { AndroidModule.class, CommonModule.class })
     public interface LibraryComponent {
-        /**
-         * Inject dependencies into {@link MapView} component.
-         */
         void inject(MapView mapView);
+        void inject(MapInitializer mapInitializer);
     }
 
     private LibraryComponent component;

--- a/library/src/test/java/com/mapzen/android/MapInitializerTest.java
+++ b/library/src/test/java/com/mapzen/android/MapInitializerTest.java
@@ -1,18 +1,17 @@
 package com.mapzen.android;
 
+import com.mapzen.android.dagger.DI;
 import com.mapzen.tangram.MapController;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import android.content.Context;
-import android.content.res.Resources;
-
+import static com.mapzen.android.TestHelper.getMockContext;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -20,27 +19,37 @@ import static org.mockito.Mockito.verify;
 @SuppressStaticInitializationFor("com.mapzen.tangram.MapController")
 public class MapInitializerTest {
 
-    private Context context = mock(Context.class);
-    private Resources res = mock(Resources.class);
-    private MapInitializer mapInitializer = new MapInitializer(context, res);
+    private MapInitializer mapInitializer;
+
+    @Before
+    public void setUp() throws Exception {
+        DI.init(getMockContext());
+        mapInitializer = new MapInitializer();
+    }
 
     @Test public void shouldNotBeNull() throws Exception {
         assertThat(mapInitializer).isNotNull();
     }
 
-    @Test
-    public void init_shouldReturnMapController() throws Exception {
+    @Test public void init_shouldReturnMapController() throws Exception {
         final TestCallback callback = new TestCallback();
         final TestMapView mapView = new TestMapView();
         mapInitializer.init(mapView, callback);
         assertThat(callback.map).isInstanceOf(MapController.class);
     }
 
-    @Test
-    public void init_shouldSetHttpHandler() throws Exception {
+    @Test public void init_shouldSetHttpHandler() throws Exception {
         final TestCallback callback = new TestCallback();
         final TestMapView mapView = new TestMapView();
         mapInitializer.init(mapView, callback);
         verify(callback.map, times(1)).setHttpHandler((TileHttpHandler) Mockito.any());
+    }
+
+    @Test public void init_shouldSetHttpHandlerWithGivenApiKey() throws Exception {
+        final TestCallback callback = new TestCallback();
+        final TestMapView mapView = new TestMapView();
+        final String key = "vector-tiles-test-key";
+        mapInitializer.init(mapView, callback, key);
+        assertThat(mapInitializer.httpHandler.getApiKey()).isEqualTo(key);
     }
 }

--- a/library/src/test/java/com/mapzen/android/MapViewTest.java
+++ b/library/src/test/java/com/mapzen/android/MapViewTest.java
@@ -33,4 +33,13 @@ public class MapViewTest {
         mapView.getMapAsync(callback);
         verify(mapInitializer, times(1)).init(mapView, callback);
     }
+
+    @Test public void getMapAsync_shouldInvokeMapInitializerWithApiKey() throws Exception {
+        final MapInitializer mapInitializer = mock(MapInitializer.class);
+        final MapView.OnMapReadyCallback callback = new TestCallback();
+        final String key = "vector-tiles-test-key";
+        mapView.mapInitializer = mapInitializer;
+        mapView.getMapAsync(callback, key);
+        verify(mapInitializer, times(1)).init(mapView, callback, key);
+    }
 }


### PR DESCRIPTION
Adds ability to set the vector tiles API key via `MapView#getMapAsync(callback, key)`. This way client app developers can secure the API key in code rather than specifying it in an XML resource. Providing the API key via XML resource is still supported as a convenience for debug builds and sample apps.

Closes #25
