### PR TITLE
Adds Gradle Release plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+version=1.0.9-SNAPSHOT
+
 POM_ARTIFACT_ID=mapzen-android-sdk
 POM_NAME=Mapzen Android SDK
 POM_PACKAGING=aar

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,7 @@ version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
 
 release {
+  tagTemplate = 'v${version}'
   versionPropertyFile = '../gradle.properties'
   versionProperties = ['VERSION_NAME']
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,9 +2,13 @@ buildscript {
   repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
   }
   dependencies {
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+    classpath 'net.researchgate:gradle-release:2.4.0'
   }
 }
 
@@ -14,10 +18,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.neenbedankt.android-apt'
+apply plugin: 'net.researchgate.release'
 
 group = GROUP
 version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
+
+release {
+  versionPropertyFile = '../gradle.properties'
+  versionProperties = ['VERSION_NAME']
+}
+
+afterReleaseBuild.dependsOn uploadArchives
 
 android {
   compileSdkVersion 23

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -2,41 +2,18 @@
 
 Steps to build a new release version AAR and deploy to [Maven Central](http://search.maven.org/).
 
-## 1. Prepare release
+## 1. Build and deploy to staging repository
 
-Remove `-SNAPSHOT` tag from version name in `gradle.properties` and commit changes.
-
+Build release and deploy to the Sonatype staging repository.
 ```bash
-VERSION_NAME=1.0.1
+$ ./gradlew clean release --refresh-dependencies
 ```
 
-## 2. Tag release
-
-Tag release and push tag to GitHub (ex. v1.0.1).
-```bash
-$ git tag v1.0.1
-$ git push origin v1.0.1
-```
-
-## 3. Build and deploy to staging repository
-
-Build release and deploy to Sonatype staging repository.
-```bash
-$ ./gradlew clean verify uploadArchives --refresh-dependencies
-```
-
-## 4. Promote release artifact
+## 2. Promote release artifact
 
 Log into [Sonatype staging repository](https://oss.sonatype.org/#stagingRepositories) and promote artifact to production using "Close" then "Release".
 
-## 5. Prepare next development cycle
-
-Update version name and add `-SNAPSHOT` tag for next development cycle. Push changes to GitHub (master).
-```bash
-VERSION_NAME=1.0.2-SNAPSHOT
-```
-
-## 6. Documentation
+## 3. Documentation
 
 Add release name and notes to GitHub [releases page](https://github.com/mapzen/android/releases). Attach and upload AAR. Update
 [installations page](https://github.com/mapzen/android/blob/master/docs/installation.md) to point to the new artifact.


### PR DESCRIPTION
* Adds release plugin to `build.gradle`.
* Sets path to `gradle.properties`.
* Adds `version` property used by gradle release plugin.
* Syncs `VERSION_NAME` property used by android-maven plugin and gradle-mvn-push.gradle.
* Triggers `uploadArchives` after successful release build.

https://github.com/researchgate/gradle-release

Closes #157 