### PR TITLE
Added Circle Tickler to CI config file to join the docs pipeline

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   java:
     version: oraclejdk8
+  python:
+    version: 2.7.10
 
 checkout:
   post:
@@ -26,3 +28,6 @@ deployment:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - scripts/deploy-sample-app.sh
       - ./gradlew aarSize countReleaseDexMethods permissions library:dependencies --configuration compile
+      - pip install 'Circle-Tickler == 1.0.1'
+      - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN
+

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ deployment:
       - ./gradlew aarSize countReleaseDexMethods permissions library:dependencies --configuration compile
   docs_pipeline:
     branch: "migurski/add-to-docs-pipeline"
+    commands:
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN
 

--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,8 @@ deployment:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - scripts/deploy-sample-app.sh
       - ./gradlew aarSize countReleaseDexMethods permissions library:dependencies --configuration compile
+  docs_pipeline:
+    branch: "migurski/add-to-docs-pipeline"
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN
 

--- a/circle.yml
+++ b/circle.yml
@@ -28,9 +28,6 @@ deployment:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - scripts/deploy-sample-app.sh
       - ./gradlew aarSize countReleaseDexMethods permissions library:dependencies --configuration compile
-  docs_pipeline:
-    branch: "migurski/add-to-docs-pipeline"
-    commands:
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen mapzen-docs-generator master $CIRCLE_TOKEN
 


### PR DESCRIPTION
### Overview

This change adds Android docs to Mapzen’s docs pipeline, so that successful master commits here trigger a fresh documentation publish process and no one needs to wait for docs to go live.

### Proposed Changes

A new deployment rule tickles [`mapzen/mapzen-docs-generator` CircleCI](https://circleci.com/gh/mapzen/mapzen-docs-generator), which causes the most-recent successful master build to be re-run. If it succeeds, new Android docs will be released to immediately.

- [x] Add tickler to config
- [x] Test on a safe branch
- [x] Switch back to master branch

Part of https://github.com/mapzen/mapzen-docs-generator/issues/224.