### PR TITLE
Disable current location layer should remove persisted map data

### DIFF
--- a/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
@@ -162,20 +162,26 @@ public class OverlayManager implements TouchInput.PanResponder {
    */
   public void setMyLocationEnabled(boolean enabled, boolean persistMapData) {
     myLocationEnabled = enabled;
+    handleTangramMapDataChanges(enabled);
+    updateCurrentLocationPersistableMapData(enabled, persistMapData);
+    handleMyLocationEnabledChanged();
+  }
 
+  private void handleTangramMapDataChanges(boolean enabled) {
     if (enabled) {
       addCurrentLocationMapData();
-      if (persistMapData) {
-        mapDataManager.addMapData(new PersistableMapData(enabled));
-      }
     } else {
       removeCurrentLocationMapData();
-      if (persistMapData) {
-        mapDataManager.removeMapData(DataLayerType.CURRENT_LOCATION);
+    }
+  }
+
+  private void updateCurrentLocationPersistableMapData(boolean enabled, boolean persistMapData) {
+    if (persistMapData) {
+      mapDataManager.removeMapData(DataLayerType.CURRENT_LOCATION);
+      if (enabled) {
+        mapDataManager.addMapData(new PersistableMapData(true));
       }
     }
-
-    handleMyLocationEnabledChanged();
   }
 
   /**

--- a/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
+++ b/library/src/main/java/com/mapzen/android/graphics/OverlayManager.java
@@ -161,14 +161,18 @@ public class OverlayManager implements TouchInput.PanResponder {
    * Optionally persists the map data to the {@link MapDataManager}.
    */
   public void setMyLocationEnabled(boolean enabled, boolean persistMapData) {
-    if (persistMapData) {
-      mapDataManager.addMapData(new PersistableMapData(enabled));
-    }
     myLocationEnabled = enabled;
+
     if (enabled) {
       addCurrentLocationMapData();
+      if (persistMapData) {
+        mapDataManager.addMapData(new PersistableMapData(enabled));
+      }
     } else {
       removeCurrentLocationMapData();
+      if (persistMapData) {
+        mapDataManager.removeMapData(DataLayerType.CURRENT_LOCATION);
+      }
     }
 
     handleMyLocationEnabledChanged();

--- a/library/src/main/java/com/mapzen/android/graphics/PersistableMapData.java
+++ b/library/src/main/java/com/mapzen/android/graphics/PersistableMapData.java
@@ -31,7 +31,7 @@ class PersistableMapData {
    * Creates a new object to represent polyline {@link com.mapzen.tangram.MapData}.
    * @param polyline
    */
-  public PersistableMapData(Polyline polyline) {
+  PersistableMapData(Polyline polyline) {
     this.polyline = polyline;
     this.dataLayerType = DataLayerType.POLYLINE;
   }
@@ -40,7 +40,7 @@ class PersistableMapData {
    * Creates a new object to represent polygon {@link com.mapzen.tangram.MapData}.
    * @param polygon
    */
-  public PersistableMapData(Polygon polygon) {
+  PersistableMapData(Polygon polygon) {
     this.polygon = polygon;
     this.dataLayerType = DataLayerType.POLYGON;
   }
@@ -49,7 +49,7 @@ class PersistableMapData {
    * Creates a new object to represent marker {@link com.mapzen.tangram.MapData}.
    * @param marker
    */
-  public PersistableMapData(Marker marker) {
+  PersistableMapData(Marker marker) {
     this.marker = marker;
     this.dataLayerType = DataLayerType.MARKER;
   }
@@ -59,7 +59,7 @@ class PersistableMapData {
    * @param start
    * @param end
    */
-  public PersistableMapData(LngLat start, LngLat end) {
+  PersistableMapData(LngLat start, LngLat end) {
     this.start = start;
     this.end = end;
     this.dataLayerType = DataLayerType.ROUTE_START_PIN;
@@ -72,7 +72,7 @@ class PersistableMapData {
    * @param point
    * @param layerType
    */
-  public PersistableMapData(LngLat point, DataLayerType layerType) {
+  PersistableMapData(LngLat point, DataLayerType layerType) {
     this.point = point;
     this.dataLayerType = layerType;
   }
@@ -85,7 +85,7 @@ class PersistableMapData {
    * @param active
    * @param index
    */
-  public PersistableMapData(LngLat point, boolean active, int index) {
+  PersistableMapData(LngLat point, boolean active, int index) {
     this.point = point;
     this.isActive = active;
     this.index = index;
@@ -96,7 +96,7 @@ class PersistableMapData {
    * Creates a new object to represent route line {@link com.mapzen.tangram.MapData}.
    * @param points
    */
-  public PersistableMapData(List<LngLat> points) {
+  PersistableMapData(List<LngLat> points) {
     this.points = points;
     this.dataLayerType = DataLayerType.ROUTE_LINE;
   }
@@ -107,7 +107,7 @@ class PersistableMapData {
    * @param stations
    * @param hexColor
    */
-  public PersistableMapData(List<LngLat> points, List<LngLat> stations, String hexColor) {
+  PersistableMapData(List<LngLat> points, List<LngLat> stations, String hexColor) {
     this.points = points;
     this.stations = stations;
     this.hexColor = hexColor;
@@ -118,7 +118,7 @@ class PersistableMapData {
    * Creates a new object to represent current location {@link com.mapzen.tangram.MapData}.
    * @param locationEnabled
    */
-  public PersistableMapData(boolean locationEnabled) {
+  PersistableMapData(boolean locationEnabled) {
     this.locationEnabled = locationEnabled;
     this.dataLayerType = DataLayerType.CURRENT_LOCATION;
   }

--- a/library/src/main/java/com/mapzen/android/graphics/PersistableMapData.java
+++ b/library/src/main/java/com/mapzen/android/graphics/PersistableMapData.java
@@ -29,7 +29,8 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent polyline {@link com.mapzen.tangram.MapData}.
-   * @param polyline
+   *
+   * @param polyline the polyline overlay to persist on configuration change.
    */
   PersistableMapData(Polyline polyline) {
     this.polyline = polyline;
@@ -38,7 +39,8 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent polygon {@link com.mapzen.tangram.MapData}.
-   * @param polygon
+   *
+   * @param polygon the polygon overlay to persist on configuration change.
    */
   PersistableMapData(Polygon polygon) {
     this.polygon = polygon;
@@ -47,7 +49,8 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent marker {@link com.mapzen.tangram.MapData}.
-   * @param marker
+   *
+   * @param marker the marker overlay to persist on configuration change.
    */
   PersistableMapData(Marker marker) {
     this.marker = marker;
@@ -56,8 +59,9 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent start and end pin {@link com.mapzen.tangram.MapData}.
-   * @param start
-   * @param end
+   *
+   * @param start the route start marker overlay to persist on configuration change.
+   * @param end the route end marker overlay to persist on configuration change.
    */
   PersistableMapData(LngLat start, LngLat end) {
     this.start = start;
@@ -67,10 +71,12 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent point {@link com.mapzen.tangram.MapData}. Used for
-   * {@link com.mapzen.android.graphics.DataLayerType#DROPPED_PIN}
-   * and ROUTE_PIN
-   * @param point
-   * @param layerType
+   * {@link com.mapzen.android.graphics.DataLayerType#DROPPED_PIN} and
+   * {@link com.mapzen.android.graphics.DataLayerType#ROUTE_PIN}
+   *
+   * @param point the dropped pin or route pin marker overlay to persist on configuration change.
+   * @param layerType {@link com.mapzen.android.graphics.DataLayerType#DROPPED_PIN} or
+   * {@link com.mapzen.android.graphics.DataLayerType#ROUTE_PIN}
    */
   PersistableMapData(LngLat point, DataLayerType layerType) {
     this.point = point;
@@ -81,9 +87,10 @@ class PersistableMapData {
    * Creates a new object to represent {@link com.mapzen.tangram.MapData} where a point, index and
    * active state exist. Used for
    * {@link com.mapzen.android.graphics.DataLayerType#SEARCH_RESULT_PIN}
-   * @param point
-   * @param active
-   * @param index
+   *
+   * @param point coordinates for the search result pin overlay.
+   * @param active `true` if the pin is in the active state. `false` otherwise.
+   * @param index index of the pin in the list of search results.
    */
   PersistableMapData(LngLat point, boolean active, int index) {
     this.point = point;
@@ -94,7 +101,8 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent route line {@link com.mapzen.tangram.MapData}.
-   * @param points
+   *
+   * @param points list of coordinates that will be used to persist the route line overlay.
    */
   PersistableMapData(List<LngLat> points) {
     this.points = points;
@@ -103,9 +111,10 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent transit route line {@link com.mapzen.tangram.MapData}.
-   * @param points
-   * @param stations
-   * @param hexColor
+   *
+   * @param points list of coordinates that will be used to persist the transit route line overlay.
+   * @param stations list of coordinates that will be used to represent transit stations.
+   * @param hexColor hexadecimal color value that will be used to represent the transit line.
    */
   PersistableMapData(List<LngLat> points, List<LngLat> stations, String hexColor) {
     this.points = points;
@@ -116,7 +125,8 @@ class PersistableMapData {
 
   /**
    * Creates a new object to represent current location {@link com.mapzen.tangram.MapData}.
-   * @param locationEnabled
+   *
+   * @param locationEnabled boolean flag to indicate whether current location layer is enabled.
    */
   PersistableMapData(boolean locationEnabled) {
     this.locationEnabled = locationEnabled;

--- a/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
@@ -159,6 +159,12 @@ import static org.powermock.api.mockito.PowerMockito.mock;
     assertThat(mapDataManager.getMapData()).isEmpty();
   }
 
+  @Test public void setMyLocationEnabled_shouldNotAddMoreThanOneMapData() throws Exception {
+    overlayManager.setMyLocationEnabled(true);
+    overlayManager.setMyLocationEnabled(true);
+    assertThat(mapDataManager.getMapData()).hasSize(1);
+  }
+
   @Test public void isMyLocationEnabled_shouldReturnTrue() throws Exception {
     overlayManager.setMyLocationEnabled(true);
     assertThat(overlayManager.isMyLocationEnabled()).isTrue();

--- a/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
+++ b/library/src/test/java/com/mapzen/android/graphics/OverlayManagerTest.java
@@ -43,10 +43,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
+@SuppressWarnings("MissingPermission")
 @RunWith(PowerMockRunner.class) @SuppressStaticInitializationFor("com.mapzen.tangram.MapController")
 @PrepareForTest(OverlayManager.class) public class OverlayManagerTest {
 
   private MapController mapController;
+  private MapDataManager mapDataManager;
   private MapStateManager mapStateManager;
   private OverlayManager overlayManager;
   private MapView mapView;
@@ -61,7 +63,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
     mapData = new TestMapData("test");
     setFinalStatic(LocationServices.class.getDeclaredField("FusedLocationApi"),
         Mockito.mock(FusedLocationProviderApiImpl.class));
-    MapDataManager mapDataManager = new MapDataManager();
+    mapDataManager = new MapDataManager();
     mapStateManager = mock(MapStateManager.class);
     overlayManager = new OverlayManager(mapView, mapController, mapDataManager, mapStateManager,
         lostApiClient);
@@ -144,6 +146,17 @@ import static org.powermock.api.mockito.PowerMockito.mock;
     Location loc = LocationServices.FusedLocationApi.getLastLocation(lostApiClient);
     LngLat lngLat = new LngLat(loc.getLongitude(), loc.getLatitude());
     verify(mapStateManager).setPosition(lngLat);
+  }
+
+  @Test public void setMyLocationEnabled_shouldAddMapDataIfEnabled() throws Exception {
+    overlayManager.setMyLocationEnabled(true);
+    assertThat(mapDataManager.getMapData()).isNotEmpty();
+  }
+
+  @Test public void setMyLocationEnabled_shouldRemoveMapDataIfDisabled() throws Exception {
+    overlayManager.setMyLocationEnabled(true);
+    overlayManager.setMyLocationEnabled(false);
+    assertThat(mapDataManager.getMapData()).isEmpty();
   }
 
   @Test public void isMyLocationEnabled_shouldReturnTrue() throws Exception {

--- a/library/src/test/java/com/mapzen/tangram/TestMapData.java
+++ b/library/src/test/java/com/mapzen/tangram/TestMapData.java
@@ -36,4 +36,7 @@ public class TestMapData extends MapData {
     polygon = null;
     return this;
   }
+
+  @Override public void remove() {
+  }
 }


### PR DESCRIPTION
### Overview

Fixes bug where more than one instance of the current location layer would be persisted leading to inconsistent results when map data state is restored.

### Proposed Changes

When current location layer is disabled all instances of `DataLayerType.CURRENT_LOCATION` are removed from `MapDataManager`. This prevents the situation where more than one current location layer is persisted, some with `PersistableMapData.locationEnabled` set to `true` and others `false`.

This change set also reduces the scope of `PersistableMapData` constructors to package local since this class is only intended to be used internally and adds javadoc descriptions for constructor params.

Closes https://github.com/mapzen/eraser-map/issues/753