### PR TITLE
Update Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+    classpath 'com.android.tools.build:gradle:2.2.1'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  java:
+    version: oraclejdk8
+
 checkout:
   post:
     - git submodule sync

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,7 +33,7 @@ afterReleaseBuild.dependsOn uploadArchives
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.3"
+  buildToolsVersion "23.0.1"
 
   defaultConfig {
     minSdkVersion 15

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     classpath 'net.researchgate:gradle-release:2.4.0'
   }
 }
@@ -17,7 +17,6 @@ ext.tangram_version = "0.4.2"
 apply plugin: 'com.android.library'
 apply plugin: 'checkstyle'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'net.researchgate.release'
 
 group = GROUP
@@ -103,7 +102,7 @@ dependencies {
   compile 'com.google.dagger:dagger:2.0'
   compile 'javax.annotation:javax.annotation-api:1.2'
 
-  apt 'com.google.dagger:dagger-compiler:2.0'
+  annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:1.7.1'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,7 +7,7 @@ def TURN_BY_TURN_KEY = hasProperty('turnByTurnKey') ? '"' + turnByTurnKey + '"' 
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.1"
+  buildToolsVersion "23.0.3"
 
   defaultConfig {
     applicationId "com.mapzen.android.sample"


### PR DESCRIPTION
### Overview
Updates Gradle version and dependent plugins. Removes deprecated plugin.

### Proposed Changes
- Updates Gradle to version 2.2.1
- Updates Gradle wrapper to 2.14.1
- Updates `com.github.dcendents:android-maven-gradle-plugin` to 1.4.1
- Removes deprecated `com.neenbedankt.android-apt` plugin
- Updates `circle.yml` to use jdk 8

Closes #173 
