### PR TITLE
Deprecates `LocationFactory.sharedClient` and fixes bug due to stale `Context`

### DIFF
--- a/library/src/main/java/com/mapzen/android/location/LocationFactory.java
+++ b/library/src/main/java/com/mapzen/android/location/LocationFactory.java
@@ -11,24 +11,42 @@ import android.content.Context;
 public class LocationFactory {
 
   private static LostApiClient shared;
+  private static Context context;
 
   /**
    * Returns shared {@link LostApiClient}.
+   *
+   * @deprecated This method should not be used outside the SDK. Now that Lost has proper support
+   * for multiple location clients exposing a shared client in no longer needed. Behavior has been
+   * updated to create a new client instance for each new {@link Context}. This fixes a bug
+   * where the shared client was created with a {@link Context} that had been subsequently destroyed
+   * and future attempts to bind the fused location service would fail.
    */
-  public static LostApiClient sharedClient(Context context) {
-    if (shared == null) {
+  @Deprecated public static LostApiClient sharedClient(Context context) {
+    if (LocationFactory.context != context) {
       shared = new LostApiClient.Builder(context).build();
+      LocationFactory.context = context;
     }
+
     return shared;
   }
 
   /**
    * Returns shared {@link LostApiClient} with {@link ConnectionCallbacks}.
+   *
+   * @deprecated This method should not be used outside the SDK. Now that Lost has proper support
+   * for multiple location clients exposing a shared client in no longer needed. Behavior has been
+   * updated to create a new client instance for each new {@link Context}. This fixes a bug
+   * where the shared client was created with a {@link Context} that had been subsequently destroyed
+   * and future attempts to bind the fused location service would fail.
    */
-  public static LostApiClient sharedClient(Context context, ConnectionCallbacks callbacks) {
-    if (shared == null) {
+  @Deprecated public static LostApiClient sharedClient(Context context,
+      ConnectionCallbacks callbacks) {
+    if (LocationFactory.context != context) {
       shared = new LostApiClient.Builder(context).addConnectionCallbacks(callbacks).build();
+      LocationFactory.context = context;
     }
+
     return shared;
   }
 

--- a/library/src/test/java/com/mapzen/android/location/LocationFactoryTest.java
+++ b/library/src/test/java/com/mapzen/android/location/LocationFactoryTest.java
@@ -1,0 +1,60 @@
+package com.mapzen.android.location;
+
+import com.mapzen.android.lost.api.LostApiClient;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import android.content.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocationFactoryTest {
+
+  @Test public void sharedClient_shouldNotBeNull() throws Exception {
+    assertThat(LocationFactory.sharedClient(Mockito.mock(Context.class))).isNotNull();
+  }
+
+  @Test public void sharedClientWithCallbacks_shouldNotBeNull() throws Exception {
+    assertThat(LocationFactory.sharedClient(Mockito.mock(Context.class),
+        new TestConnectionCallbacks())).isNotNull();
+  }
+
+  @Test public void getApiClient_shouldNotBeNull() throws Exception {
+    assertThat(new LocationFactory().getApiClient(Mockito.mock(Context.class))).isNotNull();
+  }
+
+  @Test public void sharedClient_shouldReturnSameClientForSameContext() throws Exception {
+    Context context = Mockito.mock(Context.class);
+    assertThat(LocationFactory.sharedClient(context))
+        .isEqualTo(LocationFactory.sharedClient(context));
+  }
+
+  @Test public void sharedClientWithCallbacks_shouldReturnSameClientForSameContext()
+      throws Exception {
+    Context context = Mockito.mock(Context.class);
+    LostApiClient.ConnectionCallbacks callbacks = new TestConnectionCallbacks();
+    assertThat(LocationFactory.sharedClient(context, callbacks))
+        .isEqualTo(LocationFactory.sharedClient(context, callbacks));
+  }
+
+  @Test public void sharedClient_shouldReturnNewClientForNewContext() throws Exception {
+    assertThat(LocationFactory.sharedClient(Mockito.mock(Context.class)))
+        .isNotEqualTo(LocationFactory.sharedClient(Mockito.mock(Context.class)));
+  }
+
+  @Test public void sharedClientWithCallbacks_shouldReturnNewClientForNewContext()
+      throws Exception {
+    LostApiClient.ConnectionCallbacks callbacks = new TestConnectionCallbacks();
+    assertThat(LocationFactory.sharedClient(Mockito.mock(Context.class), callbacks))
+        .isNotEqualTo(LocationFactory.sharedClient(Mockito.mock(Context.class), callbacks));
+  }
+
+  private class TestConnectionCallbacks implements LostApiClient.ConnectionCallbacks {
+    @Override public void onConnected() {
+    }
+
+    @Override public void onConnectionSuspended() {
+    }
+  }
+}


### PR DESCRIPTION
### Overview

Deprecates `LocationFactory.sharedClient` and fixes bug due to stale `Context`. 

### Proposed Changes

Deprecates `LocationFactory.sharedClient`. This should no longer be used outside the Mapzen SDK since Lost has proper support for multiple location clients. Apps should instead create their own location client if needed.

Ensures a new `LostApiClient` is created for a new `Context`. Re-using a shared client with a stale `Context` was causing the fused location service to fail to bind and the my location layer to break.

Fixes #229 
