### PR TITLE
Upgrades search and routing to okhttp3 and retrofit2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:24.2.1'
 
   compile 'com.mapzen.android:lost:2.1.2'
-  compile 'com.mapzen.android:pelias-android-sdk:1.0.0'
+  compile 'com.mapzen.android:pelias-android-sdk:1.1.0-SNAPSHOT'
   compile "com.mapzen.tangram:tangram:$tangram_version"
 
   compile 'com.google.dagger:dagger:2.0'

--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -82,7 +82,7 @@ task verify(dependsOn: ['compileDebugSources',
 
 dependencies {
   compile 'com.mapzen:mapzen-core:0.0.1-SNAPSHOT'
-  compile 'com.mapzen:on-the-road:1.1.1'
+  compile 'com.mapzen:on-the-road:1.2.0-SNAPSHOT'
 
   annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
 

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/TurnByTurnHttpHandler.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/TurnByTurnHttpHandler.java
@@ -2,8 +2,12 @@ package com.mapzen.android.routing;
 
 import com.mapzen.valhalla.HttpHandler;
 
-import retrofit.RequestInterceptor;
-import retrofit.RestAdapter;
+import java.io.IOException;
+
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import okhttp3.logging.HttpLoggingInterceptor;
 
 /**
  * Handles appending api keys for all turn-by-turn requests.
@@ -31,14 +35,14 @@ public class TurnByTurnHttpHandler extends HttpHandler {
   /**
    * Construct handler with log levels and default url.
    */
-  public TurnByTurnHttpHandler(RestAdapter.LogLevel logLevel) {
+  public TurnByTurnHttpHandler(HttpLoggingInterceptor.Level logLevel) {
     configure(DEFAULT_URL, logLevel);
   }
 
   /**
    * Construct handler with url and log levels.
    */
-  public TurnByTurnHttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+  public TurnByTurnHttpHandler(String endpoint, HttpLoggingInterceptor.Level logLevel) {
     configure(endpoint, logLevel);
   }
 
@@ -49,8 +53,12 @@ public class TurnByTurnHttpHandler extends HttpHandler {
     this.apiKey = apiKey;
   }
 
-  @Override
-  protected void onRequest(RequestInterceptor.RequestFacade requestFacade) {
-    requestFacade.addQueryParam(NAME_API_KEY, this.apiKey);
+  @Override protected Response onRequest(Interceptor.Chain chain) throws IOException {
+    final HttpUrl url = chain.request()
+        .url()
+        .newBuilder()
+        .addQueryParameter(NAME_API_KEY, apiKey)
+        .build();
+    return chain.proceed(chain.request().newBuilder().url(url).build());
   }
 }

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/search/MapzenSearch.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/search/MapzenSearch.java
@@ -10,7 +10,7 @@ import android.content.Context;
 
 import javax.inject.Inject;
 
-import retrofit.Callback;
+import retrofit2.Callback;
 
 /**
  * This class is the main class for interaction with the Mapzen search api.

--- a/mapzen-android-sdk/src/test/java/com/mapzen/android/search/MapzenSearchTest.java
+++ b/mapzen-android-sdk/src/test/java/com/mapzen/android/search/MapzenSearchTest.java
@@ -13,9 +13,9 @@ import static com.mapzen.android.TestHelper.getMockContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class MapzenSearchTest {
 
@@ -69,18 +69,15 @@ public class MapzenSearchTest {
     verify(search.getPelias()).setLocationProvider(provider);
   }
 
-  class TestCallback implements Callback<Result> {
-
-    @Override public void success(Result result, Response response) {
-
+  private class TestCallback implements Callback<Result> {
+    @Override public void onResponse(Call<Result> call, Response<Result> response) {
     }
 
-    @Override public void failure(RetrofitError error) {
-
+    @Override public void onFailure(Call<Result> call, Throwable t) {
     }
   }
 
-  class TestPeliasLocationProvider implements PeliasLocationProvider {
+  private class TestPeliasLocationProvider implements PeliasLocationProvider {
 
     @Override public double getLat() {
       return 0;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
@@ -18,9 +18,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * Object returned by {@link GeoDataApiImpl#getAutocompletePredictions(
@@ -70,11 +70,11 @@ public class AutocompletePendingResult extends PendingResult<AutocompletePredict
       @NonNull final ResultCallback<? super AutocompletePredictionBuffer> callback) {
     LatLng center = bounds.getCenter();
     pelias.suggest(query, center.getLatitude(), center.getLongitude(), new Callback<Result>() {
-      @Override public void success(Result result, Response response) {
+      @Override public void onResponse(Call<Result> call, Response<Result> response) {
         Status status = new Status(Status.SUCCESS);
 
         final ArrayList<AutocompletePrediction> predictions = new ArrayList<>();
-        final List<Feature> features = result.getFeatures();
+        final List<Feature> features = response.body().getFeatures();
         for (Feature feature : features) {
           AutocompletePrediction prediction = new AutocompletePrediction(feature.properties.gid,
               feature.properties.name);
@@ -85,7 +85,7 @@ public class AutocompletePendingResult extends PendingResult<AutocompletePredict
         callback.onResult(buffer);
       }
 
-      @Override public void failure(RetrofitError error) {
+      @Override public void onFailure(Call<Result> call, Throwable t) {
         Status status = new Status(Status.INTERNAL_ERROR);
         AutocompletePredictionBuffer buffer = new AutocompletePredictionBuffer(status, null);
         callback.onResult(buffer);

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/AutocompletePendingResultTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/AutocompletePendingResultTest.java
@@ -25,7 +25,8 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import retrofit.Callback;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class AutocompletePendingResultTest {
 
@@ -75,7 +76,7 @@ public class AutocompletePendingResultTest {
         Object[] args = invocation.getArguments();
         Callback callback = (Callback) args[3];
         final Result result = new Result();
-        callback.success(result, null);
+        callback.onResponse(null, Response.success(result));
         return null;
       }
     }).when(pelias).suggest(anyString(), anyDouble(), anyDouble(), any(Callback.class));
@@ -90,7 +91,7 @@ public class AutocompletePendingResultTest {
       public Object answer(InvocationOnMock invocation) {
         Object[] args = invocation.getArguments();
         Callback callback = (Callback) args[3];
-        callback.failure(null);
+        callback.onFailure(null, null);
         return null;
       }
     }).when(pelias).suggest(anyString(), anyDouble(), anyDouble(), any(Callback.class));

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MapzenSearchViewActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MapzenSearchViewActivity.java
@@ -3,8 +3,8 @@ package com.mapzen.android.sdk.sample;
 import com.mapzen.android.graphics.MapView;
 import com.mapzen.android.graphics.MapzenMap;
 import com.mapzen.android.graphics.MapzenMapPeliasLocationProvider;
-import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.android.graphics.OnMapReadyCallback;
+import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Result;
 import com.mapzen.pelias.widget.AutoCompleteAdapter;
@@ -18,9 +18,9 @@ import android.support.v7.app.AppCompatActivity;
 
 import java.util.List;
 
-import retrofit.Callback;
-import retrofit.RetrofitError;
-import retrofit.client.Response;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * Demonstrates use of {@link MapzenSearch} with a {@link PeliasSearchView} and {@link MapzenMap}.
@@ -77,16 +77,16 @@ public class MapzenSearchViewActivity extends AppCompatActivity {
     searchView.setAutoCompleteListView(listView);
     searchView.setPelias(mapzenSearch.getPelias());
     searchView.setCallback(new Callback<Result>() {
-      @Override public void success(Result result, Response response) {
+      @Override public void onResponse(Call<Result> call, Response<Result> response) {
         mapzenMap.clearSearchResults();
-        for (Feature feature : result.getFeatures()) {
+        for (Feature feature : response.body().getFeatures()) {
           List<Double> coordinates = feature.geometry.coordinates;
           LngLat point = new LngLat(coordinates.get(0), coordinates.get(1));
           mapzenMap.drawSearchResult(point);
         }
       }
 
-      @Override public void failure(RetrofitError error) {
+      @Override public void onFailure(Call<Result> call, Throwable t) {
       }
     });
     searchView.setIconifiedByDefault(false);


### PR DESCRIPTION
### Overview

Upgrades search and routing dependencies to use okhttp3 and retrofit2.

### Proposed Changes

Update Pelias Android SDK to version 1.1.0-SNAPSHOT and On the Road to 1.2.0-SNAPSHOT. Both libraries have been updated to use okhttp3 and retrofit2 (see below). Makes all necessary changes in the Mapzen SDK to remain compatible with library public APIs.

### Depends On

https://github.com/pelias/pelias-android-sdk/pull/55
https://github.com/mapzen/on-the-road_android/pull/98