### PR TITLE
Update dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -97,9 +97,9 @@ assemble.doFirst {
 dependencies {
   compile 'com.android.support:appcompat-v7:23.4.0'
   compile "com.mapzen.tangram:tangram:$tangram_version"
-  compile 'com.mapzen.android:lost:1.1.1'
-  compile 'com.mapzen:on-the-road:0.8.4'
-  compile 'com.mapzen.android:pelias-android-sdk:0.7.2'
+  compile 'com.mapzen.android:lost:2.0.0'
+  compile 'com.mapzen:on-the-road:1.0.0'
+  compile 'com.mapzen.android:pelias-android-sdk:1.0.0'
   compile 'com.google.dagger:dagger:2.0'
   compile 'javax.annotation:javax.annotation-api:1.2'
 

--- a/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
@@ -77,6 +77,12 @@ public class OverlayManager implements TouchInput.PanResponder {
     @Override public void onLocationChanged(Location location) {
       handleLocationChange(location);
     }
+
+    @Override public void onProviderEnabled(String provider) {
+    }
+
+    @Override public void onProviderDisabled(String provider) {
+    }
   };
 
   View.OnClickListener findMeExternalClickListener;
@@ -651,14 +657,14 @@ public class OverlayManager implements TouchInput.PanResponder {
   }
 
   private void showLastKnownLocation() {
-    final Location current = LocationServices.FusedLocationApi.getLastLocation();
+    final Location current = LocationServices.FusedLocationApi.getLastLocation(lostApiClient);
     if (current != null) {
       updateCurrentLocationMapData(current);
     }
   }
 
   private void centerMapOnLastKnownLocation() {
-    final Location current = LocationServices.FusedLocationApi.getLastLocation();
+    final Location current = LocationServices.FusedLocationApi.getLastLocation(lostApiClient);
     if (current != null) {
       updateMapPosition(current);
     }
@@ -669,7 +675,8 @@ public class OverlayManager implements TouchInput.PanResponder {
         .setInterval(LOCATION_REQUEST_INTERVAL_MILLIS)
         .setFastestInterval(LOCATION_REQUEST_DISPLACEMENT_MILLIS)
         .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-    LocationServices.FusedLocationApi.requestLocationUpdates(locationRequest, locationListener);
+    LocationServices.FusedLocationApi.requestLocationUpdates(lostApiClient, locationRequest,
+        locationListener);
   }
 
   private void removeLocationUpdates() {

--- a/library/src/main/java/com/mapzen/android/location/LocationFactory.java
+++ b/library/src/main/java/com/mapzen/android/location/LocationFactory.java
@@ -1,6 +1,7 @@
 package com.mapzen.android.location;
 
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.api.LostApiClient.ConnectionCallbacks;
 
 import android.content.Context;
 
@@ -17,6 +18,16 @@ public class LocationFactory {
   public static LostApiClient sharedClient(Context context) {
     if (shared == null) {
       shared = new LostApiClient.Builder(context).build();
+    }
+    return shared;
+  }
+
+  /**
+   * Returns shared {@link LostApiClient} with {@link ConnectionCallbacks}.
+   */
+  public static LostApiClient sharedClient(Context context, ConnectionCallbacks callbacks) {
+    if (shared == null) {
+      shared = new LostApiClient.Builder(context).addConnectionCallbacks(callbacks).build();
     }
     return shared;
   }

--- a/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
@@ -67,6 +67,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
         lostApiClient);
     when(LocationServices.FusedLocationApi.getLastLocation(lostApiClient))
         .thenReturn(new Location("test"));
+    when(lostApiClient.isConnected()).thenReturn(true);
     findMeButton = new TestButton(null);
     when(mapController.addDataLayer(any(String.class))).thenReturn(mapData);
     when(mapView.showFindMe()).thenReturn(findMeButton);

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'checkstyle'
 
 def VECTOR_TILES_KEY = hasProperty('vectorTilesKey') ? '"' + vectorTilesKey + '"' : "null";
+def SEARCH_KEY = hasProperty('searchKey') ? '"' + searchKey + '"' : "null";
 def TURN_BY_TURN_KEY = hasProperty('turnByTurnKey') ? '"' + turnByTurnKey + '"' : "null";
 
 android {
@@ -15,6 +16,7 @@ android {
     versionCode 1
     versionName "1.0"
     buildConfigField "String", "VECTOR_TILES_KEY", VECTOR_TILES_KEY
+    buildConfigField "String", "SEARCH_KEY", SEARCH_KEY
     buildConfigField "String", "TURN_BY_TURN_KEY", TURN_BY_TURN_KEY
   }
   buildTypes {


### PR DESCRIPTION
Updates pelias-android-sdk, on-the-road, and lost.

`OverlayManager` should wait for Lost connection callbacks before manipulating map data.

Also adds logic to make sure current `OverlayManager` (recreated when the activity is destroyed) receives the callback. Fixes crash in sample app on rotation.