### PR TITLE
Include library transitive dependencies in sample app

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -40,8 +40,9 @@ task verify(dependsOn: [
 ])
 
 dependencies {
-  compile project(':library')
+  compile (project(':library')) {
+    transitive = true;
+  }
   compile 'com.android.support:appcompat-v7:23.2.1'
   compile 'com.android.support:design:23.2.1'
-  compile 'com.mapzen.tangram:tangram:0.2-SNAPSHOT'
 }


### PR DESCRIPTION
Adds `transitive = true` to library dependency in the sample app `build.gradle` file. This alleviates the need to declare transitive dependencies such as Tangram to make the API directly available in the app.