### PR TITLE
Set httphandler in MapzenRouter constructor

### DIFF
--- a/library/src/main/java/com/mapzen/android/MapzenDistanceFormatter.java
+++ b/library/src/main/java/com/mapzen/android/MapzenDistanceFormatter.java
@@ -1,0 +1,26 @@
+package com.mapzen.android;
+
+import com.mapzen.android.model.Converter;
+import com.mapzen.helpers.DistanceFormatter;
+import com.mapzen.valhalla.Router;
+
+/**
+ * Formatter for dealing with {@link MapzenRouter.DistanceUnits}.
+ */
+public class MapzenDistanceFormatter {
+
+  /**
+   * Format distance for display using specified distance units.
+   *
+   * @param distanceInMeters the actual distance in meters.
+   * @param realTime boolean flag for navigation vs. list view.
+   * @param units miles or kilometers.
+   * @return distance string formatted according to the rules of the formatter.
+   */
+  public static String format(int distanceInMeters, boolean realTime,
+      MapzenRouter.DistanceUnits units) {
+    Router.DistanceUnits routerUnits = Converter.UNITS_TO_ROUTER_UNITS.get(units);
+    return DistanceFormatter.format(distanceInMeters, realTime, routerUnits);
+  }
+
+}

--- a/library/src/main/java/com/mapzen/android/MapzenRouter.java
+++ b/library/src/main/java/com/mapzen/android/MapzenRouter.java
@@ -1,6 +1,5 @@
 package com.mapzen.android;
 
-import com.mapzen.valhalla.HttpHandler;
 import com.mapzen.valhalla.RouteCallback;
 import com.mapzen.valhalla.Router;
 import com.mapzen.valhalla.ValhallaRouter;
@@ -26,15 +25,19 @@ public class MapzenRouter {
    * Creates a new {@link MapzenRouter} with api key set from mapzen.xml.
    */
   public MapzenRouter(Context context) {
-    String key = initializeRouterKey(context);
-    internalRouter.setHttpHandler(new HttpHandler(key));
+    String apiKey = initializeRouterKey(context);
+    TurnByTurnHttpHandler httpHandler = new TurnByTurnHttpHandler();
+    httpHandler.setApiKey(apiKey);
+    internalRouter.setHttpHandler(httpHandler);
   }
 
   /**
    * Creates a new {@link MapzenRouter} with api key set in code.
    */
   public MapzenRouter(String apiKey) {
-    internalRouter.setHttpHandler(new HttpHandler(apiKey));
+    TurnByTurnHttpHandler httpHandler = new TurnByTurnHttpHandler();
+    httpHandler.setApiKey(apiKey);
+    internalRouter.setHttpHandler(httpHandler);
   }
 
   private String initializeRouterKey(Context context) {

--- a/library/src/main/java/com/mapzen/android/TurnByTurnHttpHandler.java
+++ b/library/src/main/java/com/mapzen/android/TurnByTurnHttpHandler.java
@@ -1,0 +1,56 @@
+package com.mapzen.android;
+
+import com.mapzen.valhalla.HttpHandler;
+
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+
+/**
+ * Handles appending api keys for all turn-by-turn requests.
+ */
+public class TurnByTurnHttpHandler extends HttpHandler {
+
+  private static final String NAME_API_KEY = "api_key";
+
+  private String apiKey;
+
+  /**
+   * Construct handler with default url and log levels.
+   */
+  public TurnByTurnHttpHandler() {
+    configure(DEFAULT_URL, DEFAULT_LOG_LEVEL);
+  }
+
+  /**
+   * Construct handler with url and default log levels.
+   */
+  public TurnByTurnHttpHandler(String endpoint) {
+    configure(endpoint, DEFAULT_LOG_LEVEL);
+  }
+
+  /**
+   * Construct handler with log levels and default url.
+   */
+  public TurnByTurnHttpHandler(RestAdapter.LogLevel logLevel) {
+    configure(DEFAULT_URL, logLevel);
+  }
+
+  /**
+   * Construct handler with url and log levels.
+   */
+  public TurnByTurnHttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+    configure(endpoint, logLevel);
+  }
+
+  /**
+   * Set the api key to be sent with every request.
+   */
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  @Override
+  protected void onRequest(RequestInterceptor.RequestFacade requestFacade) {
+    requestFacade.addQueryParam(NAME_API_KEY, this.apiKey);
+  }
+}

--- a/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
+++ b/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.dagger;
 
 import com.mapzen.android.TileHttpHandler;
+import com.mapzen.android.TurnByTurnHttpHandler;
 
 import android.content.Context;
 import android.content.res.Resources;
@@ -16,7 +17,8 @@ import dagger.Provides;
  */
 @Module public class AndroidModule {
   private static final String TAG = AndroidModule.class.getSimpleName();
-  private static final String API_KEY_RES_NAME = "vector_tiles_key";
+  private static final String API_KEY_TILE_RES_NAME = "vector_tiles_key";
+  private static final String API_KEY_TURN_BY_TURN_RES_NAME = "turn_by_turn_key";
   private static final String API_KEY_RES_TYPE = "string";
 
   private final Context context;
@@ -51,12 +53,29 @@ import dagger.Provides;
   @Provides @Singleton public TileHttpHandler provideTileHttpHandler(Resources res) {
     final String packageName = context.getPackageName();
     try {
-      final int apiKeyId = res.getIdentifier(API_KEY_RES_NAME, API_KEY_RES_TYPE, packageName);
+      final int apiKeyId = res.getIdentifier(API_KEY_TILE_RES_NAME, API_KEY_RES_TYPE, packageName);
       final String apiKey = res.getString(apiKeyId);
       return new TileHttpHandler(apiKey);
     } catch (Resources.NotFoundException e) {
       Log.e(TAG, e.getLocalizedMessage());
     }
     return new TileHttpHandler(null);
+  }
+
+  /**
+   * Provides HTTP handler to append API key to outgoing turn-by-turn requests.
+   */
+  @Provides @Singleton public TurnByTurnHttpHandler provideTurnByTurnHttpHandler(Resources res) {
+    TurnByTurnHttpHandler handler = new TurnByTurnHttpHandler();
+    final String packageName = context.getPackageName();
+    try {
+      final int apiKeyId = res.getIdentifier(API_KEY_TURN_BY_TURN_RES_NAME, API_KEY_RES_TYPE,
+          packageName);
+      final String apiKey = res.getString(apiKeyId);
+      handler.setApiKey(apiKey);
+    } catch (Resources.NotFoundException e) {
+      Log.e(TAG, e.getLocalizedMessage());
+    }
+    return handler;
   }
 }

--- a/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
+++ b/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
@@ -2,6 +2,7 @@ package com.mapzen.android.dagger;
 
 import com.mapzen.android.MapInitializer;
 import com.mapzen.android.MapView;
+import com.mapzen.android.MapzenRouter;
 
 import android.content.Context;
 
@@ -21,6 +22,7 @@ class DependencyInjector {
     void inject(MapView mapView);
 
     void inject(MapInitializer mapInitializer);
+    void inject(MapzenRouter router);
   }
 
   private LibraryComponent component;

--- a/library/src/main/java/com/mapzen/android/model/Converter.java
+++ b/library/src/main/java/com/mapzen/android/model/Converter.java
@@ -1,0 +1,21 @@
+package com.mapzen.android.model;
+
+import com.mapzen.android.MapzenRouter;
+import com.mapzen.valhalla.Router;
+
+import java.util.HashMap;
+
+/**
+ * Converts distance units between {@link MapzenRouter.DistanceUnits} and
+ * {@link Router.DistanceUnits}.
+ */
+public class Converter {
+
+  public static final HashMap<MapzenRouter.DistanceUnits,
+      Router.DistanceUnits> UNITS_TO_ROUTER_UNITS = new HashMap<>();
+  static {
+    UNITS_TO_ROUTER_UNITS.put(MapzenRouter.DistanceUnits.MILES, Router.DistanceUnits.MILES);
+    UNITS_TO_ROUTER_UNITS.put(MapzenRouter.DistanceUnits.KILOMETERS,
+        Router.DistanceUnits.KILOMETERS);
+  }
+}

--- a/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android;
 
+import com.mapzen.valhalla.HttpHandler;
 import com.mapzen.valhalla.Route;
 import com.mapzen.valhalla.RouteCallback;
 import com.mapzen.valhalla.Router;
@@ -33,22 +34,20 @@ public class MapzenRouterTest {
 
   @Test
   public void routerShouldHaveEndpoint() {
-    assertThat(router.getRouter().getEndpoint()).isEqualTo(ValhallaRouter.DEFAULT_URL);
+    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
+    HttpHandler httpHandler = (HttpHandler) Whitebox.getInternalState(valhallaRouter,
+        "httpHandler");
+    String endpoint = (String) Whitebox.getInternalState(httpHandler, "endpoint");
+    assertThat(endpoint).isEqualTo("https://valhalla.mapzen.com/");
   }
 
   @Test
   public void routerShouldHaveApiKey() {
     ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
-    String apiKey = (String) Whitebox.getInternalState(valhallaRouter, "API_KEY");
+    HttpHandler httpHandler = (HttpHandler) Whitebox.getInternalState(valhallaRouter,
+        "httpHandler");
+    String apiKey = (String) Whitebox.getInternalState(httpHandler, "apiKey");
     assertThat(apiKey).isEqualTo("TEST_KEY");
-  }
-
-  @Test
-  public void setApiKey_shouldSetKey() {
-    router.setApiKey("test");
-    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
-    String apiKey = (String) Whitebox.getInternalState(valhallaRouter, "API_KEY");
-    assertThat(apiKey).isEqualTo("test");
   }
 
   @Test

--- a/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenRouterTest.java
@@ -1,6 +1,5 @@
 package com.mapzen.android;
 
-import com.mapzen.valhalla.HttpHandler;
 import com.mapzen.valhalla.Route;
 import com.mapzen.valhalla.RouteCallback;
 import com.mapzen.valhalla.Router;
@@ -8,14 +7,10 @@ import com.mapzen.valhalla.ValhallaRouter;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.Whitebox;
 
 import android.content.Context;
-import android.content.res.Resources;
 
 import static com.mapzen.android.TestHelper.getMockContext;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -26,40 +21,18 @@ public class MapzenRouterTest {
   @Before
   public void setup() {
     Context context = getMockContext();
-    Resources resources = context.getResources();
-    Mockito.when(resources.getIdentifier("turn_by_turn_key", "string", null)).thenReturn(101);
-    Mockito.when(resources.getString(101)).thenReturn("TEST_KEY");
     router = new MapzenRouter(context);
-  }
-
-  @Test
-  public void routerShouldHaveEndpoint() {
-    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
-    HttpHandler httpHandler = (HttpHandler) Whitebox.getInternalState(valhallaRouter,
-        "httpHandler");
-    String endpoint = (String) Whitebox.getInternalState(httpHandler, "endpoint");
-    assertThat(endpoint).isEqualTo("https://valhalla.mapzen.com/");
-  }
-
-  @Test
-  public void routerShouldHaveApiKey() {
-    ValhallaRouter valhallaRouter = (ValhallaRouter) router.getRouter();
-    HttpHandler httpHandler = (HttpHandler) Whitebox.getInternalState(valhallaRouter,
-        "httpHandler");
-    String apiKey = (String) Whitebox.getInternalState(httpHandler, "apiKey");
-    assertThat(apiKey).isEqualTo("TEST_KEY");
+    router.setValhallaRouter(mock(ValhallaRouter.class));
   }
 
   @Test
   public void fetch_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     router.fetch();
     verify(router.getRouter()).fetch();
   }
 
   @Test
   public void setCallback_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     TestRouteCallback callback = new TestRouteCallback();
     router.setCallback(callback);
     verify(router.getRouter()).setCallback(callback);
@@ -67,35 +40,30 @@ public class MapzenRouterTest {
 
   @Test
   public void setDistanceUnits_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     router.setDistanceUnits(MapzenRouter.DistanceUnits.MILES);
     verify(router.getRouter()).setDistanceUnits(Router.DistanceUnits.MILES);
   }
 
   @Test
   public void setBiking_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     router.setBiking();
     verify(router.getRouter()).setBiking();
   }
 
   @Test
   public void setDriving_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     router.setDriving();
     verify(router.getRouter()).setDriving();
   }
 
   @Test
   public void setWalking_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     router.setBiking();
     verify(router.getRouter()).setBiking();
   }
 
   @Test
   public void setLocation_shouldInvokeInternalRouter() {
-    Whitebox.setInternalState(router, "internalRouter", mock(ValhallaRouter.class));
     double[] point = {70.0, 30.0};
     router.setLocation(point);
     verify(router.getRouter()).setLocation(point);

--- a/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
@@ -18,6 +18,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public class RouterActivity extends AppCompatActivity {
   MapzenRouter router;
   MapData markerMapData;
   MapData lineMapData;
+  int points = 0;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -78,13 +80,18 @@ public class RouterActivity extends AppCompatActivity {
         if (markerMapData != null) {
           markerMapData.clear();
         }
+        points = 0;
       }
     });
 
     Button routeBtn = (Button) findViewById(R.id.route_btn);
     routeBtn.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
-        router.fetch();
+        if (points >= 2) {
+          router.fetch();
+        } else {
+          Toast.makeText(RouterActivity.this, R.string.min_two_points, Toast.LENGTH_SHORT).show();
+        }
       }
     });
 
@@ -113,6 +120,7 @@ public class RouterActivity extends AppCompatActivity {
     router.setLocation(point);
     Marker marker = new Marker(lngLat.longitude, lngLat.latitude);
     markerMapData = map.addMarker(marker);
+    points++;
   }
 
   @Override protected void onDestroy() {

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
   <string name="route">Get Route</string>
   <string name="router_map_demo_label">Router</string>
   <string name="router_map_demo_description">Demonstrates how to use MapzenRouter</string>
+  <string name="min_two_points">You must add at least two points</string>
 </resources>


### PR DESCRIPTION
- Migrates `MapzenRouter` to use on-the-road's new `HttpHandler` when setting api key

Depends on: https://github.com/mapzen/on-the-road/pull/73
