### PR TITLE
Add route key management

### DIFF
--- a/library/src/main/java/com/mapzen/android/MapzenRouter.java
+++ b/library/src/main/java/com/mapzen/android/MapzenRouter.java
@@ -1,0 +1,174 @@
+package com.mapzen.android;
+
+import com.mapzen.valhalla.RouteCallback;
+import com.mapzen.valhalla.Router;
+import com.mapzen.valhalla.ValhallaRouter;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Log;
+
+import java.util.HashMap;
+
+/**
+ * Main class for interaction with Mapzen's turn-by-turn service.
+ */
+public class MapzenRouter {
+
+  private static final String API_KEY_RES_NAME = "turn_by_turn_key";
+  private static final String API_KEY_RES_TYPE = "string";
+  private static final String TAG = MapzenRouter.class.getSimpleName();
+
+  private Router internalRouter = new ValhallaRouter();
+  private Context context;
+
+  private static final HashMap<DistanceUnits, Router.DistanceUnits> UNITS_TO_ROUTER_UNITS =
+      new HashMap<>();
+  static {
+    UNITS_TO_ROUTER_UNITS.put(DistanceUnits.MILES, Router.DistanceUnits.MILES);
+    UNITS_TO_ROUTER_UNITS.put(DistanceUnits.KILOMETERS, Router.DistanceUnits.KILOMETERS);
+  }
+
+  /**
+   * Creates a new {@link MapzenRouter}.
+   * @param context
+   */
+  public MapzenRouter(Context context) {
+    this.context = context;
+    initializeRouterKey();
+    initializeRouterUrl();
+  }
+
+  private void initializeRouterKey() {
+    final String packageName = context.getPackageName();
+    Resources res = context.getResources();
+    try {
+      final int apiKeyId = res.getIdentifier(API_KEY_RES_NAME, API_KEY_RES_TYPE, packageName);
+      final String apiKey = res.getString(apiKeyId);
+      internalRouter.setApiKey(apiKey);
+    } catch (Resources.NotFoundException e) {
+      Log.e(TAG, e.getLocalizedMessage());
+    }
+  }
+
+  private void initializeRouterUrl() {
+    internalRouter.setEndpoint(ValhallaRouter.DEFAULT_URL);
+  }
+
+  /**
+   * Set's the turn-by-turn api key.
+   * @param key
+   */
+  public MapzenRouter setApiKey(String key) {
+    internalRouter.setApiKey(key);
+    return this;
+  }
+
+
+  /**
+   * Fetch a route for the given configuration.
+   */
+  public void fetch() {
+    internalRouter.fetch();
+  }
+
+  /**
+   * Set the callback to be invoked after calling {@link MapzenRouter#fetch()}.
+   * @param callback
+   * @return
+   */
+  public MapzenRouter setCallback(RouteCallback callback) {
+    internalRouter.setCallback(callback);
+    return this;
+  }
+
+  /**
+   * Set the distance units on the router.
+   * @param units
+   * @return
+   */
+  public MapzenRouter setDistanceUnits(DistanceUnits units) {
+    internalRouter.setDistanceUnits(UNITS_TO_ROUTER_UNITS.get(units));
+    return this;
+  }
+
+  /**
+   * The router can fetch different types of directions. Set the type to be biking.
+   * @return
+   */
+  public MapzenRouter setBiking() {
+    internalRouter.setBiking();
+    return this;
+  }
+
+  /**
+   * The router can fetch different types of directions. Set the type to be driving.
+   * @return
+   */
+  public MapzenRouter setDriving() {
+    internalRouter.setDriving();
+    return this;
+  }
+
+  /**
+   * The router can fetch different types of directions. Set the type to be walking.
+   * @return
+   */
+  public MapzenRouter setWalking() {
+    internalRouter.setWalking();
+    return this;
+  }
+
+  /**
+   * Adds a location to the route.
+   * @param point
+   * @return
+   */
+  public MapzenRouter setLocation(double[] point) {
+    internalRouter.setLocation(point);
+    return this;
+  }
+
+  /**
+   * Adds a location and heading to the route.
+   * @param point
+   * @return
+   */
+  public MapzenRouter setLocation(double[] point, float heading) {
+    internalRouter.setLocation(point, heading);
+    return this;
+  }
+
+  /**
+   * Adds a location, name, street, city, and state to the route.
+   * @param point
+   * @return
+   */
+  public MapzenRouter setLocation(double[] point, String name, String street, String city,
+      String state) {
+    internalRouter.setLocation(point, name, street, city, state);
+    return this;
+  }
+
+  /**
+   * Remove all locations from the route.
+   * @return
+   */
+  public MapzenRouter clearLocations() {
+    internalRouter.clearLocations();
+    return this;
+  }
+
+  public Router getRouter() {
+    return internalRouter;
+  }
+
+  /**
+   * Units of distance.
+   */
+  public enum DistanceUnits {
+    MILES,
+    KILOMETERS
+  }
+
+}

--- a/library/src/main/java/com/mapzen/android/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/OverlayManager.java
@@ -455,14 +455,20 @@ public class OverlayManager {
   }
 
   private MapData addPolylineToPolylineMapData(List<LngLat> coordinates) {
-    return polylineMapData.addPolyline(coordinates, null);
+    MapData mapData = polylineMapData.addPolyline(coordinates, null);
+    mapController.requestRender();
+    return mapData;
   }
 
   private MapData addPolygonToPolygonMapData(List<List<LngLat>> coordinates) {
-    return polygonMapData.addPolygon(coordinates, null);
+    MapData mapData = polygonMapData.addPolygon(coordinates, null);
+    mapController.requestRender();
+    return mapData;
   }
 
   private MapData addPointToMarkerMapData(Marker marker) {
-    return markerMapData.addPoint(marker.getLocation(), null);
+    MapData mapData = markerMapData.addPoint(marker.getLocation(), null);
+    mapController.requestRender();
+    return mapData;
   }
 }

--- a/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
@@ -1,0 +1,124 @@
+package com.mapzen.android;
+
+import com.mapzen.valhalla.Route;
+import com.mapzen.valhalla.RouteCallback;
+import com.mapzen.valhalla.Router;
+import com.mapzen.valhalla.ValhallaRouter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import static com.mapzen.android.TestHelper.getMockContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MapzenRouterTest {
+
+  MapzenRouter router;
+
+  @Before
+  public void setup() {
+    Context context = getMockContext();
+    Resources resources = context.getResources();
+    Mockito.when(resources.getIdentifier("turn_by_turn_key", "string", null)).thenReturn(101);
+    Mockito.when(resources.getString(101)).thenReturn("TEST_KEY");
+    router = new MapzenRouter(context);
+  }
+
+  @Test
+  public void routerShouldHaveEndpoint() {
+    assertThat(router.getRouter().getEndpoint()).isEqualTo(ValhallaRouter.DEFAULT_URL);
+  }
+
+  @Test
+  public void routerShouldHaveApiKey() {
+    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
+    String apiKey = (String) Whitebox.getInternalState(valhallaRouter, "API_KEY");
+    assertThat(apiKey).isEqualTo("TEST_KEY");
+  }
+
+  @Test
+  public void setApiKey_shouldSetKey() {
+    router.setApiKey("test");
+    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
+    String apiKey = (String) Whitebox.getInternalState(valhallaRouter, "API_KEY");
+    assertThat(apiKey).isEqualTo("test");
+  }
+
+  @Test
+  public void fetch_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    router.fetch();
+    verify(router.getRouter()).fetch();
+  }
+
+  @Test
+  public void setCallback_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    TestRouteCallback callback = new TestRouteCallback();
+    router.setCallback(callback);
+    verify(router.getRouter()).setCallback(callback);
+  }
+
+  @Test
+  public void setDistanceUnits_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    router.setDistanceUnits(MapzenRouter.DistanceUnits.MILES);
+    verify(router.getRouter()).setDistanceUnits(Router.DistanceUnits.MILES);
+  }
+
+  @Test
+  public void setBiking_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    router.setBiking();
+    verify(router.getRouter()).setBiking();
+  }
+
+  @Test
+  public void setDriving_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    router.setDriving();
+    verify(router.getRouter()).setDriving();
+  }
+
+  @Test
+  public void setWalking_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    router.setBiking();
+    verify(router.getRouter()).setBiking();
+  }
+
+  @Test
+  public void setLocation_shouldInvokeInternalRouter() {
+    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
+    double[] point = {70.0, 30.0};
+    router.setLocation(point);
+    verify(router.getRouter()).setLocation(point);
+    float heading = 1.5f;
+    router.setLocation(point, heading);
+    verify(router.getRouter()).setLocation(point, heading);
+    String name = "Num Pang Sandwich";
+    String street = "Broadway";
+    String city = "New York";
+    String state = "New York";
+    router.setLocation(point, name, street, city, state);
+    verify(router.getRouter()).setLocation(point, name, street, city, state);
+  }
+
+  class TestRouteCallback implements RouteCallback {
+
+    @Override public void success(Route route) {
+
+    }
+
+    @Override public void failure(int i) {
+
+    }
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
     <activity android:name=".SearchResultsActivity"/>
     <activity android:name="FeaturePickListenerActivity"/>
     <activity android:name=".QueueEventActivity"/>
+    <activity android:name=".RouterActivity" />
   </application>
 
 </manifest>

--- a/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
@@ -1,0 +1,127 @@
+package com.mapzen.android.sample;
+
+import com.mapzen.android.MapFragment;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.MapzenRouter;
+import com.mapzen.android.OnMapReadyCallback;
+import com.mapzen.android.model.Marker;
+import com.mapzen.android.model.Polyline;
+import com.mapzen.model.ValhallaLocation;
+import com.mapzen.tangram.LngLat;
+import com.mapzen.tangram.MapData;
+import com.mapzen.tangram.TouchInput;
+import com.mapzen.valhalla.Route;
+import com.mapzen.valhalla.RouteCallback;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Demonstrates how to use {@link MapzenRouter}.
+ */
+public class RouterActivity extends AppCompatActivity {
+
+  MapzenMap map;
+  MapzenRouter router;
+  MapData markerMapData;
+  MapData lineMapData;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_route);
+
+    router = new MapzenRouter(this);
+
+    final MapFragment mapFragment =
+        (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
+    mapFragment.getMapAsync(new OnMapReadyCallback() {
+      @Override public void onMapReady(MapzenMap map) {
+        RouterActivity.this.map = map;
+        configureMap();
+        configureBtns();
+        configureRouter();
+      }
+    });
+  }
+
+  private void configureMap() {
+    map.setMyLocationEnabled(true);
+    map.setZoom(15f);
+    map.setPosition(new LngLat(-73.9918, 40.73633));
+    map.setTapResponder(new TouchInput.TapResponder() {
+      @Override public boolean onSingleTapUp(float x, float y) {
+        LngLat point = map.coordinatesAtScreenPosition(x, y);
+        addPointToRoute(point);
+        return false;
+      }
+
+      @Override public boolean onSingleTapConfirmed(float x, float y) {
+        return false;
+      }
+    });
+  }
+
+  private void configureBtns() {
+    Button clearBtn = (Button) findViewById(R.id.clear_btn);
+    clearBtn.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        router.clearLocations();
+        if (lineMapData != null) {
+          lineMapData.clear();
+        }
+        if (markerMapData != null) {
+          markerMapData.clear();
+        }
+      }
+    });
+
+    Button routeBtn = (Button) findViewById(R.id.route_btn);
+    routeBtn.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        router.fetch();
+      }
+    });
+
+  }
+
+  private void configureRouter() {
+    router.setWalking();
+    router.setCallback(new RouteCallback() {
+      @Override public void success(Route route) {
+        List<LngLat> coordinates = new ArrayList<>();
+        for (ValhallaLocation location : route.getGeometry()) {
+            coordinates.add(new LngLat(location.getLongitude(), location.getLatitude()));
+        }
+        Polyline polyline = new Polyline(coordinates);
+        lineMapData = map.addPolyline(polyline);
+      }
+
+      @Override public void failure(int i) {
+        Log.d("Fail", "Failed to get route");
+      }
+    });
+  }
+
+  private void addPointToRoute(LngLat lngLat) {
+    double[] point = {lngLat.latitude, lngLat.longitude};
+    router.setLocation(point);
+    Marker marker = new Marker(lngLat.longitude, lngLat.latitude);
+    markerMapData = map.addMarker(marker);
+  }
+
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    if (lineMapData != null) {
+      lineMapData.clear();
+    }
+    if (markerMapData != null) {
+      markerMapData.clear();
+    }
+  }
+}

--- a/sample/src/main/java/com/mapzen/android/sample/SampleDetailsList.java
+++ b/sample/src/main/java/com/mapzen/android/sample/SampleDetailsList.java
@@ -47,6 +47,9 @@ public final class SampleDetailsList {
           FeaturePickListenerActivity.class),
       new SampleDetails(R.string.queue_event_map_demo_label,
           R.string.queue_event_map_demo_description,
-          QueueEventActivity.class)
+          QueueEventActivity.class),
+      new SampleDetails(R.string.router_map_demo_label,
+          R.string.router_map_demo_description,
+          RouterActivity.class)
   };
 }

--- a/sample/src/main/res/layout/activity_route.xml
+++ b/sample/src/main/res/layout/activity_route.xml
@@ -1,0 +1,32 @@
+<fragment android:id="@+id/fragment"
+    android:name="com.mapzen.android.MapFragment"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    >
+
+  <LinearLayout
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      >
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/clear"
+        android:id="@+id/clear_btn"
+        />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/route"
+        android:id="@+id/route_btn"
+        />
+
+  </LinearLayout>
+
+</fragment>

--- a/sample/src/main/res/values/mapzen.xml
+++ b/sample/src/main/res/values/mapzen.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="vector_tiles_key">[YOUR_VECTOR_TILES_KEY]</string>
+  <string name="turn_by_turn_key">[YOUR_TURN_BY_TURN_KEY]</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -64,4 +64,7 @@
   <string name="view_complete">Animations complete</string>
   <string name="queue_event_map_demo_label">Queue Event</string>
   <string name="queue_event_map_demo_description">Queues a runnable to execute animations on map</string>
+  <string name="route">Get Route</string>
+  <string name="router_map_demo_label">Router</string>
+  <string name="router_map_demo_description">Demonstrates how to use MapzenRouter</string>
 </resources>


### PR DESCRIPTION
Creates `MapzenRouter` to handle routing functionality
- Handles key management for mapzen.xml with key resource named "turn_by_turn_key"
- Allows for setting of key in code
- Provides access to underlying `Router` for more custom interaction (like setting request log levels)
- Adds example activity to demonstrate router's use

Closes #90 