### PR TITLE
Replace 'git@github.com:' with 'https://github.com/' in submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "library/src/main/assets/styles/bubble-wrap"]
 	path = library/src/main/assets/styles/bubble-wrap
-	url = git@github.com:tangrams/bubble-wrap.git
+	url = https://github.com/tangrams/bubble-wrap.git
 [submodule "library/src/main/assets/styles/cinnabar"]
 	path = library/src/main/assets/styles/cinnabar
-	url = git@github.com:tangrams/cinnabar-style.git
+	url = https://github.com/tangrams/cinnabar-style.git
 [submodule "library/src/main/assets/styles/refill"]
 	path = library/src/main/assets/styles/refill
-	url = git@github.com:tangrams/refill-style.git
+	url = https://github.com/tangrams/refill-style.git


### PR DESCRIPTION
Fixes ability to clone submodules for some (read: my) configurations. I'm not totally sure how the 'git@github.com:' URL is supposed to work, feel free to re-educate me about git practices.