### PR TITLE
Check presence of walkabout style instead of bubble-wrap in submodules task

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -82,7 +82,7 @@ task verify(dependsOn: ['compileDebugSources',
                         'lint'])
 
 task submodules {
-  def folder = new File( 'library/src/main/assets/styles/bubble-wrap/bubble-wrap.yaml' )
+  def folder = new File( 'library/src/main/assets/styles/walkabout-style-more-labels/walkabout-style-more-labels.yaml' )
   if(!folder.exists()) {
     throw new GradleException("Submodules aren't present, please run:\n`git submodule init`, " +
         "\n`git submodule update`\nfrom your root directory")


### PR DESCRIPTION
This will ensure that new users and users who already had the sdk installed and pull the latest (which now includes walkabout) will update their submodules.