### PR TITLE
Removes tron style

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "library/src/main/assets/styles/zinc-style-more-labels"]
 	path = library/src/main/assets/styles/zinc-style-more-labels
 	url = https://github.com/tangrams/zinc-style-more-labels.git
-[submodule "library/src/main/assets/styles/tron-style"]
-	path = library/src/main/assets/styles/tron-style
-	url = https://github.com/tangrams/tron-style.git

--- a/sample/src/main/java/com/mapzen/android/sample/SwitchStyleActivity.java
+++ b/sample/src/main/java/com/mapzen/android/sample/SwitchStyleActivity.java
@@ -7,7 +7,6 @@ import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.CinnabarStyle;
 import com.mapzen.android.graphics.model.MapStyle;
 import com.mapzen.android.graphics.model.RefillStyle;
-import com.mapzen.android.graphics.model.TronStyle;
 import com.mapzen.android.graphics.model.WalkaboutStyle;
 import com.mapzen.android.graphics.model.ZincStyle;
 
@@ -78,9 +77,6 @@ public class SwitchStyleActivity extends AppCompatActivity
         break;
       case 4:
         changeMapStyle(new ZincStyle());
-        break;
-      case 5:
-        changeMapStyle(new TronStyle());
         break;
       default:
         changeMapStyle(new BubbleWrapStyle());

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
     <item>Refill</item>
     <item>Walkabout</item>
     <item>Zinc</item>
-    <item>Tron</item>
   </string-array>
   <string name="on_single_tap_up">Single Tap Up</string>
   <string name="on_single_tap_confirmed">Single Tap Confirmed</string>


### PR DESCRIPTION
### Overview

Temporarily removing Tron 2.0 style due to incompatibilities with Android's `AssetManager`.

### Proposed Changes

The new Tron stylesheet and Blocks submodule rely on relative import paths to load modular resources. Unfortunately loading assets via relative paths is not supported by the `AssetManager`.

```yaml
import:
    - ../blocks/functions/zoom.yaml
    - ../blocks/functions/pulse.yaml
    - ../blocks/geometry/dynamic-width.yaml
    - ../blocks/geometry/dynamic-height.yaml
```

https://github.com/tangrams/tron-style/blob/gh-pages/styles/common.yaml#L1-L5

Supporting this version of Tron will require normalizing paths in Tangram ES or finding an alternate way to load imported stylesheets.

Another possibility would be switching from bundled submodules to remote stylesheets distrubuted by the CDN but this is not yet officially supported by Tangram ES.

Keeping https://github.com/mapzen/android/issues/206 open to track adding support. Stay tuned for updates.