### PR TITLE
Allow explicitly setting the style to override MapStateManager style

### DIFF
--- a/library/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/library/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -29,7 +29,7 @@ public class MapInitializer {
    * Initialize map for the current {@link MapView} and notify via {@link OnMapReadyCallback}.
    */
   public void init(final MapView mapView, final OnMapReadyCallback callback) {
-    init(mapView, new BubbleWrapStyle(), callback);
+    loadMap(mapView, new BubbleWrapStyle(), false, callback);
   }
 
   /**
@@ -37,7 +37,7 @@ public class MapInitializer {
    * {@link OnMapReadyCallback}.
    */
   public void init(final MapView mapView, MapStyle mapStyle, final OnMapReadyCallback callback) {
-    loadMap(mapView, mapStyle, callback);
+    loadMap(mapView, mapStyle, true, callback);
   }
 
   /**
@@ -46,7 +46,7 @@ public class MapInitializer {
    */
   public void init(final MapView mapView, String key, final OnMapReadyCallback callback) {
     httpHandler.setApiKey(key);
-    loadMap(mapView, new BubbleWrapStyle(), callback);
+    loadMap(mapView, new BubbleWrapStyle(), false, callback);
   }
 
   /**
@@ -56,16 +56,16 @@ public class MapInitializer {
   public void init(final MapView mapView, String key, MapStyle mapStyle,
       final OnMapReadyCallback callback) {
     httpHandler.setApiKey(key);
-    loadMap(mapView, mapStyle, callback);
+    loadMap(mapView, mapStyle, true, callback);
   }
 
   private TangramMapView getTangramView(final MapView mapView) {
     return mapView.getTangramMapView();
   }
 
-  private void loadMap(final MapView mapView, MapStyle mapStyle,
+  private void loadMap(final MapView mapView, MapStyle mapStyle, boolean styleExplicitlySet,
       final OnMapReadyCallback callback) {
-    if (mapStateManager.getPersistMapState()) {
+    if (mapStateManager.getPersistMapState() && !styleExplicitlySet) {
       MapStyle restoredMapStyle = mapStateManager.getMapStyle();
       mapStyle = restoredMapStyle;
     }

--- a/library/src/test/java/com/mapzen/android/graphics/MapViewTest.java
+++ b/library/src/test/java/com/mapzen/android/graphics/MapViewTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.graphics.model.RefillStyle;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
@@ -43,5 +45,18 @@ public class MapViewTest {
     mapView.mapInitializer = mapInitializer;
     mapView.getMapAsync(key, callback);
     verify(mapInitializer, times(1)).init(mapView, key, callback);
+  }
+
+  @Test public void getMapAsync_shouldSetStyle() {
+    mapView.getMapAsync(new RefillStyle(), new TestCallback());
+    assertThat(mapView.mapInitializer.mapStateManager.getMapStyle()).isInstanceOf(
+        RefillStyle.class);
+  }
+
+  @Test public void getMapAsync_shouldSetStyleAndKey() {
+    mapView.getMapAsync("apikey", new RefillStyle(), new TestCallback());
+    assertThat(mapView.mapInitializer.httpHandler.getApiKey()).isEqualTo("apikey");
+    assertThat(mapView.mapInitializer.mapStateManager.getMapStyle()).isInstanceOf(
+        RefillStyle.class);
   }
 }


### PR DESCRIPTION
This commit fixes a bug where an explicitly passed style would not be set on the map. Now, calls to `MapView#getMapAsync(MapStyle, OnMapReadyCallback)` and `MapView#getMapAsync(String, MapStyle, OnMapReadyCallback) will overwrite the `MapStateManager`'s cached map state.

Closes #160