### PR TITLE
Set sample app API keys in gradle props

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 
+def VECTOR_TILES_KEY = hasProperty('vectorTilesKey') ? '"' + vectorTilesKey + '"' : "null";
+def TURN_BY_TURN_KEY = hasProperty('turnByTurnKey') ? '"' + turnByTurnKey + '"' : "null";
+
 android {
   compileSdkVersion 23
   buildToolsVersion "23.0.1"
@@ -11,6 +14,8 @@ android {
     targetSdkVersion 23
     versionCode 1
     versionName "1.0"
+    buildConfigField "String", "VECTOR_TILES_KEY", VECTOR_TILES_KEY
+    buildConfigField "String", "TURN_BY_TURN_KEY", TURN_BY_TURN_KEY
   }
   buildTypes {
     release {

--- a/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/RouterActivity.java
@@ -38,7 +38,12 @@ public class RouterActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_route);
 
-    router = new MapzenRouter(this);
+    final String turnByturnKey = BuildConfig.TURN_BY_TURN_KEY;
+    if (turnByturnKey != null) {
+      router = new MapzenRouter(this, turnByturnKey);
+    } else {
+      router = new MapzenRouter(this);
+    }
 
     final MapFragment mapFragment =
         (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);


### PR DESCRIPTION
Adds option to set sample app API keys in Gradle properties. Prefers turn by turn API key in BuildConfig.java if present.

Closes #126