### PR TITLE
Stateful find me button

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -11,4 +11,5 @@
     <suppress checks="JavadocMethod" files="DependencyInjector.java" />
     <suppress checks="JavadocType" files=".*src/test/java/*" />
     <suppress checks="JavadocStyle" files=".*src/test/java/*" />
+    <suppress checks="VisibilityModifier" files=".*src/test/java/*" />
 </suppressions>

--- a/library/src/main/java/com/mapzen/android/MapzenMap.java
+++ b/library/src/main/java/com/mapzen/android/MapzenMap.java
@@ -71,11 +71,28 @@ public class MapzenMap {
   }
 
   /**
+   * Internal map pan gesture listener that forwards events to both external listener and the
+   * {@link OverlayManager}.
+   */
+  TouchInput.PanResponder internalPanResponder = new TouchInput.PanResponder() {
+    @Override public boolean onPan(float startX, float startY, float endX, float endY) {
+      overlayManager.onPan(startX, startY, endX, endY);
+      return panResponder != null && panResponder.onPan(startX, startY, endX, endY);
+    }
+
+    @Override public boolean onFling(float posX, float posY, float velocityX, float velocityY) {
+      overlayManager.onFling(posX, posY, velocityX, velocityY);
+      return panResponder != null && panResponder.onFling(posX, posY, velocityX, velocityY);
+    }
+  };
+
+  /**
    * Creates a new map based on the given {@link MapView} and {@link MapController}.
    */
   MapzenMap(MapController mapController, OverlayManager overlayManager) {
     this.mapController = mapController;
     this.overlayManager = overlayManager;
+    mapController.setPanResponder(internalPanResponder);
   }
 
   /**
@@ -353,7 +370,6 @@ public class MapzenMap {
    */
   public void setPanResponder(TouchInput.PanResponder panResponder) {
     this.panResponder = panResponder;
-    mapController.setPanResponder(this.panResponder);
   }
 
   /**

--- a/library/src/main/res/drawable/mz_find_me.xml
+++ b/library/src/main/res/drawable/mz_find_me.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_activated="true" android:drawable="@drawable/mz_find_me_pressed"/>
   <item android:state_pressed="true" android:drawable="@drawable/mz_find_me_pressed"/>
   <item android:drawable="@drawable/mz_find_me_normal"/>
 </selector>

--- a/library/src/test/java/com/mapzen/android/MapzenMapTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenMapTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -220,16 +221,46 @@ public class MapzenMapTest {
     assertThat(map.getLongPressResponder()).isNotNull();
   }
 
-  @Test public void setPanResponder_shouldInvokeMapController() {
+  @Test public void setPanResponder_shouldNotInvokeMapController() {
     TestPanResponder panResponder = new TestPanResponder();
     map.setPanResponder(panResponder);
-    verify(mapController).setPanResponder(panResponder);
+    verify(mapController, never()).setPanResponder(panResponder);
   }
 
   @Test public void getPanResponder_shouldNotBeNull() {
     TestPanResponder panResponder = new TestPanResponder();
     map.setPanResponder(panResponder);
     assertThat(map.getPanResponder()).isNotNull();
+  }
+
+  @Test public void onPan_shouldInvokeExternalPanResponder() throws Exception {
+    TestPanResponder panResponder = new TestPanResponder();
+    map.setPanResponder(panResponder);
+    map.internalPanResponder.onPan(1f, 2f, 3f, 4f);
+    assertThat(panResponder.startX).isEqualTo(1f);
+    assertThat(panResponder.startY).isEqualTo(2f);
+    assertThat(panResponder.endX).isEqualTo(3f);
+    assertThat(panResponder.endY).isEqualTo(4f);
+  }
+
+  @Test public void onFling_shouldInvokeExternalPanResponder() throws Exception {
+    TestPanResponder panResponder = new TestPanResponder();
+    map.setPanResponder(panResponder);
+    map.internalPanResponder.onFling(1f, 2f, 3f, 4f);
+    assertThat(panResponder.posX).isEqualTo(1f);
+    assertThat(panResponder.posY).isEqualTo(2f);
+    assertThat(panResponder.velocityX).isEqualTo(3f);
+    assertThat(panResponder.velocityY).isEqualTo(4f);
+  }
+
+  @Test public void onPan_shouldInvokeOverlayManager() throws Exception {
+    map.internalPanResponder.onPan(1f, 2f, 3f, 4f);
+    verify(overlayManager).onPan(1f, 2f, 3f, 4f);
+  }
+
+  @Test public void onFling_shouldInvokeOverlayManager() throws Exception {
+    map.internalPanResponder.onFling(1f, 2f, 3f, 4f);
+    verify(overlayManager).onFling(1f, 2f, 3f, 4f);
   }
 
   @Test public void setRotateResponder_shouldInvokeMapController() {
@@ -376,30 +407,11 @@ public class MapzenMapTest {
     assertThat(listener.picked).isTrue();
   }
 
-  private class TestFeaturePickListener implements FeaturePickListener {
-
-    boolean picked = false;
-
-    @Override
-    public void onFeaturePick(Map<String, String> properties, float positionX, float positionY) {
-      picked = true;
-    }
-  }
-
   @Test public void setViewCompleteListener_shouldInvokeViewCompleteListener() {
     TestViewCompleteListener listener = new TestViewCompleteListener();
     map.setViewCompleteListener(listener);
     listener.onViewComplete();
     assertThat(listener.viewComplete).isTrue();
-  }
-
-  private class TestViewCompleteListener implements ViewCompleteListener {
-
-    boolean viewComplete = false;
-
-    @Override public void onViewComplete() {
-      viewComplete = true;
-    }
   }
 
   @Test public void queueEvent_shouldInvokeMapController() {
@@ -420,5 +432,24 @@ public class MapzenMapTest {
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
     verify(mapController).applySceneUpdates();
+  }
+
+  private class TestFeaturePickListener implements FeaturePickListener {
+
+    boolean picked = false;
+
+    @Override
+    public void onFeaturePick(Map<String, String> properties, float positionX, float positionY) {
+      picked = true;
+    }
+  }
+
+  private class TestViewCompleteListener implements ViewCompleteListener {
+
+    boolean viewComplete = false;
+
+    @Override public void onViewComplete() {
+      viewComplete = true;
+    }
   }
 }

--- a/library/src/test/java/com/mapzen/android/TestPanResponder.java
+++ b/library/src/test/java/com/mapzen/android/TestPanResponder.java
@@ -2,15 +2,30 @@ package com.mapzen.android;
 
 import com.mapzen.tangram.TouchInput;
 
-/**
- *
- */
 public class TestPanResponder implements TouchInput.PanResponder {
+  public float startX = 0f;
+  public float startY = 0f;
+  public float endX = 0f;
+  public float endY = 0f;
+
+  public float posX = 0f;
+  public float posY = 0f;
+  public float velocityX = 0f;
+  public float velocityY = 0f;
+
   @Override public boolean onPan(float startX, float startY, float endX, float endY) {
+    this.startX = startX;
+    this.startY = startY;
+    this.endX = endX;
+    this.endY = endY;
     return false;
   }
 
   @Override public boolean onFling(float posX, float posY, float velocityX, float velocityY) {
+    this.posX = posX;
+    this.posY = posY;
+    this.velocityX = velocityX;
+    this.velocityY = velocityY;
     return false;
   }
 }

--- a/library/src/test/java/com/mapzen/tangram/TestMapData.java
+++ b/library/src/test/java/com/mapzen/tangram/TestMapData.java
@@ -7,24 +7,33 @@ import java.util.Map;
  * Returned by {@link com.mapzen.android.TestMapController}
  */
 public class TestMapData extends MapData {
+  public LngLat point;
+  public List<LngLat> polyline;
+  public List<List<LngLat>> polygon;
 
   public TestMapData(String name) {
     super(name, 0, null);
   }
 
-  @Override public MapData addPolyline(List<LngLat> polyline, Map<String, String> properties) {
+  @Override public MapData addPoint(LngLat point, Map<String, String> properties) {
+    this.point = point;
     return this;
   }
 
-  @Override public MapData addPoint(LngLat point, Map<String, String> properties) {
+  @Override public MapData addPolyline(List<LngLat> polyline, Map<String, String> properties) {
+    this.polyline = polyline;
     return this;
   }
 
   @Override public MapData addPolygon(List<List<LngLat>> polygon, Map<String, String> properties) {
+    this.polygon = polygon;
     return this;
   }
 
   @Override public MapData clear() {
+    point = null;
+    polyline = null;
+    polygon = null;
     return this;
   }
 }


### PR DESCRIPTION
Tap to activate find me button. While activated map will remain centered on current location. Tap again or pan map to deactivate.

* Removes `locationRequested` boolean flag from `OverlayManager`.
* Adds activated state to find me button.
* Center map on location update only if find me is active.
* Un-mock class under test in `OverlayManagerTest`.
* Re-restrict scope on private constant value `NAME_CURRENT_LOCATION`.
* Suppress visibility modifier checkstyle check for test classes.
* Moves inner test classes to bottom of `MapzenMapTest`.
* Adds internal pan responder to `MapzenMap`.
* Forwards pan and fling events to both external listener and `OverlayManager`.
* Deactivates find me button on map pan or fling.

Closes https://github.com/mapzen/eraser-map/issues/536