### PR TITLE
Circle CI updates

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ checkout:
 
 test:
   override:
-    - ./gradlew clean verify assembleDebug
+    - ./gradlew clean verify
 
 deployment:
   master:

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -60,6 +60,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 task verify(dependsOn: [
+    'compileDebugSources',
     'test',
     'checkstyle',
     'lint'


### PR DESCRIPTION
Replaces `assembleDebug` with `compileDebugSources` on Circle CI.

This way we can still detect compile errors in the sample app but avoid the dreaded `transformClassesWithDexForDebug` which spawns a ridiculous number of threads (4 per library) and eats up all the memory allocated to the container causing the build to intermittently fail. Nom Nom.

* Adds `compileDebugSources` to Gradle verify task
* Removes `assembleDebug` from `circle.yml` test tasks