### PR TITLE
Add Pelias to SDK and include example Activity

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,9 @@
 The Mapzen Android SDK is a thin wrapper that packages up everything you need to use Mapzen services in your Android applications. It also simplify setup, installation, API key management and generally make your life better.
 
 ## Current functionality:
-Currently the Mapzen SDK supports map rendering and location tracking through the following projects:
+Currently the Mapzen SDK supports map rendering, location tracking, turn-by-turn directions, and search/geocoding through the following projects:
 
 - [L.O.S.T](https://github.com/mapzen/lost)- Our drop-in replacement for Google Play Services Location APIs
 - [Tangram](https://github.com/tangrams/tangram-es/)- Our 2D and 3D map renderer using OpenGL ES
-
-## What's coming up:
-We will be incorporating all of Mapzen’s services into the SDK through the following projects:
-
 - [On the road](https://github.com/mapzen/on-the-road)- The Mapzen Turn-by-Turn wrapper and other routing utilities.
 - [Pelias](https://github.com/pelias/pelias-android-sdk)- The Mapzen Search wrapper

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -85,6 +85,7 @@ dependencies {
   compile "com.mapzen.tangram:tangram:$tangram_version"
   compile 'com.mapzen.android:lost:1.1.1'
   compile 'com.mapzen:on-the-road:0.8.4'
+  compile('com.mapzen.android:pelias-android-sdk:0.7.2-SNAPSHOT')
   compile 'com.google.dagger:dagger:2.0'
   compile 'com.google.dagger:dagger-compiler:2.0'
   compile 'javax.annotation:javax.annotation-api:1.2'

--- a/library/src/main/java/com/mapzen/android/ApiKeyConstants.java
+++ b/library/src/main/java/com/mapzen/android/ApiKeyConstants.java
@@ -1,0 +1,12 @@
+package com.mapzen.android;
+
+/**
+ * Api key constants.
+ */
+public class ApiKeyConstants {
+  public static final String API_KEY_TILE_RES_NAME = "vector_tiles_key";
+  public static final String API_KEY_TURN_BY_TURN_RES_NAME = "turn_by_turn_key";
+  public static final String API_KEY_SEARCH_RES_NAME = "search_key";
+  public static final String API_KEY_RES_TYPE = "string";
+  public static final String API_KEY = "api_key";
+}

--- a/library/src/main/java/com/mapzen/android/MapzenMapPeliasLocationProvider.java
+++ b/library/src/main/java/com/mapzen/android/MapzenMapPeliasLocationProvider.java
@@ -1,0 +1,74 @@
+package com.mapzen.android;
+
+import com.mapzen.pelias.BoundingBox;
+import com.mapzen.pelias.PeliasLocationProvider;
+import com.mapzen.tangram.LngLat;
+
+import android.content.Context;
+import android.graphics.PointF;
+import android.view.Display;
+import android.view.WindowManager;
+
+/**
+ * This class uses a {@link MapzenMap} to return both lat/lon and a bounding box based on the map's
+ * current position. Use this class in conjunction with a {@link PeliasSearchView} if you want
+ * search/autocomplete results relevant to the map's position.
+ */
+public class MapzenMapPeliasLocationProvider implements PeliasLocationProvider {
+
+  Context context;
+  MapzenMap mapzenMap;
+
+  /**
+   * Public constructor.
+   * @param context
+   */
+  public MapzenMapPeliasLocationProvider(Context context) {
+    this.context = context;
+  }
+
+  /**
+   * Set the map to use for retrieving lat/lon/bounding box.
+   * @param map
+   */
+  public void setMapzenMap(MapzenMap map) {
+    this.mapzenMap = map;
+  }
+
+  @Override public double getLat() {
+    if (mapzenMap == null) {
+      return 0;
+    }
+    WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    Display display = windowManager.getDefaultDisplay();
+    LngLat midLatLon = mapzenMap.screenPositionToLngLat(new PointF(display.getWidth() / 2,
+        display.getHeight() / 2));
+    return midLatLon.latitude;
+  }
+
+  @Override public double getLon() {
+    if (mapzenMap == null) {
+      return 0;
+    }
+    WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    Display display = windowManager.getDefaultDisplay();
+    LngLat midLatLon = mapzenMap.screenPositionToLngLat(new PointF(display.getWidth() / 2,
+        display.getHeight() / 2));
+    return midLatLon.longitude;
+  }
+
+  @Override public BoundingBox getBoundingBox() {
+    if (mapzenMap == null) {
+      return null;
+    }
+    WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+    Display display = windowManager.getDefaultDisplay();
+    LngLat minLatLon = mapzenMap.screenPositionToLngLat(new PointF(0.f, display.getHeight()));
+    LngLat maxLatLon = mapzenMap.screenPositionToLngLat(new PointF(display.getWidth(), 0.f));
+    BoundingBox boundingBox =
+        new BoundingBox(minLatLon.latitude, minLatLon.longitude, maxLatLon.latitude,
+            maxLatLon.longitude);
+    return boundingBox;
+  }
+}
+

--- a/library/src/main/java/com/mapzen/android/MapzenSearch.java
+++ b/library/src/main/java/com/mapzen/android/MapzenSearch.java
@@ -1,0 +1,148 @@
+package com.mapzen.android;
+
+import com.mapzen.android.dagger.DI;
+import com.mapzen.pelias.BoundingBox;
+import com.mapzen.pelias.Pelias;
+import com.mapzen.pelias.PeliasLocationProvider;
+import com.mapzen.pelias.gson.Result;
+
+import android.content.Context;
+
+import javax.inject.Inject;
+
+import retrofit.Callback;
+
+/**
+ * This class is the main class for interaction with the Mapzen search api.
+ */
+public class MapzenSearch {
+
+  @Inject SearchInitializer searchInitializer;
+
+  private Pelias internalSearch;
+
+  /**
+   * Creates a new {@link MapzenSearch} with api key set from mapzen.xml.
+   */
+  public MapzenSearch(Context context) {
+    initDI(context);
+    internalSearch = new Pelias();
+    searchInitializer.initSearch(this, context);
+  }
+
+  /**
+   * Creates a new {@link MapzenSearch} with api key set in code.
+   */
+  public MapzenSearch(Context context, String apiKey) {
+    initDI(context);
+    internalSearch = new Pelias();
+    searchInitializer.initSearch(this, apiKey);
+  }
+
+  /**
+   * Creates a new {@link MapzenSearch} with the {@link Pelias} object used for underlying
+   * search/autocomplete queries.
+   */
+  public MapzenSearch(Context context, Pelias pelias) {
+    initDI(context);
+    internalSearch = pelias;
+    searchInitializer.initSearch(this, context);
+  }
+
+  private void initDI(Context context) {
+    DI.init(context);
+    DI.component().inject(this);
+  }
+
+  /**
+   * Returns autocomplete suggestions given a query string. The query will use the
+   * {@link PeliasLocationProvider} to retrieve a lat/lon to use as a focus point for the request.
+   * The callback will be notified upon success or failure of query.
+   * @param query
+   * @param callback
+   */
+  public void suggest(String query, Callback<Result> callback) {
+    internalSearch.suggest(query, callback);
+  }
+
+  /**
+   * Requests autocomplete suggestions given a query and lat/lon. The lat/lon is used as a focus
+   * point for results The callback will be notified upon success or failure of the query.
+   * @param query
+   * @param callback
+   */
+  public void suggest(String query, double lat, double lon, Callback<Result> callback) {
+    internalSearch.suggest(query, lat, lon, callback);
+  }
+
+  /**
+   * Requests search results given a query. The {@link PeliasLocationProvider} will be used to
+   * generate a bounding box for results. The callback will be notified upon success or failure of
+   * the query.
+   * @param query
+   * @param callback
+   */
+  public void search(String query, Callback<Result> callback) {
+    internalSearch.search(query, callback);
+  }
+
+  /**
+   * Requests search results given a query. The {@link BoundingBox} will be used to
+   * generate relevant results. The callback will be notified upon success or failure of
+   * the query.
+   * @param query
+   * @param callback
+   */
+  public void search(String query, BoundingBox box, Callback<Result> callback) {
+    internalSearch.search(query, box, callback);
+  }
+
+  /**
+   * Requests search results given a query. The lat/lon will be used as a focus point to
+   * generate relevant results. The callback will be notified upon success or failure of
+   * the query.
+   * @param query
+   * @param callback
+   */
+  public void search(String query, double lat, double lon, Callback<Result> callback) {
+    internalSearch.search(query, lat, lon, callback);
+  }
+
+  /**
+   * Issues a reverse geocode request given the lat/lon. The callback will be notified upon success
+   * or failure of the query.
+   * @param lat
+   * @param lon
+   * @param callback
+   */
+  public void reverse(double lat, double lon, Callback<Result> callback) {
+    internalSearch.reverse(lat, lon, callback);
+  }
+
+  /**
+   * Issues a place request for a given global identifier. The callback will be notified upon
+   * success or failure of the query.
+   * @param gid
+   * @param callback
+   */
+  public void place(String gid, Callback<Result> callback) {
+    internalSearch.place(gid, callback);
+  }
+
+  /**
+   * Set a location provider to be used in search and suggest requests. This will be used to return
+   * more relevant results for given positions and areas
+   * @param locationProvider
+   */
+  public void setLocationProvider(PeliasLocationProvider locationProvider) {
+    internalSearch.setLocationProvider(locationProvider);
+  }
+
+  /**
+   * Return the underlying {@link Pelias} object.
+   * @return
+   */
+  public Pelias getPelias() {
+    return internalSearch;
+  }
+}

--- a/library/src/main/java/com/mapzen/android/SearchInitializer.java
+++ b/library/src/main/java/com/mapzen/android/SearchInitializer.java
@@ -1,0 +1,54 @@
+package com.mapzen.android;
+
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Log;
+
+/**
+ * Handles setting the api key and a request handler for given {@link MapzenSearch} objects.
+ */
+public class SearchInitializer {
+
+  private static final String TAG = SearchInitializer.class.getSimpleName();
+
+  private SearchRequestHandler requestHandler = new SearchRequestHandler();
+
+  /**
+   * Initialize the {@link MapzenSearch}'s api key from mapzen.xml and set it's
+   * {@link SearchRequestHandler}.
+   * @param search
+   * @param context
+   */
+  public void initSearch(MapzenSearch search, Context context) {
+    Resources res = context.getResources();
+    final String packageName = context.getPackageName();
+    try {
+      final int apiKeyId = res.getIdentifier(ApiKeyConstants.API_KEY_SEARCH_RES_NAME,
+          ApiKeyConstants.API_KEY_RES_TYPE, packageName);
+      final String apiKey = res.getString(apiKeyId);
+      initSearch(search, apiKey);
+    } catch (Resources.NotFoundException e) {
+      Log.e(TAG, e.getLocalizedMessage());
+    }
+  }
+
+  /**
+   * Initialize the {@link MapzenSearch}'s api key in code and set it's
+   * {@link SearchRequestHandler}.
+   * @param search
+   * @param apiKey
+   */
+  public void initSearch(MapzenSearch search, String apiKey) {
+    requestHandler.setApiKey(apiKey);
+    search.getPelias().setRequestHandler(requestHandler);
+  }
+
+  /**
+   * Returns the request handler.
+   * @return
+   */
+  public SearchRequestHandler getRequestHandler() {
+    return requestHandler;
+  }
+}

--- a/library/src/main/java/com/mapzen/android/SearchRequestHandler.java
+++ b/library/src/main/java/com/mapzen/android/SearchRequestHandler.java
@@ -1,0 +1,39 @@
+package com.mapzen.android;
+
+import com.mapzen.pelias.PeliasRequestHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Request handler in charge of appending the api key for {@link MapzenSearch} requests.
+ */
+public class SearchRequestHandler implements PeliasRequestHandler {
+
+  private String apiKey;
+
+  /**
+   * Set the api key to be used for {@link MapzenSearch} requests.
+   * @param apiKey
+   */
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Get the api key used for {@link MapzenSearch} requests.
+   */
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  @Override public Map<String, String> headersForRequest() {
+    return null;
+  }
+
+  @Override public Map<String, String> queryParamsForRequest() {
+    HashMap<String, String> params = new HashMap<>();
+    params.put(ApiKeyConstants.API_KEY, apiKey);
+    return params;
+  }
+}

--- a/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
+++ b/library/src/main/java/com/mapzen/android/dagger/AndroidModule.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.dagger;
 
+import com.mapzen.android.ApiKeyConstants;
+import com.mapzen.android.SearchInitializer;
 import com.mapzen.android.TileHttpHandler;
 import com.mapzen.android.TurnByTurnHttpHandler;
 
@@ -17,9 +19,6 @@ import dagger.Provides;
  */
 @Module public class AndroidModule {
   private static final String TAG = AndroidModule.class.getSimpleName();
-  private static final String API_KEY_TILE_RES_NAME = "vector_tiles_key";
-  private static final String API_KEY_TURN_BY_TURN_RES_NAME = "turn_by_turn_key";
-  private static final String API_KEY_RES_TYPE = "string";
 
   private final Context context;
 
@@ -53,7 +52,8 @@ import dagger.Provides;
   @Provides @Singleton public TileHttpHandler provideTileHttpHandler(Resources res) {
     final String packageName = context.getPackageName();
     try {
-      final int apiKeyId = res.getIdentifier(API_KEY_TILE_RES_NAME, API_KEY_RES_TYPE, packageName);
+      final int apiKeyId = res.getIdentifier(ApiKeyConstants.API_KEY_TILE_RES_NAME,
+          ApiKeyConstants.API_KEY_RES_TYPE, packageName);
       final String apiKey = res.getString(apiKeyId);
       return new TileHttpHandler(apiKey);
     } catch (Resources.NotFoundException e) {
@@ -69,13 +69,21 @@ import dagger.Provides;
     TurnByTurnHttpHandler handler = new TurnByTurnHttpHandler();
     final String packageName = context.getPackageName();
     try {
-      final int apiKeyId = res.getIdentifier(API_KEY_TURN_BY_TURN_RES_NAME, API_KEY_RES_TYPE,
-          packageName);
+      final int apiKeyId = res.getIdentifier(ApiKeyConstants.API_KEY_TURN_BY_TURN_RES_NAME,
+          ApiKeyConstants.API_KEY_RES_TYPE, packageName);
       final String apiKey = res.getString(apiKeyId);
       handler.setApiKey(apiKey);
     } catch (Resources.NotFoundException e) {
       Log.e(TAG, e.getLocalizedMessage());
     }
     return handler;
+  }
+
+  /**
+   * Provide initializer for configuring {@link MapzenSearch} objects.
+   * @return
+   */
+  @Provides @Singleton public SearchInitializer provideSearchInitializer() {
+    return new SearchInitializer();
   }
 }

--- a/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
+++ b/library/src/main/java/com/mapzen/android/dagger/DependencyInjector.java
@@ -3,6 +3,7 @@ package com.mapzen.android.dagger;
 import com.mapzen.android.MapInitializer;
 import com.mapzen.android.MapView;
 import com.mapzen.android.MapzenRouter;
+import com.mapzen.android.MapzenSearch;
 
 import android.content.Context;
 
@@ -23,6 +24,7 @@ class DependencyInjector {
 
     void inject(MapInitializer mapInitializer);
     void inject(MapzenRouter router);
+    void inject(MapzenSearch search);
   }
 
   private LibraryComponent component;

--- a/library/src/test/java/com/mapzen/android/MapzenSearchTest.java
+++ b/library/src/test/java/com/mapzen/android/MapzenSearchTest.java
@@ -1,0 +1,97 @@
+package com.mapzen.android;
+
+import com.mapzen.pelias.BoundingBox;
+import com.mapzen.pelias.Pelias;
+import com.mapzen.pelias.PeliasLocationProvider;
+import com.mapzen.pelias.gson.Result;
+
+import org.junit.Test;
+
+import android.content.Context;
+
+import static com.mapzen.android.TestHelper.getMockContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+public class MapzenSearchTest {
+
+  Context context = getMockContext();
+  Pelias pelias = mock(Pelias.class);
+  MapzenSearch search = new MapzenSearch(context, pelias);
+
+  @Test public void shouldCreatePelias() {
+    MapzenSearch mzSearch = new MapzenSearch(context, "API_KEY");
+    assertThat(mzSearch.getPelias()).isNotNull();
+    assertThat(mzSearch.searchInitializer.getRequestHandler().getApiKey()).isEqualTo("API_KEY");
+  }
+
+  @Test public void suggest_shouldCallPelias() {
+    TestCallback callback = new TestCallback();
+    search.suggest("query", callback);
+    verify(search.getPelias()).suggest("query", callback);
+
+    search.suggest("query", 40, 70, callback);
+    verify(search.getPelias()).suggest("query", 40, 70, callback);
+  }
+
+  @Test public void search_shouldCallPelias() {
+    TestCallback callback = new TestCallback();
+    search.search("query", callback);
+    verify(search.getPelias()).search("query", callback);
+
+    BoundingBox boundingBox = new BoundingBox(0, 0, 40, 70);
+    search.search("query", boundingBox, callback);
+    verify(search.getPelias()).search("query", boundingBox, callback);
+
+    search.search("query", 40, 70, callback);
+    verify(search.getPelias()).search("query", 40, 70, callback);
+  }
+
+  @Test public void reverse_shouldCallPelias() {
+    TestCallback callback = new TestCallback();
+    search.reverse(40, 70, callback);
+    verify(search.getPelias()).reverse(40, 70, callback);
+  }
+
+  @Test public void place_shouldCallPelias() {
+    TestCallback callback = new TestCallback();
+    search.place("123", callback);
+    verify(search.getPelias()).place("123", callback);
+  }
+
+  @Test public void setLocationProvider_shouldCallPelias() {
+    TestPeliasLocationProvider provider = new TestPeliasLocationProvider();
+    search.setLocationProvider(provider);
+    verify(search.getPelias()).setLocationProvider(provider);
+  }
+
+  class TestCallback implements Callback<Result> {
+
+    @Override public void success(Result result, Response response) {
+
+    }
+
+    @Override public void failure(RetrofitError error) {
+
+    }
+  }
+
+  class TestPeliasLocationProvider implements PeliasLocationProvider {
+
+    @Override public double getLat() {
+      return 0;
+    }
+
+    @Override public double getLon() {
+      return 0;
+    }
+
+    @Override public BoundingBox getBoundingBox() {
+      return null;
+    }
+  }
+}

--- a/library/src/test/java/com/mapzen/android/SearchInitializerTest.java
+++ b/library/src/test/java/com/mapzen/android/SearchInitializerTest.java
@@ -1,0 +1,20 @@
+package com.mapzen.android;
+
+import org.junit.Test;
+
+import android.content.Context;
+
+import static com.mapzen.android.TestHelper.getMockContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchInitializerTest {
+
+  SearchInitializer searchInitializer = new SearchInitializer();
+  Context context = getMockContext();
+  MapzenSearch search = new MapzenSearch(context);
+
+  @Test public void initSearch_shouldSetApiKey() {
+    searchInitializer.initSearch(search, "TEST_API_KEY");
+    assertThat(searchInitializer.getRequestHandler().getApiKey()).isEqualTo("TEST_API_KEY");
+  }
+}

--- a/library/src/test/java/com/mapzen/android/SearchRequestHandlerTest.java
+++ b/library/src/test/java/com/mapzen/android/SearchRequestHandlerTest.java
@@ -1,0 +1,20 @@
+package com.mapzen.android;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchRequestHandlerTest {
+
+  SearchRequestHandler adapter = new SearchRequestHandler();
+
+  @Test public void setApiKey_shouldSetKey() {
+    adapter.setApiKey("TEST_KEY");
+    assertThat(adapter.getApiKey()).isEqualTo("TEST_KEY");
+  }
+
+  @Test public void queryParamsForRequest_shouldReturnApiKey() {
+    adapter.setApiKey("TEST_KEY");
+    assertThat(adapter.queryParamsForRequest().get(ApiKeyConstants.API_KEY)).isEqualTo("TEST_KEY");
+  }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <activity android:name="FeaturePickListenerActivity"/>
     <activity android:name=".QueueEventActivity"/>
     <activity android:name=".RouterActivity" />
+    <activity android:name=".MapzenSearchViewActivity"/>
   </application>
 
 </manifest>

--- a/sample/src/main/java/com/mapzen/android/sample/MapzenSearchViewActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/MapzenSearchViewActivity.java
@@ -1,0 +1,98 @@
+package com.mapzen.android.sample;
+
+import com.mapzen.android.MapView;
+import com.mapzen.android.MapzenMap;
+import com.mapzen.android.MapzenMapPeliasLocationProvider;
+import com.mapzen.android.MapzenSearch;
+import com.mapzen.android.OnMapReadyCallback;
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.pelias.gson.Result;
+import com.mapzen.pelias.widget.AutoCompleteAdapter;
+import com.mapzen.pelias.widget.AutoCompleteListView;
+import com.mapzen.pelias.widget.PeliasSearchView;
+import com.mapzen.tangram.LngLat;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+
+import java.util.List;
+
+import retrofit.Callback;
+import retrofit.RetrofitError;
+import retrofit.client.Response;
+
+/**
+ * Demonstrates use of {@link MapzenSearch} with a {@link PeliasSearchView} and {@link MapzenMap}.
+ * Allows the user to search for a place, displays autocomplete results in a list and search
+ * results on a map.
+ */
+public class MapzenSearchViewActivity extends AppCompatActivity {
+
+  AutoCompleteListView listView;
+
+  MapzenMapPeliasLocationProvider peliasLocationProvider;
+  MapzenMap mapzenMap;
+  MapzenSearch mapzenSearch;
+
+  AutoCompleteAdapter autocompleteAdapter;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_search);
+
+    listView = (AutoCompleteListView) findViewById(R.id.list_view);
+    autocompleteAdapter = new AutoCompleteAdapter(this, android.R.layout.simple_list_item_1);
+    listView.setAdapter(autocompleteAdapter);
+
+    peliasLocationProvider = new MapzenMapPeliasLocationProvider(this);
+
+    MapView mapView = (MapView) findViewById(R.id.map_view);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override public void onMapReady(MapzenMap mapzenMap) {
+        MapzenSearchViewActivity.this.mapzenMap = mapzenMap;
+        configMap();
+      }
+    });
+
+    mapzenSearch = new MapzenSearch(this);
+    mapzenSearch.setLocationProvider(peliasLocationProvider);
+
+    PeliasSearchView peliasSearchView = new PeliasSearchView(this);
+    ActionBar.LayoutParams lp = new ActionBar.LayoutParams(ActionBar.LayoutParams.MATCH_PARENT,
+        ActionBar.LayoutParams.MATCH_PARENT);
+    getSupportActionBar().setCustomView(peliasSearchView, lp);
+    getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
+    setupPeliasSearchView(peliasSearchView);
+  }
+
+  private void configMap() {
+    peliasLocationProvider.setMapzenMap(mapzenMap);
+    mapzenMap.setMyLocationEnabled(true);
+  }
+
+  private void setupPeliasSearchView(PeliasSearchView searchView) {
+    searchView.setAutoCompleteListView(listView);
+    searchView.setPelias(mapzenSearch.getPelias());
+    searchView.setCallback(new Callback<Result>() {
+      @Override public void success(Result result, Response response) {
+        mapzenMap.clearSearchResults();
+        for (Feature feature : result.getFeatures()) {
+          List<Double> coordinates = feature.geometry.coordinates;
+          LngLat point = new LngLat(coordinates.get(0), coordinates.get(1));
+          mapzenMap.drawSearchResult(point);
+        }
+      }
+
+      @Override public void failure(RetrofitError error) {
+      }
+    });
+    searchView.setIconifiedByDefault(false);
+    searchView.setQueryHint(this.getString(R.string.search_hint));
+    searchView.setOnBackPressListener(new PeliasSearchView.OnBackPressListener() {
+      @Override public void onBackPressed() {
+        mapzenMap.clearSearchResults();
+      }
+    });
+  }
+}

--- a/sample/src/main/java/com/mapzen/android/sample/SampleDetailsList.java
+++ b/sample/src/main/java/com/mapzen/android/sample/SampleDetailsList.java
@@ -50,6 +50,9 @@ public final class SampleDetailsList {
           QueueEventActivity.class),
       new SampleDetails(R.string.router_map_demo_label,
           R.string.router_map_demo_description,
-          RouterActivity.class)
+          RouterActivity.class),
+      new SampleDetails(R.string.pelias_search_demo_label,
+          R.string.pelias_search_demo_description,
+          MapzenSearchViewActivity.class)
   };
 }

--- a/sample/src/main/res/layout/activity_search.xml
+++ b/sample/src/main/res/layout/activity_search.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <com.mapzen.android.MapView
+      android:id="@+id/map_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
+
+  <com.mapzen.pelias.widget.AutoCompleteListView
+      android:id="@+id/list_view"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:background="@color/mz_white"
+      android:visibility="gone"
+      />
+
+</FrameLayout>

--- a/sample/src/main/res/values/mapzen.xml
+++ b/sample/src/main/res/values/mapzen.xml
@@ -2,4 +2,5 @@
 <resources>
   <string name="vector_tiles_key">[YOUR_VECTOR_TILES_KEY]</string>
   <string name="turn_by_turn_key">[YOUR_TURN_BY_TURN_KEY]</string>
+  <string name="search_key">[YOUR_SEARCH_KEY]</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -68,4 +68,7 @@
   <string name="router_map_demo_label">Router</string>
   <string name="router_map_demo_description">Demonstrates how to use MapzenRouter</string>
   <string name="min_two_points">You must add at least two points</string>
+  <string name="pelias_search_demo_label">Search</string>
+  <string name="pelias_search_demo_description">Demonstrates how to use Pelias</string>
+  <string name="search_hint">Search</string>
 </resources>


### PR DESCRIPTION
- Adds `MapzenSearch` to SDK for interaction with `Pelias` and configuration of related api key
- Adds `MapzenSearchViewActivity` to demonstrate use of `MapzenSearch` using `PeliasSearchView` and `MapzenMap`

Depends on: https://github.com/pelias/pelias-android-sdk/pull/44

Closes #145 