### PR TITLE
Adds MapzenMap

### DIFF
--- a/library/src/main/java/com/mapzen/android/MapFragment.java
+++ b/library/src/main/java/com/mapzen/android/MapFragment.java
@@ -25,7 +25,7 @@ public class MapFragment extends Fragment {
      * Asynchronously creates the map and configures the vector tiles API key using the string
      * resource declared in the client application. Uses default stylesheet (bubble wrap).
      */
-    public void getMapAsync(final MapView.OnMapReadyCallback callback) {
+    public void getMapAsync(final OnMapReadyCallback callback) {
         mapView.getMapAsync(callback);
     }
 
@@ -33,7 +33,7 @@ public class MapFragment extends Fragment {
      * Asynchronously creates the map and configures the vector tiles API key using the given
      * string parameter. Uses default stylesheet (bubble wrap).
      */
-    public void getMapAsync(final MapView.OnMapReadyCallback callback, final String key) {
+    public void getMapAsync(final OnMapReadyCallback callback, final String key) {
         mapView.getMapAsync(callback, key);
     }
 

--- a/library/src/main/java/com/mapzen/android/MapInitializer.java
+++ b/library/src/main/java/com/mapzen/android/MapInitializer.java
@@ -21,18 +21,17 @@ public class MapInitializer {
     }
 
     /**
-     * Initialize map for the current {@link MapView} and notify via
-     * {@link MapView.OnMapReadyCallback}.
+     * Initialize map for the current {@link MapView} and notify via {@link OnMapReadyCallback}.
      */
-    public void init(final MapView mapView, final MapView.OnMapReadyCallback callback) {
+    public void init(final MapView mapView, final OnMapReadyCallback callback) {
         loadMap(mapView, callback);
     }
 
     /**
      * Initialize map for the current {@link MapView} with given API key and notify via
-     * {@link MapView.OnMapReadyCallback}.
+     * {@link OnMapReadyCallback}.
      */
-    public void init(final MapView mapView, final MapView.OnMapReadyCallback callback, String key) {
+    public void init(final MapView mapView, final OnMapReadyCallback callback, String key) {
         httpHandler.setApiKey(key);
         loadMap(mapView, callback);
     }
@@ -41,12 +40,12 @@ public class MapInitializer {
         return mapView.getTangramMapView();
     }
 
-    private void loadMap(final MapView mapView, final MapView.OnMapReadyCallback callback) {
+    private void loadMap(final MapView mapView, final OnMapReadyCallback callback) {
         getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
             @Override public void onMapReady(MapController mapController) {
                 mapController.setHttpHandler(httpHandler);
                 mapView.mapController = mapController;
-                callback.onMapReady(mapController);
+                callback.onMapReady(new MapzenMap(mapController));
             }
         }, DEFAULT_SCENE_FILE);
     }

--- a/library/src/main/java/com/mapzen/android/MapInitializer.java
+++ b/library/src/main/java/com/mapzen/android/MapInitializer.java
@@ -37,8 +37,8 @@ public class MapInitializer {
         loadMap(mapView, callback);
     }
 
-    private TangramMap getTangramView(final MapView mapView) {
-        return mapView.getTangramMap();
+    private TangramMapView getTangramView(final MapView mapView) {
+        return mapView.getTangramMapView();
     }
 
     private void loadMap(final MapView mapView, final MapView.OnMapReadyCallback callback) {

--- a/library/src/main/java/com/mapzen/android/MapView.java
+++ b/library/src/main/java/com/mapzen/android/MapView.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
 public class MapView extends RelativeLayout {
     @Inject MapInitializer mapInitializer;
 
-    TangramMap tangramMap;
+    TangramMapView tangramMapView;
     ImageButton findMe;
     MapController mapController;
 
@@ -56,7 +56,7 @@ public class MapView extends RelativeLayout {
 
     @Override protected void onFinishInflate() {
         super.onFinishInflate();
-        tangramMap = (TangramMap) findViewById(R.id.map);
+        tangramMapView = (TangramMapView) findViewById(R.id.map);
         findMe = (ImageButton) findViewById(R.id.find_me);
     }
 
@@ -64,8 +64,8 @@ public class MapView extends RelativeLayout {
      * Get the underlying Tangram map object.
      * @return
      */
-    public TangramMap getTangramMap() {
-        return tangramMap;
+    public TangramMapView getTangramMapView() {
+        return tangramMapView;
     }
 
     /**

--- a/library/src/main/java/com/mapzen/android/MapView.java
+++ b/library/src/main/java/com/mapzen/android/MapView.java
@@ -89,17 +89,6 @@ public class MapView extends RelativeLayout {
     }
 
     /**
-     * Interface for receiving a {@code MapController} once it is ready to be used.
-     */
-    public interface OnMapReadyCallback {
-        /**
-         * Called when the map is ready to be used.
-         * @param mapController A non-null {@code MapController} instance for this {@code MapView}.
-         */
-        void onMapReady(MapController mapController);
-    }
-
-    /**
      * Show button for finding user's location on map.
      * @return
      */

--- a/library/src/main/java/com/mapzen/android/MapzenMap.java
+++ b/library/src/main/java/com/mapzen/android/MapzenMap.java
@@ -1,0 +1,27 @@
+package com.mapzen.android;
+
+import com.mapzen.tangram.MapController;
+
+/**
+ * This is the main class of the Mapzen Android API and is the entry point for all methods related
+ * to the map. You cannot instantiate a {@link MapzenMap} object directly. Rather you must obtain
+ * one from {@link MapFragment#getMapAsync(MapView.OnMapReadyCallback)} or
+ * {@link MapView#getMapAsync(MapView.OnMapReadyCallback)}.
+ */
+public class MapzenMap {
+    private final MapController mapController;
+
+    /**
+     * Creates a new map based on the given {@link MapController}.
+     */
+    MapzenMap(MapController mapController) {
+        this.mapController = mapController;
+    }
+
+    /**
+     * Provides access to the underlying Tangram {@link MapController}.
+     */
+    public MapController getMapController() {
+        return mapController;
+    }
+}

--- a/library/src/main/java/com/mapzen/android/OnMapReadyCallback.java
+++ b/library/src/main/java/com/mapzen/android/OnMapReadyCallback.java
@@ -1,0 +1,12 @@
+package com.mapzen.android;
+
+/**
+ * Interface for receiving a {@code MapController} once it is ready to be used.
+ */
+public interface OnMapReadyCallback {
+    /**
+     * Called when the map is ready to be used.
+     * @param mapzenMap A non-null {@link MapzenMap} instance for this {@code MapView}.
+     */
+    void onMapReady(MapzenMap mapzenMap);
+}

--- a/library/src/main/java/com/mapzen/android/TangramMapView.java
+++ b/library/src/main/java/com/mapzen/android/TangramMapView.java
@@ -7,21 +7,21 @@ import android.util.AttributeSet;
  * Entry point for interaction with Tangram map. Wrapped inside of {@link MapView}.
  * Do not use this class directly, instead access it via {@link MapView}.
  */
-public class TangramMap extends com.mapzen.tangram.MapView {
+public class TangramMapView extends com.mapzen.tangram.MapView {
 
     /**
-     * Creates a new {@link TangramMap}.
+     * Creates a new {@link TangramMapView}.
      * @param context
      */
-    public TangramMap(Context context) {
+    public TangramMapView(Context context) {
         super(context);
     }
 
     /**
-     * Creates a new {@link TangramMap}.
+     * Creates a new {@link TangramMapView}.
      * @param context
      */
-    public TangramMap(Context context, AttributeSet attrs) {
+    public TangramMapView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 }

--- a/library/src/main/res/layout/view_map.xml
+++ b/library/src/main/res/layout/view_map.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent" android:layout_height="match_parent">
 
-    <com.mapzen.android.TangramMap
+    <com.mapzen.android.TangramMapView
         android:id="@+id/map"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/library/src/test/java/com/mapzen/android/MapFragmentTest.java
+++ b/library/src/test/java/com/mapzen/android/MapFragmentTest.java
@@ -1,11 +1,8 @@
 package com.mapzen.android;
 
-import com.mapzen.tangram.MapController;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -16,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -44,16 +42,16 @@ public class MapFragmentTest {
     }
 
     @Test
-    public void getMap_shouldReturnMapController() throws Exception {
+    public void getMap_shouldReturnMapzenMap() throws Exception {
         TestCallback callback = new TestCallback();
         mapFragment.getMapAsync(callback);
-        assertThat(callback.map).isInstanceOf(MapController.class);
+        assertThat(callback.map).isInstanceOf(MapzenMap.class);
     }
 
     @Test
     public void getMap_shouldSetHttpHandler() throws Exception {
         TestCallback callback = new TestCallback();
         mapFragment.getMapAsync(callback);
-        Mockito.verify(callback.map, times(1)).setHttpHandler((TileHttpHandler) Mockito.any());
+        verify(callback.map.getMapController(), times(1)).setHttpHandler((TileHttpHandler) any());
     }
 }

--- a/library/src/test/java/com/mapzen/android/MapInitializerTest.java
+++ b/library/src/test/java/com/mapzen/android/MapInitializerTest.java
@@ -1,17 +1,16 @@
 package com.mapzen.android;
 
 import com.mapzen.android.dagger.DI;
-import com.mapzen.tangram.MapController;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.mapzen.android.TestHelper.getMockContext;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -31,18 +30,18 @@ public class MapInitializerTest {
         assertThat(mapInitializer).isNotNull();
     }
 
-    @Test public void init_shouldReturnMapController() throws Exception {
+    @Test public void init_shouldReturnMapzenMap() throws Exception {
         final TestCallback callback = new TestCallback();
         final TestMapView mapView = new TestMapView();
         mapInitializer.init(mapView, callback);
-        assertThat(callback.map).isInstanceOf(MapController.class);
+        assertThat(callback.map).isInstanceOf(MapzenMap.class);
     }
 
     @Test public void init_shouldSetHttpHandler() throws Exception {
         final TestCallback callback = new TestCallback();
         final TestMapView mapView = new TestMapView();
         mapInitializer.init(mapView, callback);
-        verify(callback.map, times(1)).setHttpHandler((TileHttpHandler) Mockito.any());
+        verify(callback.map.getMapController(), times(1)).setHttpHandler((TileHttpHandler) any());
     }
 
     @Test public void init_shouldSetHttpHandlerWithGivenApiKey() throws Exception {

--- a/library/src/test/java/com/mapzen/android/MapViewTest.java
+++ b/library/src/test/java/com/mapzen/android/MapViewTest.java
@@ -4,7 +4,6 @@ import com.mapzen.tangram.MapController;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
 import static com.mapzen.android.TestHelper.getMockContext;
@@ -12,13 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MapViewTest {
     private MapView mapView;
 
     @Before public void setup() throws Exception {
         mapView = PowerMockito.spy(new MapView(getMockContext()));
-        Mockito.when(mapView.getTangramMap()).thenReturn(mock(TangramMap.class));
+        when(mapView.getTangramMapView()).thenReturn(mock(TangramMapView.class));
     }
 
     @Test public void shouldNotBeNull() throws Exception {

--- a/library/src/test/java/com/mapzen/android/MapViewTest.java
+++ b/library/src/test/java/com/mapzen/android/MapViewTest.java
@@ -1,7 +1,5 @@
 package com.mapzen.android;
 
-import com.mapzen.tangram.MapController;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
@@ -26,17 +24,13 @@ public class MapViewTest {
     }
 
     @Test public void getMapAsync_shouldInjectMapInitializer() throws Exception {
-        mapView.getMapAsync(new TestCallback() {
-            @Override public void onMapReady(MapController mapController) {
-            }
-        });
-
+        mapView.getMapAsync(new TestCallback());
         assertThat(mapView.mapInitializer).isNotNull();
     }
 
     @Test public void getMapAsync_shouldInvokeMapInitializer() throws Exception {
         final MapInitializer mapInitializer = mock(MapInitializer.class);
-        final MapView.OnMapReadyCallback callback = new TestCallback();
+        final OnMapReadyCallback callback = new TestCallback();
         mapView.mapInitializer = mapInitializer;
         mapView.getMapAsync(callback);
         verify(mapInitializer, times(1)).init(mapView, callback);
@@ -44,7 +38,7 @@ public class MapViewTest {
 
     @Test public void getMapAsync_shouldInvokeMapInitializerWithApiKey() throws Exception {
         final MapInitializer mapInitializer = mock(MapInitializer.class);
-        final MapView.OnMapReadyCallback callback = new TestCallback();
+        final OnMapReadyCallback callback = new TestCallback();
         final String key = "vector-tiles-test-key";
         mapView.mapInitializer = mapInitializer;
         mapView.getMapAsync(callback, key);

--- a/library/src/test/java/com/mapzen/android/MapzenMapTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenMapTest.java
@@ -1,0 +1,31 @@
+package com.mapzen.android;
+
+import com.mapzen.tangram.MapController;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("com.mapzen.tangram.MapController")
+public class MapzenMapTest {
+
+    private MapzenMap map;
+
+    @Before public void setUp() throws Exception {
+        map = new MapzenMap(mock(MapController.class));
+    }
+
+    @Test public void shouldNotBeNull() throws Exception {
+        assertThat(map).isNotNull();
+    }
+
+    @Test public void getMapController_shouldNotBeNull() throws Exception {
+        assertThat(map.getMapController()).isNotNull();
+    }
+}

--- a/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
@@ -7,7 +7,6 @@ import com.mapzen.android.model.Polyline;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapData;
-import com.mapzen.tangram.TestMapController;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/library/src/test/java/com/mapzen/android/TestCallback.java
+++ b/library/src/test/java/com/mapzen/android/TestCallback.java
@@ -1,11 +1,9 @@
 package com.mapzen.android;
 
-import com.mapzen.tangram.MapController;
+public class TestCallback implements OnMapReadyCallback {
+    MapzenMap map;
 
-public class TestCallback implements MapView.OnMapReadyCallback {
-    MapController map;
-
-    @Override public void onMapReady(MapController mapController) {
-        map = mapController;
+    @Override public void onMapReady(MapzenMap map) {
+        this.map = map;
     }
 }

--- a/library/src/test/java/com/mapzen/android/TestMapController.java
+++ b/library/src/test/java/com/mapzen/android/TestMapController.java
@@ -1,4 +1,7 @@
-package com.mapzen.tangram;
+package com.mapzen.android;
+
+import com.mapzen.tangram.LngLat;
+import com.mapzen.tangram.MapController;
 
 import org.mockito.Mockito;
 

--- a/library/src/test/java/com/mapzen/android/TestMapView.java
+++ b/library/src/test/java/com/mapzen/android/TestMapView.java
@@ -19,7 +19,7 @@ public class TestMapView extends MapView {
         callback.onMapReady(mock(MapController.class));
     }
 
-    @Override public TangramMap getTangramMap() {
+    @Override public TangramMapView getTangramMapView() {
         return new TestTangramMapView(mock(Context.class));
     }
 }

--- a/library/src/test/java/com/mapzen/android/TestMapView.java
+++ b/library/src/test/java/com/mapzen/android/TestMapView.java
@@ -16,7 +16,7 @@ public class TestMapView extends MapView {
     @Override public void getMapAsync(
             @NonNull OnMapReadyCallback callback,
             @NonNull String sceneFilePath) {
-        callback.onMapReady(mock(MapController.class));
+        callback.onMapReady(new MapzenMap(mock(MapController.class)));
     }
 
     @Override public TangramMapView getTangramMapView() {

--- a/library/src/test/java/com/mapzen/android/TestTangramMapView.java
+++ b/library/src/test/java/com/mapzen/android/TestTangramMapView.java
@@ -8,7 +8,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 
-public class TestTangramMapView extends TangramMap {
+public class TestTangramMapView extends TangramMapView {
 
     public TestTangramMapView(Context context) {
         super(context);

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,4 +45,5 @@ dependencies {
   }
   compile 'com.android.support:appcompat-v7:23.2.1'
   compile 'com.android.support:design:23.2.1'
+  compile 'com.mapzen.tangram:tangram:0.2-SNAPSHOT'
 }

--- a/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
@@ -1,8 +1,9 @@
 package com.mapzen.android.sample;
 
 import com.mapzen.android.MapFragment;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.OnMapReadyCallback;
 import com.mapzen.android.OverlayManager;
-import com.mapzen.android.MapView;
 import com.mapzen.tangram.MapController;
 
 import android.os.Bundle;
@@ -23,9 +24,9 @@ public class BasicMapzenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sample_mapzen);
 
         mapFragment = (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-        mapFragment.getMapAsync(new MapView.OnMapReadyCallback() {
-            @Override public void onMapReady(MapController mapController) {
-                BasicMapzenActivity.this.mapController = mapController;
+        mapFragment.getMapAsync(new OnMapReadyCallback() {
+            @Override public void onMapReady(MapzenMap map) {
+                BasicMapzenActivity.this.mapController = map.getMapController();
                 configureMap();
             }
         });

--- a/sample/src/main/java/com/mapzen/android/sample/MarkerMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/MarkerMapzenActivity.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.sample;
 
 import com.mapzen.android.MapFragment;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.OnMapReadyCallback;
 import com.mapzen.android.OverlayManager;
 import com.mapzen.android.model.Marker;
 import com.mapzen.tangram.LngLat;
@@ -25,9 +27,9 @@ public class MarkerMapzenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sample_mapzen);
 
         mapFragment = (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-        mapFragment.getMapAsync(new com.mapzen.android.MapView.OnMapReadyCallback() {
-            @Override public void onMapReady(MapController mapController) {
-                MarkerMapzenActivity.this.mapController = mapController;
+        mapFragment.getMapAsync(new OnMapReadyCallback() {
+            @Override public void onMapReady(MapzenMap map) {
+                MarkerMapzenActivity.this.mapController = map.getMapController();
                 configureMap();
             }
         });

--- a/sample/src/main/java/com/mapzen/android/sample/PolygonMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/PolygonMapzenActivity.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.sample;
 
 import com.mapzen.android.MapFragment;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.OnMapReadyCallback;
 import com.mapzen.android.OverlayManager;
 import com.mapzen.android.model.Polygon;
 import com.mapzen.tangram.LngLat;
@@ -26,9 +28,9 @@ public class PolygonMapzenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sample_mapzen);
 
         mapFragment = (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-        mapFragment.getMapAsync(new com.mapzen.android.MapView.OnMapReadyCallback() {
-            @Override public void onMapReady(MapController mapController) {
-                PolygonMapzenActivity.this.mapController = mapController;
+        mapFragment.getMapAsync(new OnMapReadyCallback() {
+            @Override public void onMapReady(MapzenMap map) {
+                PolygonMapzenActivity.this.mapController = map.getMapController();
                 configureMap();
             }
         });

--- a/sample/src/main/java/com/mapzen/android/sample/PolylineMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/PolylineMapzenActivity.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.sample;
 
 import com.mapzen.android.MapFragment;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.OnMapReadyCallback;
 import com.mapzen.android.OverlayManager;
 import com.mapzen.android.model.Polyline;
 import com.mapzen.tangram.LngLat;
@@ -26,9 +28,9 @@ public class PolylineMapzenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sample_mapzen);
 
         mapFragment = (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-        mapFragment.getMapAsync(new com.mapzen.android.MapView.OnMapReadyCallback() {
-            @Override public void onMapReady(MapController mapController) {
-                PolylineMapzenActivity.this.mapController = mapController;
+        mapFragment.getMapAsync(new OnMapReadyCallback() {
+            @Override public void onMapReady(MapzenMap map) {
+                PolylineMapzenActivity.this.mapController = map.getMapController();
                 configureMap();
             }
         });


### PR DESCRIPTION
Adds `MapzenMap` wrapper for `MapController`.

TODO: Make `OverlayManager` a member of `MapzenMap` to provide a single class API for all common map operations including markers and overlays. Add wrapper methods for common `MapController` methods. Add ability to switch between bundled stylesheets.