### PR TITLE
Update my location layer

### DIFF
--- a/library/src/main/java/com/mapzen/android/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/OverlayManager.java
@@ -26,7 +26,8 @@ public class OverlayManager {
 
   private static final int LOCATION_REQUEST_INTERVAL_MILLIS = 5000;
   private static final int LOCATION_REQUEST_DISPLACEMENT_MILLIS = 5000;
-  private static final int ANIMATION_DURATION_MILLIS = 300;
+  private static final int ANIMATION_DURATION_MILLIS = 500;
+  private static final float DEFAULT_ZOOM = 16f;
 
   static final String NAME_CURRENT_LOCATION = "mz_current_location";
   private static final String NAME_POLYLINE = "mz_default_line";
@@ -432,6 +433,7 @@ public class OverlayManager {
     }
 
     final LngLat lngLat = new LngLat(location.getLongitude(), location.getLatitude());
+    mapController.setZoomEased(DEFAULT_ZOOM, ANIMATION_DURATION_MILLIS);
     mapController.setPositionEased(lngLat, ANIMATION_DURATION_MILLIS);
     mapController.requestRender();
   }

--- a/library/src/main/java/com/mapzen/android/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/OverlayManager.java
@@ -28,7 +28,7 @@ public class OverlayManager {
   private static final int LOCATION_REQUEST_DISPLACEMENT_MILLIS = 5000;
   private static final int ANIMATION_DURATION_MILLIS = 300;
 
-  private static final String NAME_CURRENT_LOCATION = "mz_current_location";
+  static final String NAME_CURRENT_LOCATION = "mz_current_location";
   private static final String NAME_POLYLINE = "mz_default_line";
   private static final String NAME_POLYGON = "mz_default_polygon";
   private static final String NAME_MARKER = "mz_default_point";
@@ -383,12 +383,19 @@ public class OverlayManager {
   private void centerMap() {
     locationRequested = true;
     showLastKnownLocation();
+    centerMapOnLastKnownLocation();
   }
 
   private void showLastKnownLocation() {
     final Location current = LocationServices.FusedLocationApi.getLastLocation();
     if (current != null) {
       updateCurrentLocationMapData(current);
+    }
+  }
+
+  private void centerMapOnLastKnownLocation() {
+    final Location current = LocationServices.FusedLocationApi.getLastLocation();
+    if (current != null) {
       updateMapPosition(current);
     }
   }

--- a/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
@@ -27,6 +27,7 @@ import android.widget.ImageButton;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -350,6 +351,32 @@ import static org.powermock.api.mockito.PowerMockito.spy;
     overlayManager.setMyLocationEnabled(true);
     testFindMeButton.performClick();
     assertThat(listener.click).isTrue();
+  }
+
+  @Test public void onClickFindMe_shouldUpdateCurrentLocationMarker() throws Exception {
+    TestButton testFindMeButton = new TestButton(null);
+    OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
+    MapData mapData = mock(MapData.class);
+    when(mapController.addDataLayer(OverlayManager.NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapView.showFindMe()).thenReturn(testFindMeButton);
+    when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
+    overlayManager.setMyLocationEnabled(true);
+    testFindMeButton.performClick();
+    verify(mapData, times(2)).clear();
+    verify(mapData, times(2)).addPoint(any(LngLat.class), any(Map.class));
+  }
+
+  @Test public void onClickFindMe_shouldUpdateMapPosition() throws Exception {
+    TestButton testFindMeButton = new TestButton(null);
+    OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
+    MapData mapData = mock(MapData.class);
+    when(mapController.addDataLayer(OverlayManager.NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapView.showFindMe()).thenReturn(testFindMeButton);
+    when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
+    overlayManager.setMyLocationEnabled(true);
+    testFindMeButton.performClick();
+    verify(mapController, times(1)).setPositionEased(any(LngLat.class), anyInt());
+    verify(mapController, times(1)).requestRender();
   }
 
   private class TestOnClickListener implements View.OnClickListener {

--- a/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
@@ -51,15 +51,21 @@ import static org.powermock.api.mockito.PowerMockito.spy;
   private OverlayManager overlayManager;
   private MapView mapView;
   private LostApiClient lostApiClient;
+  private TestButton findMeButton;
+  private MapData mapData;
 
   @Before public void setup() throws Exception {
     mapController = mock(TestMapController.class);
     lostApiClient = mock(LostApiClient.class);
     mapView = mock(MapView.class);
+    mapData = mock(MapData.class);
     LocationServices.FusedLocationApi = Mockito.mock(FusedLocationProviderApiImpl.class);
     overlayManager = spy(new OverlayManager(mapView, mapController, lostApiClient));
     doNothing().when(overlayManager, "addCurrentLocationMapData");
     doNothing().when(overlayManager, "handleMyLocationEnabledChanged");
+    findMeButton = new TestButton(null);
+    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapView.showFindMe()).thenReturn(findMeButton);
   }
 
   @Test public void setMyLocationEnabled_shouldCenterMapOnCurrentLocation() throws Exception {
@@ -344,51 +350,38 @@ import static org.powermock.api.mockito.PowerMockito.spy;
 
   @Test public void setFindMeOnClickListener_shouldInvokeListenerOnButtonClick() throws Exception {
     TestOnClickListener listener = new TestOnClickListener();
-    TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
 
-    when(mapView.showFindMe()).thenReturn(testFindMeButton);
+    when(mapView.showFindMe()).thenReturn(findMeButton);
     overlayManager.setFindMeOnClickListener(listener);
     overlayManager.setMyLocationEnabled(true);
-    testFindMeButton.performClick();
+    findMeButton.performClick();
     assertThat(listener.click).isTrue();
   }
 
   @Test public void onClickFindMe_shouldUpdateCurrentLocationMarker() throws Exception {
-    TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
-    MapData mapData = mock(MapData.class);
-    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
-    when(mapView.showFindMe()).thenReturn(testFindMeButton);
     when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
     overlayManager.setMyLocationEnabled(true);
-    testFindMeButton.performClick();
+    findMeButton.performClick();
     verify(mapData, times(2)).clear();
     verify(mapData, times(2)).addPoint(any(LngLat.class), any(Map.class));
   }
 
   @Test public void onClickFindMe_shouldUpdateMapPosition() throws Exception {
-    TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
-    MapData mapData = mock(MapData.class);
-    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
-    when(mapView.showFindMe()).thenReturn(testFindMeButton);
     when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
     overlayManager.setMyLocationEnabled(true);
-    testFindMeButton.performClick();
+    findMeButton.performClick();
     verify(mapController, times(1)).setPositionEased(any(LngLat.class), anyInt());
     verify(mapController, times(1)).requestRender();
   }
 
   @Test public void onClickFindMe_shouldZoomMap() throws Exception {
-    TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
-    MapData mapData = mock(MapData.class);
-    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
-    when(mapView.showFindMe()).thenReturn(testFindMeButton);
     when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
     overlayManager.setMyLocationEnabled(true);
-    testFindMeButton.performClick();
+    findMeButton.performClick();
     verify(mapController, times(1)).setZoomEased(anyFloat(), anyInt());
     verify(mapController, times(1)).requestRender();
   }

--- a/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/OverlayManagerTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.mapzen.android.OverlayManager.NAME_CURRENT_LOCATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyFloat;
@@ -357,7 +358,7 @@ import static org.powermock.api.mockito.PowerMockito.spy;
     TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
     MapData mapData = mock(MapData.class);
-    when(mapController.addDataLayer(OverlayManager.NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
     when(mapView.showFindMe()).thenReturn(testFindMeButton);
     when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
     overlayManager.setMyLocationEnabled(true);
@@ -370,12 +371,25 @@ import static org.powermock.api.mockito.PowerMockito.spy;
     TestButton testFindMeButton = new TestButton(null);
     OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
     MapData mapData = mock(MapData.class);
-    when(mapController.addDataLayer(OverlayManager.NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
     when(mapView.showFindMe()).thenReturn(testFindMeButton);
     when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
     overlayManager.setMyLocationEnabled(true);
     testFindMeButton.performClick();
     verify(mapController, times(1)).setPositionEased(any(LngLat.class), anyInt());
+    verify(mapController, times(1)).requestRender();
+  }
+
+  @Test public void onClickFindMe_shouldZoomMap() throws Exception {
+    TestButton testFindMeButton = new TestButton(null);
+    OverlayManager overlayManager = new OverlayManager(mapView, mapController, lostApiClient);
+    MapData mapData = mock(MapData.class);
+    when(mapController.addDataLayer(NAME_CURRENT_LOCATION)).thenReturn(mapData);
+    when(mapView.showFindMe()).thenReturn(testFindMeButton);
+    when(LocationServices.FusedLocationApi.getLastLocation()).thenReturn(new Location("test"));
+    overlayManager.setMyLocationEnabled(true);
+    testFindMeButton.performClick();
+    verify(mapController, times(1)).setZoomEased(anyFloat(), anyInt());
     verify(mapController, times(1)).requestRender();
   }
 


### PR DESCRIPTION
Map position is no longer automatically updated when the current location layer is enabled. Instead the position is set only when the user clicks the find me button. Showing the current location marker is now decoupled from centering the map on the current location.

In addition clicking the find me button will zoom the map to a default zoom level (16).

This patch also adds unit test for the find me button click handler.