### PR TITLE
add metrics

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,3 +19,4 @@ deployment:
     commands:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - scripts/deploy-sample-app.sh
+      - ./gradlew aarSize countReleaseDexMethods permissions library:dependencies --configuration compile

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   dependencies {
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     classpath 'net.researchgate:gradle-release:2.4.0'
-    classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.0'
+    classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
   }
 }
 
@@ -126,10 +126,9 @@ task aarSize {
 }
 aarSize.dependsOn(assembleRelease)
 
-//TODO: uncomment after merge: https://github.com/KeepSafe/dexcount-gradle-plugin/pull/133
-//dexcount {
-//  runOnEachAssemble false
-//}
+dexcount {
+  runOnEachAssemble false
+}
 
 task permissions {
   File manifest = file("src/main/AndroidManifest.xml")

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -118,10 +118,31 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
 task aarSize {
   doLast {
-    File aar = file("build/outputs/aar/mapzen-android-sdk-release.aar")
+
+    File mapzen = file("build/outputs/aar/mapzen-android-sdk-release.aar")
+    def mapzenSize = mapzen.length() / (1024 * 1024)
+
+    def depsSize = 0
+    configurations._releaseCompile.collect { it.length() / (1024 * 1024) }.each { depsSize += it }
+
+    def totalSize = mapzenSize + depsSize
     println ""
-    println "AAR Size: ${aar.length()} bytes"
+    println "TOTAL SIZE (mapzen aar + dependencies): ${Math.round(totalSize * 100) / 100} Mb"
     println ""
+
+    println "MAPZEN AAR SIZE: ${Math.round(mapzen.length() / (1024) * 100) / 100} kb"
+    println ""
+
+
+    println "ALL DEPENDENCIES: ${Math.round(depsSize * 100) / 100} Mb"
+    println ""
+
+    println "DEPENDENCIES:"
+    configurations
+        ._releaseCompile
+        .sort { -it.length() }
+        .each { println "${it.name} : ${Math.round(it.length() / (1024) * 100) / 100} kb" }
+
   }
 }
 aarSize.dependsOn(assembleRelease)

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,6 +9,7 @@ buildscript {
   dependencies {
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     classpath 'net.researchgate:gradle-release:2.4.0'
+    classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.0'
   }
 }
 
@@ -19,6 +20,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'net.researchgate.release'
+apply plugin: 'com.getkeepsafe.dexcount'
 
 group = GROUP
 version = VERSION_NAME
@@ -123,3 +125,8 @@ task aarSize {
   }
 }
 aarSize.dependsOn(assembleRelease)
+
+//TODO: uncomment after merge: https://github.com/KeepSafe/dexcount-gradle-plugin/pull/133
+//dexcount {
+//  runOnEachAssemble false
+//}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -130,3 +130,11 @@ aarSize.dependsOn(assembleRelease)
 //dexcount {
 //  runOnEachAssemble false
 //}
+
+task permissions {
+  File manifest = file("src/main/AndroidManifest.xml")
+  println ""
+  println "Permissions:"
+  println manifest.readLines().findAll { x -> x.contains("uses-permission")}
+  println ""
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -113,3 +113,13 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+task aarSize {
+  doLast {
+    File aar = file("build/outputs/aar/mapzen-android-sdk-release.aar")
+    println ""
+    println "AAR Size: ${aar.length()} bytes"
+    println ""
+  }
+}
+aarSize.dependsOn(assembleRelease)

--- a/library/src/main/java/com/mapzen/android/graphics/TileHttpHandler.java
+++ b/library/src/main/java/com/mapzen/android/graphics/TileHttpHandler.java
@@ -4,14 +4,24 @@ import com.mapzen.tangram.HttpHandler;
 
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.HashMap;
 
 /**
  * A handler responsible for appending an API key to vector tile requests.
  */
 public class TileHttpHandler extends HttpHandler {
+  private static final String TAG = TileHttpHandler.class.getSimpleName();
+  private static final boolean DEBUG_REQUESTS = false;
+
   static final String PARAM_API_KEY = "?api_key=";
 
   private String apiKey;
+  private HashMap<String, Long> urlToMillis = new HashMap<>();
 
   /**
    * Creates a new HTTP handler.
@@ -34,8 +44,34 @@ public class TileHttpHandler extends HttpHandler {
   }
 
   @Override public boolean onRequest(String url, Callback cb) {
+    final Callback fnlCb = cb;
     final String urlWithKey = url + PARAM_API_KEY + apiKey;
-    return super.onRequest(urlWithKey, cb);
+    Callback internalCallback = new Callback() {
+      @Override public void onFailure(Request request, IOException e) {
+        String requestUrl = request.urlString();
+        urlToMillis.remove(requestUrl);
+        fnlCb.onFailure(request, e);
+      }
+
+      @Override public void onResponse(Response response) throws IOException {
+        String requestUrl = response.request().urlString();
+        if (DEBUG_REQUESTS) {
+          Long endMillis = System.currentTimeMillis();
+          Long startMillis = urlToMillis.get(requestUrl);
+          Long elapsedMillis = endMillis - startMillis;
+          boolean fromCache = response.cacheResponse() != null;
+          if (fromCache) {
+            Log.d(TAG, "loaded from cache [" + elapsedMillis + "] millis");
+          } else {
+            Log.d(TAG, "loaded from network [" + elapsedMillis + "] millis");
+          }
+        }
+        urlToMillis.remove(requestUrl);
+        fnlCb.onResponse(response);
+      }
+    };
+    urlToMillis.put(urlWithKey, System.currentTimeMillis());
+    return super.onRequest(urlWithKey, internalCallback);
   }
 
   @Override public void onCancel(String url) {

--- a/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
@@ -7,6 +7,7 @@ import com.mapzen.android.graphics.OnMapReadyCallback;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -20,6 +21,7 @@ public class BasicMapzenActivity extends AppCompatActivity
     implements AdapterView.OnItemSelectedListener {
 
   private static final String KEY_LOCATION_ENABLED = "enabled";
+  private static final String TAG = BasicMapzenActivity.class.getSimpleName();
 
   private MapzenMap map;
 
@@ -48,10 +50,15 @@ public class BasicMapzenActivity extends AppCompatActivity
     final boolean enabled = (savedInstanceState == null ||
         savedInstanceState.getBoolean(KEY_LOCATION_ENABLED));
 
+    final float millis = System.currentTimeMillis();
+
     final MapFragment mapFragment =
         (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
     mapFragment.getMapAsync(new OnMapReadyCallback() {
       @Override public void onMapReady(MapzenMap map) {
+        float now = System.currentTimeMillis();
+        float elapsedTime = now - millis;
+        Log.d(TAG, "onMapReady [" + elapsedTime + "] millis");
         BasicMapzenActivity.this.map = map;
         configureMap(enabled);
       }

--- a/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/BasicMapzenActivity.java
@@ -50,14 +50,14 @@ public class BasicMapzenActivity extends AppCompatActivity
     final boolean enabled = (savedInstanceState == null ||
         savedInstanceState.getBoolean(KEY_LOCATION_ENABLED));
 
-    final float millis = System.currentTimeMillis();
+    final long millis = System.currentTimeMillis();
 
     final MapFragment mapFragment =
         (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
     mapFragment.getMapAsync(new OnMapReadyCallback() {
       @Override public void onMapReady(MapzenMap map) {
-        float now = System.currentTimeMillis();
-        float elapsedTime = now - millis;
+        long now = System.currentTimeMillis();
+        long elapsedTime = now - millis;
         Log.d(TAG, "onMapReady [" + elapsedTime + "] millis");
         BasicMapzenActivity.this.map = map;
         configureMap(enabled);


### PR DESCRIPTION
Adds gradle tasks and adb log output to get various metrics:

- aar size
`./gradlew aarSize`

- number of methods
`./gradlew countReleaseDexMethods`

- view dependency tree
`./gradlew library:dependencies --configuration compile`

- view required permissions
`./gradlew permissions`

- map load time
`adb logcat -s BasicMapzenActivity`

- cached / non-cached tile load times
`adb logcat -s TileHttpHandler` (must enable logging by modifying value of `DEBUG_REQUESTS` in `TileHttpHandler`)

Newly added gradle tasks are run each time master is built

TODO:
- task to analyze unused dependencies (https://github.com/mapzen/android/issues/186)

Closes #164 
