### PR TITLE
Places Autocomplete (part 2)

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
@@ -8,10 +8,17 @@ import android.os.Parcelable;
  */
 public class AutocompleteFilter implements Parcelable {
 
+  /**
+   * Constructs a new object.
+   */
   public AutocompleteFilter() {
 
   }
 
+  /**
+   * Construsts a new object from a {@link Parcel}.
+   * @param in
+   */
   protected AutocompleteFilter(Parcel in) {
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
@@ -1,8 +1,34 @@
 package com.mapzen.places.api;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 /**
  * Filter for customizing autocomplete results from {@link GeoDataApi}.
  */
-public class AutocompleteFilter {
+public class AutocompleteFilter implements Parcelable {
 
+  public AutocompleteFilter() {
+
+  }
+
+  protected AutocompleteFilter(Parcel in) {
+  }
+
+  public static final Creator<AutocompleteFilter> CREATOR = new Creator<AutocompleteFilter>() {
+    @Override public AutocompleteFilter createFromParcel(Parcel in) {
+      return new AutocompleteFilter(in);
+    }
+
+    @Override public AutocompleteFilter[] newArray(int size) {
+      return new AutocompleteFilter[size];
+    }
+  };
+
+  @Override public int describeContents() {
+    return 0;
+  }
+
+  @Override public void writeToParcel(Parcel parcel, int i) {
+  }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -22,7 +22,6 @@ import android.util.Log;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
-import static com.mapzen.places.api.ui.PlaceAutocomplete.EXTRA_STATUS;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -8,6 +8,7 @@ import com.mapzen.pelias.gson.Result;
 import com.mapzen.pelias.widget.AutoCompleteAdapter;
 import com.mapzen.pelias.widget.AutoCompleteListView;
 import com.mapzen.pelias.widget.PeliasSearchView;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 
@@ -19,6 +20,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
 import static com.mapzen.places.api.ui.PlaceAutocomplete.EXTRA_STATUS;
 import retrofit2.Call;
@@ -69,22 +71,28 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     pelias.setDebug(true);
     pelias.setLocationProvider(new PeliasLocationProvider() {
 
-      // TODO: Replace with real location integration
       @Override public double getLat() {
-        return 40.7443;
+        return presenter.getLat();
       }
 
       @Override public double getLon() {
-        return  -73.9903;
+        return presenter.getLon();
       }
 
       @Override public BoundingBox getBoundingBox() {
-        return null;
+        return presenter.getBoundingBox();
       }
     });
 
     peliasSearchView.setAutoCompleteListView(listView);
     peliasSearchView.setPelias(pelias);
+  }
+
+  @Override public LatLngBounds getBounds() {
+    if (getIntent().getExtras() == null) {
+      return null;
+    }
+    return getIntent().getExtras().getParcelable(EXTRA_BOUNDS);
   }
 
   @Override public void setResult(Place place, Status status) {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -1,5 +1,6 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.PeliasLocationProvider;
@@ -7,15 +8,19 @@ import com.mapzen.pelias.gson.Result;
 import com.mapzen.pelias.widget.AutoCompleteAdapter;
 import com.mapzen.pelias.widget.AutoCompleteListView;
 import com.mapzen.pelias.widget.PeliasSearchView;
+import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
+import static com.mapzen.places.api.ui.PlaceAutocomplete.EXTRA_STATUS;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -82,10 +87,11 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     peliasSearchView.setPelias(pelias);
   }
 
-  @Override public void setResult(String name) {
-    // TODO: Replace String result with Place object. Details should be fetched by presenter.
+  @Override public void setResult(Place place, Status status) {
     final Intent intent = new Intent();
-    intent.putExtra("mapzen_place", name);
+    intent.putExtra(EXTRA_PLACE, (Parcelable) place);
+    //TODO: update LOST, make Status Parcelable
+    //intent.putExtra(EXTRA_STATUS, (Parcelable) status);
     setResult(RESULT_OK, intent);
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
@@ -1,5 +1,8 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.Place;
+
 /**
  * Interface for place autocomplete wrapper Activity.
  */
@@ -7,9 +10,10 @@ interface PlaceAutocompleteController {
 
   /**
    * Set result code and data to return to calling activity/fragment.
-   * @param result Name of venue selected. To be replaced by fully populated {@code Place} object.
+   * @param result Selected{@code Place} object.
+   * @param status Selection status.
    */
-  void setResult(String result);
+  void setResult(Place result, Status status);
 
   /**
    * Finish place autocomplete wrapper activity and return to calling application.

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
@@ -1,6 +1,7 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
 /**
@@ -20,4 +21,10 @@ interface PlaceAutocompleteController {
    */
   void finish();
 
+  /**
+   * Return the bounds for this controller so that it can be converted to a
+   * {@link com.mapzen.pelias.BoundingBox} by the presenter.
+   * @return
+   */
+  LatLngBounds getBounds();
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -1,6 +1,9 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.Place;
 
 import retrofit2.Response;
 
@@ -23,8 +26,16 @@ class PlaceAutocompletePresenter {
    * @param response parsed result returned by the service.
    */
   void onResponse(Response<Result> response) {
-    // TODO: Fetch place details and populate full Place object.
-    controller.setResult(response.body().getFeatures().get(0).properties.name);
+    // TODO: Fetch place details.
+    Properties properties = response.body().getFeatures().get(0).properties;
+    String name = properties.name;
+    String address = properties.label;
+    Place place = new PlaceImpl.Builder()
+        .setName(name)
+        .setAddress(address)
+        .build();
+    Status status = new Status(Status.SUCCESS);
+    controller.setResult(place, status);
     controller.finish();
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -4,7 +4,6 @@ import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
-import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
@@ -42,9 +41,16 @@ class PlaceAutocompletePresenter {
     controller.finish();
   }
 
+  /**
+   * Return the bounding box that should be used to limit autocomplete results. This value is either
+   * set explicitly via {@link com.mapzen.places.api.ui.PlaceAutocomplete.IntentBuilder#
+   * setBoundsBias(LatLngBounds)} or is retrieved from the device's last known location.
+   * @return
+   */
   BoundingBox getBoundingBox() {
     LatLngBounds bounds = controller.getBounds();
     if (bounds == null) {
+      //TODO: retrieve device's last known location
       return null;
     }
     double minLat = bounds.getSouthwest().getLatitude();
@@ -54,6 +60,12 @@ class PlaceAutocompletePresenter {
     return new BoundingBox(minLat, minLon, maxLat, maxLon);
   }
 
+  /**
+   * Returns the latitude value that should be used to limit autocomplete results. It will be the
+   * center of the {@link BoundingBox} returned from
+   * {@link PlaceAutocompletePresenter#getBoundingBox()}.
+   * @return
+   */
   double getLat() {
     BoundingBox boundingBox = getBoundingBox();
     if (boundingBox == null) {
@@ -63,6 +75,12 @@ class PlaceAutocompletePresenter {
     return midLat;
   }
 
+  /**
+   * Returns the longitude value that should be used to limit autocomplete results. It will be the
+   * center of the {@link BoundingBox} returned from
+   * {@link PlaceAutocompletePresenter#getBoundingBox()}.
+   * @return
+   */
   double getLon() {
     BoundingBox boundingBox = getBoundingBox();
     if (boundingBox == null) {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -1,8 +1,11 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.LatLng;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
 import retrofit2.Response;
@@ -37,5 +40,35 @@ class PlaceAutocompletePresenter {
     Status status = new Status(Status.SUCCESS);
     controller.setResult(place, status);
     controller.finish();
+  }
+
+  BoundingBox getBoundingBox() {
+    LatLngBounds bounds = controller.getBounds();
+    if (bounds == null) {
+      return null;
+    }
+    double minLat = bounds.getSouthwest().getLatitude();
+    double minLon = bounds.getSouthwest().getLongitude();
+    double maxLat = bounds.getNortheast().getLatitude();
+    double maxLon = bounds.getNortheast().getLongitude();
+    return new BoundingBox(minLat, minLon, maxLat, maxLon);
+  }
+
+  double getLat() {
+    BoundingBox boundingBox = getBoundingBox();
+    if (boundingBox == null) {
+      return 40.7443;
+    }
+    double midLat = (boundingBox.getMaxLat() - boundingBox.getMinLat()) / 2;
+    return midLat;
+  }
+
+  double getLon() {
+    BoundingBox boundingBox = getBoundingBox();
+    if (boundingBox == null) {
+      return -73.9903;
+    }
+    double midLon = (boundingBox.getMaxLon() - boundingBox.getMinLon()) / 2;
+    return midLon;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteView.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteView.java
@@ -1,7 +1,6 @@
-package com.mapzen.places.api.ui;
+package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.R;
-import com.mapzen.places.api.internal.PlaceAutocompleteActivity;
 
 import android.app.Activity;
 import android.app.Fragment;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
@@ -1,0 +1,10 @@
+package com.mapzen.places.api.internal;
+
+/**
+ * Intent constants for {@link com.mapzen.places.api.ui.PlaceAutocomplete} and
+ * {@link com.mapzen.places.api.ui.PlacePicker} APIs.
+ */
+public class PlaceIntentConsts {
+  public static final String EXTRA_PLACE = "extra_place";
+  public static final String EXTRA_BOUNDS = "extra_bounds";
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
@@ -7,4 +7,6 @@ package com.mapzen.places.api.internal;
 public class PlaceIntentConsts {
   public static final String EXTRA_PLACE = "extra_place";
   public static final String EXTRA_BOUNDS = "extra_bounds";
+  public static final String EXTRA_STATUS = "extra_status";
+  public static final String EXTRA_FILTER = "extra_filter";
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -8,6 +8,7 @@ import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
+import com.mapzen.places.api.ui.PlaceAutocomplete;
 import com.mapzen.places.api.ui.PlaceAutocompleteView;
 import com.mapzen.places.api.ui.PlacePicker;
 import com.mapzen.tangram.LabelPickResult;
@@ -22,6 +23,9 @@ import android.graphics.PointF;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
+
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
 
 /**
  * Activity which displays a map and a dialog when the user selects a place on the map.
@@ -92,20 +96,26 @@ public class PlacePickerActivity extends Activity implements
     if (place instanceof PlaceImpl) {
       PlaceImpl placeImpl = (PlaceImpl) place;
       Intent intent = new Intent();
-      intent.putExtra(PlacePicker.EXTRA_PLACE, placeImpl);
+      intent.putExtra(EXTRA_PLACE, placeImpl);
       setResult(RESULT_OK, intent);
     }
     finish();
   }
 
+  @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    if (resultCode == RESULT_OK) {
+      Place place = PlaceAutocomplete.getPlace(this, data);
+      presenter.onAutocompletePlacePicked(place);
+    }
+  }
+
   private void initializeMap() {
-    //TODO center on either curr location or given bounds
     map.setMyLocationEnabled(true);
     map.setLabelPickListener(this);
 
     Bundle extras = getIntent().getExtras();
     if (extras != null) {
-      LatLngBounds bounds = (LatLngBounds) extras.get(PlacePicker.EXTRA_BOUNDS);
+      LatLngBounds bounds = (LatLngBounds) extras.get(EXTRA_BOUNDS);
       if (bounds != null) {
         LatLng center = bounds.getCenter();
         double lng = center.getLongitude();

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -8,6 +8,7 @@ import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
+import com.mapzen.places.api.ui.PlaceAutocompleteView;
 import com.mapzen.places.api.ui.PlacePicker;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
@@ -19,6 +20,8 @@ import android.content.Intent;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
 
 /**
  * Activity which displays a map and a dialog when the user selects a place on the map.
@@ -28,6 +31,7 @@ public class PlacePickerActivity extends Activity implements
     DialogInterface.OnClickListener {
 
   PlacePickerPresenter presenter;
+  PlaceAutocompleteView autocompleteView;
   MapView mapView;
   MapzenMap map;
   AlertDialog dialog;
@@ -35,7 +39,10 @@ public class PlacePickerActivity extends Activity implements
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    setContentView(R.layout.mz_fragment_map);
+    setContentView(R.layout.place_picker_activity);
+
+    autocompleteView = (PlaceAutocompleteView) findViewById(R.id.autocomplete_view);
+    autocompleteView.setActivity(this);
 
     //TODO inject
     presenter = new PlacePickerPresenterImpl(new PeliasPlaceDetailFetcher());

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -9,7 +9,6 @@ import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 import com.mapzen.places.api.ui.PlaceAutocomplete;
-import com.mapzen.places.api.ui.PlaceAutocompleteView;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -10,7 +10,6 @@ import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 import com.mapzen.places.api.ui.PlaceAutocomplete;
 import com.mapzen.places.api.ui.PlaceAutocompleteView;
-import com.mapzen.places.api.ui.PlacePicker;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
 
@@ -21,8 +20,6 @@ import android.content.Intent;
 import android.graphics.Point;
 import android.graphics.PointF;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.TextView;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
@@ -1,5 +1,6 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.places.api.Place;
 import com.mapzen.tangram.LngLat;
 
 import java.util.Map;
@@ -26,4 +27,10 @@ interface PlacePickerPresenter {
    * a POI has been picked.
    */
   void onPlaceConfirmed();
+
+  /**
+   * Called when a {@link Place} is selected from the PlaceAutocomplete UI.
+   * @param place
+   */
+  void onAutocompletePlacePicked(Place place);
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -46,4 +46,8 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
     Place place = detailFetcher.getFetchedPlace();
     controller.finishWithPlace(place);
   }
+
+  @Override public void onAutocompletePlacePicked(Place place) {
+    controller.finishWithPlace(place);
+  }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
@@ -11,7 +11,9 @@ import android.content.Context;
 import android.content.Intent;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_FILTER;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_STATUS;
 
 /**
  * Main entry point for the autocomplete API. A search widget is presented and users can select
@@ -21,9 +23,6 @@ public class PlaceAutocomplete {
 
   public static final int MODE_FULLSCREEN = 1;
   public static final int MODE_OVERLAY = 2;
-
-  public static final String EXTRA_STATUS = "extra_status";
-  public static final String EXTRA_FILTER = "extra_filter";
 
   /**
    * Retrieves a {@link Place} object from the {@link Intent}.

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
@@ -26,7 +26,7 @@ public class PlaceAutocomplete {
   public static final String EXTRA_FILTER = "extra_filter";
 
   /**
-   * Returns a {@link Place} object.
+   * Retrieves a {@link Place} object from the {@link Intent}.
    * @param context
    * @param intent
    * @return
@@ -38,6 +38,12 @@ public class PlaceAutocomplete {
     return intent.getParcelableExtra(EXTRA_PLACE);
   }
 
+  /**
+   * Retrieves a {@link Status} object from the {@link Intent}.
+   * @param context
+   * @param intent
+   * @return
+   */
   public static Status getStatus(Context context, Intent intent) {
     if (intent == null) {
       return null;
@@ -86,6 +92,11 @@ public class PlaceAutocomplete {
       return this;
     }
 
+    /**
+     * Set a filter to be used to limit autocomplete results.
+     * @param filter
+     * @return
+     */
     public IntentBuilder setFilter(AutocompleteFilter filter) {
       this.filter = filter;
       return this;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
@@ -1,0 +1,94 @@
+package com.mapzen.places.api.ui;
+
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.AutocompleteFilter;
+import com.mapzen.places.api.LatLngBounds;
+import com.mapzen.places.api.Place;
+import com.mapzen.places.api.internal.PlaceAutocompleteActivity;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
+
+/**
+ * Main entry point for the autocomplete API. A search widget is presented and users can select
+ * autocomplete results. Unlike the {@link PlacePicker} API, a map is not shown.
+ */
+public class PlaceAutocomplete {
+
+  public static final int MODE_FULLSCREEN = 1;
+  public static final int MODE_OVERLAY = 2;
+
+  public static final String EXTRA_STATUS = "extra_status";
+  public static final String EXTRA_FILTER = "extra_filter";
+
+  /**
+   * Returns a {@link Place} object.
+   * @param context
+   * @param intent
+   * @return
+   */
+  public static Place getPlace(Context context, Intent intent) {
+    if (intent == null) {
+      return null;
+    }
+    return intent.getParcelableExtra(EXTRA_PLACE);
+  }
+
+  public static Status getStatus(Context context, Intent intent) {
+    if (intent == null) {
+      return null;
+    }
+    return intent.getParcelableExtra(EXTRA_STATUS);
+  }
+
+  /**
+   * Handles constructing an intent to launch the PlaceAutocomplete UI.
+   */
+  public static class IntentBuilder {
+
+    private LatLngBounds bounds;
+    private AutocompleteFilter filter;
+    private int mode;
+
+    /**
+     * Construct builder with either {@link PlaceAutocomplete#MODE_FULLSCREEN} or
+     * {@link PlaceAutocomplete#MODE_OVERLAY}.
+     * @param mode
+     */
+    public IntentBuilder(int mode) {
+      this.mode = mode;
+    }
+
+    /**
+     * Construct an intent which will launch the PlaceAutocomplete UI.
+     * @param activity
+     * @return
+     */
+    public Intent build(Activity activity) {
+      Intent intent = new Intent(activity, PlaceAutocompleteActivity.class);
+      intent.putExtra(EXTRA_BOUNDS, bounds);
+      intent.putExtra(EXTRA_FILTER, filter);
+      return intent;
+    }
+
+    /**
+     * Set the bounds that the Place Picker map should be centered on. If not set, the map will be
+     * centered on the user's current location.
+     * @param latLngBounds
+     * @return
+     */
+    public IntentBuilder setBoundsBias(LatLngBounds latLngBounds) {
+      this.bounds = latLngBounds;
+      return this;
+    }
+
+    public IntentBuilder setFilter(AutocompleteFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -2,6 +2,7 @@ package com.mapzen.places.api.ui;
 
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
+import com.mapzen.places.api.internal.PlaceAutocompleteView;
 
 import android.app.Fragment;
 import android.content.Intent;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -2,7 +2,6 @@ package com.mapzen.places.api.ui;
 
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
-import com.mapzen.places.api.internal.PlaceAutocompleteActivity;
 
 import android.app.Fragment;
 import android.content.Intent;
@@ -11,7 +10,6 @@ import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
 import static android.app.Activity.RESULT_OK;
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -1,5 +1,6 @@
 package com.mapzen.places.api.ui;
 
+import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 import com.mapzen.places.api.internal.PlaceAutocompleteActivity;
 
@@ -18,7 +19,9 @@ import static android.app.Activity.RESULT_OK;
  * A fragment that provides auto-completion for places.
  */
 public class PlaceAutocompleteFragment extends Fragment {
+
   private PlaceAutocompleteView autocompleteView;
+  private PlaceSelectionListener listener;
 
   @Nullable @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
@@ -30,8 +33,20 @@ public class PlaceAutocompleteFragment extends Fragment {
 
   @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (resultCode == RESULT_OK) {
-      // TODO: Replace with PlaceAutocomplete.getPlace(Context, Intent)
-      autocompleteView.setText(data.getStringExtra("mapzen_place"));
+      Place place = PlaceAutocomplete.getPlace(this.getActivity(), data);
+      String address = null;
+      if (place.getAddress() != null) {
+        address = place.getAddress().toString();
+      }
+      autocompleteView.setText(address);
+      if (listener != null) {
+        listener.onPlaceSelected(place);
+      }
     }
   }
+
+  public void setPlaceSelectionListener(PlaceSelectionListener listener) {
+    this.listener = listener;
+  }
+
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -18,24 +18,20 @@ import static android.app.Activity.RESULT_OK;
  * A fragment that provides auto-completion for places.
  */
 public class PlaceAutocompleteFragment extends Fragment {
-  private TextView input;
+  private PlaceAutocompleteView autocompleteView;
 
   @Nullable @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
-    final View view = inflater.inflate(R.layout.place_autocomplete_fragment, container, false);
-    input = (TextView) view.findViewById(R.id.place_autocomplete_search_input);
-    input.setOnClickListener(new View.OnClickListener() {
-      @Override public void onClick(View v) {
-        startActivityForResult(new Intent(getActivity(), PlaceAutocompleteActivity.class), 0);
-      }
-    });
-    return view;
+    autocompleteView = (PlaceAutocompleteView) inflater.inflate(
+        R.layout.place_autocomplete_fragment, container, false);
+    autocompleteView.setFragment(this);
+    return autocompleteView;
   }
 
   @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (resultCode == RESULT_OK) {
       // TODO: Replace with PlaceAutocomplete.getPlace(Context, Intent)
-      input.setText(data.getStringExtra("mapzen_place"));
+      autocompleteView.setText(data.getStringExtra("mapzen_place"));
     }
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteView.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteView.java
@@ -1,0 +1,70 @@
+package com.mapzen.places.api.ui;
+
+import com.mapzen.places.api.R;
+import com.mapzen.places.api.internal.PlaceAutocompleteActivity;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.content.Context;
+import android.content.Intent;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+/**
+ * Compound view which displays search icon, autocomplete text view and clear button.
+ */
+public class PlaceAutocompleteView extends LinearLayout {
+
+  TextView input;
+
+  public PlaceAutocompleteView(Context context) {
+    super(context);
+    setup(context);
+  }
+
+  public PlaceAutocompleteView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    setup(context);
+  }
+
+  public PlaceAutocompleteView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+    setup(context);
+  }
+
+  private void setup(Context context) {
+    LayoutInflater inflater = (LayoutInflater) context.getSystemService(
+        Context.LAYOUT_INFLATER_SERVICE);
+    inflater.inflate(R.layout.place_autocomplete_view, this, true);
+    setBackgroundColor(getResources().getColor(R.color.mz_white));
+  }
+
+  public void setActivity(Activity a) {
+    final Activity activity = a;
+    input = (TextView) findViewById(R.id.place_autocomplete_search_input);
+    input.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        activity.startActivityForResult(new Intent(activity.getBaseContext(),
+            PlaceAutocompleteActivity.class), 0);
+      }
+    });
+  }
+
+  public void setFragment(Fragment f) {
+    final Fragment fragment = f;
+    input = (TextView) findViewById(R.id.place_autocomplete_search_input);
+    input.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View v) {
+        fragment.startActivityForResult(new Intent(fragment.getActivity().getBaseContext(),
+            PlaceAutocompleteActivity.class), 0);
+      }
+    });
+  }
+
+  public void setText(String s) {
+    input.setText(s);
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteView.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteView.java
@@ -20,16 +20,31 @@ public class PlaceAutocompleteView extends LinearLayout {
 
   TextView input;
 
+  /**
+   * Public constructor.
+   * @param context
+   */
   public PlaceAutocompleteView(Context context) {
     super(context);
     setup(context);
   }
 
+  /**
+   * Public constructor.
+   * @param context
+   * @param attrs
+   */
   public PlaceAutocompleteView(Context context, AttributeSet attrs) {
     super(context, attrs);
     setup(context);
   }
 
+  /**
+   * Public constructor.
+   * @param context
+   * @param attrs
+   * @param defStyleAttr
+   */
   public PlaceAutocompleteView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     setup(context);
@@ -42,6 +57,11 @@ public class PlaceAutocompleteView extends LinearLayout {
     setBackgroundColor(getResources().getColor(R.color.mz_white));
   }
 
+  /**
+   * Set the view's {@link Activity} so that when the view is clicked the
+   * {@link PlaceAutocompleteActivity} can be started for a result via the activity context.
+   * @param a
+   */
   public void setActivity(Activity a) {
     final Activity activity = a;
     input = (TextView) findViewById(R.id.place_autocomplete_search_input);
@@ -53,6 +73,11 @@ public class PlaceAutocompleteView extends LinearLayout {
     });
   }
 
+  /**
+   * Set the view's {@link Fragment} so that when the view is clicked the
+   * {@link PlaceAutocompleteActivity} can be started for a result via the fragment context.
+   * @param f
+   */
   public void setFragment(Fragment f) {
     final Fragment fragment = f;
     input = (TextView) findViewById(R.id.place_autocomplete_search_input);
@@ -64,6 +89,10 @@ public class PlaceAutocompleteView extends LinearLayout {
     });
   }
 
+  /**
+   * Sets the view input text.
+   * @param s
+   */
   public void setText(String s) {
     input.setText(s);
   }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlacePicker.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlacePicker.java
@@ -8,14 +8,14 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
+
 /**
  * Entry point for interaction with the PlacePicker API which allows the user to select a place on
  * the map and receive detailed information about it.
  */
 public class PlacePicker {
-
-  public static final String EXTRA_PLACE = "extra_place";
-  public static final String EXTRA_BOUNDS = "extra_bounds";
 
   /**
    * Returns the place's attributions.

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
@@ -5,7 +5,7 @@ import com.mapzen.places.api.Place;
 
 /**
  * Interface for receiving information about a {@link Place} after it is selected from a
- * {@link PlaceAutocompleteFragment}
+ * {@link PlaceAutocompleteFragment}.
  */
 public interface PlaceSelectionListener {
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
@@ -1,0 +1,23 @@
+package com.mapzen.places.api.ui;
+
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.Place;
+
+/**
+ * Interface for receiving information about a {@link Place} after it is selected from a
+ * {@link PlaceAutocompleteFragment}
+ */
+public interface PlaceSelectionListener {
+
+  /**
+   * Called when the user selects a {@link Place}.
+   * @param place
+   */
+  abstract void onPlaceSelected(Place place);
+
+  /**
+   * Called when an error occurs while trying to select a {@link Place}.
+   * @param status
+   */
+  abstract void onError(Status status);
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceSelectionListener.java
@@ -13,11 +13,11 @@ public interface PlaceSelectionListener {
    * Called when the user selects a {@link Place}.
    * @param place
    */
-  abstract void onPlaceSelected(Place place);
+  void onPlaceSelected(Place place);
 
   /**
    * Called when an error occurs while trying to select a {@link Place}.
    * @param status
    */
-  abstract void onError(Status status);
+  void onError(Status status);
 }

--- a/mapzen-places-api/src/main/res/layout/place_autocomplete_fragment.xml
+++ b/mapzen-places-api/src/main/res/layout/place_autocomplete_fragment.xml
@@ -1,53 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.mapzen.places.api.ui.PlaceAutocompleteView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:gravity="center"
-    android:focusable="true"
-    android:focusableInTouchMode="true"
-    >
-
-  <ImageButton
-      android:id="@+id/place_autocomplete_search_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_weight="0"
-      android:padding="@dimen/place_autocomplete_button_padding"
-      android:src="@drawable/places_ic_search"
-      android:background="@null"
-      android:contentDescription="@string/place_autocomplete_search_hint"
-      />
-
-  <EditText
-      android:id="@+id/place_autocomplete_search_input"
-      android:layout_width="0dp"
-      android:layout_height="match_parent"
-      android:layout_weight="1"
-      android:background="@null"
-      android:textColor="@color/place_autocomplete_search_text"
-      android:textColorHint="@color/place_autocomplete_search_hint"
-      android:textSize="20dp"
-      android:paddingLeft="16dp"
-      android:paddingRight="16dp"
-      android:singleLine="true"
-      android:lines="1"
-      android:maxLines="1"
-      android:inputType="textNoSuggestions"
-      android:hint="@string/place_autocomplete_search_hint"
-      android:focusable="false"
-      android:focusableInTouchMode="false"
-      />
-
-  <ImageButton
-      android:id="@+id/place_autocomplete_clear_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_weight="0"
-      android:padding="@dimen/place_autocomplete_button_padding"
-      android:src="@drawable/places_ic_clear"
-      android:background="@null"
-      android:contentDescription="@string/place_autocomplete_clear_button"
-      />
-
-</LinearLayout>
+    android:layout_height="wrap_content"/>

--- a/mapzen-places-api/src/main/res/layout/place_autocomplete_fragment.xml
+++ b/mapzen-places-api/src/main/res/layout/place_autocomplete_fragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.mapzen.places.api.ui.PlaceAutocompleteView
+<com.mapzen.places.api.internal.PlaceAutocompleteView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"/>

--- a/mapzen-places-api/src/main/res/layout/place_autocomplete_view.xml
+++ b/mapzen-places-api/src/main/res/layout/place_autocomplete_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    >
+
+  <ImageButton
+      android:id="@+id/place_autocomplete_search_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:padding="@dimen/place_autocomplete_button_padding"
+      android:src="@drawable/places_ic_search"
+      android:background="@null"
+      android:contentDescription="@string/place_autocomplete_search_hint"
+      />
+
+  <EditText
+      android:id="@+id/place_autocomplete_search_input"
+      android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="1"
+      android:background="@null"
+      android:textColor="@color/place_autocomplete_search_text"
+      android:textColorHint="@color/place_autocomplete_search_hint"
+      android:textSize="20dp"
+      android:paddingLeft="16dp"
+      android:paddingRight="16dp"
+      android:singleLine="true"
+      android:lines="1"
+      android:maxLines="1"
+      android:inputType="textNoSuggestions"
+      android:hint="@string/place_autocomplete_search_hint"
+      android:focusable="false"
+      android:focusableInTouchMode="false"
+      />
+
+  <ImageButton
+      android:id="@+id/place_autocomplete_clear_button"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_weight="0"
+      android:padding="@dimen/place_autocomplete_button_padding"
+      android:src="@drawable/places_ic_clear"
+      android:background="@null"
+      android:contentDescription="@string/place_autocomplete_clear_button"
+      />
+
+</merge>

--- a/mapzen-places-api/src/main/res/layout/place_picker_activity.xml
+++ b/mapzen-places-api/src/main/res/layout/place_picker_activity.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <include layout="@layout/mz_fragment_map"/>
+
+  <com.mapzen.places.api.ui.PlaceAutocompleteView
+      android:id="@+id/autocomplete_view"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
+
+</FrameLayout>

--- a/mapzen-places-api/src/main/res/layout/place_picker_activity.xml
+++ b/mapzen-places-api/src/main/res/layout/place_picker_activity.xml
@@ -5,7 +5,7 @@
 
   <include layout="@layout/mz_fragment_map"/>
 
-  <com.mapzen.places.api.ui.PlaceAutocompleteView
+  <com.mapzen.places.api.internal.PlaceAutocompleteView
       android:id="@+id/autocomplete_view"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"/>

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -1,8 +1,10 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.Place;
 
 import org.junit.Test;
 
@@ -25,7 +27,7 @@ public class PlaceAutocompletePresenterTest {
   public void onResponse_shouldSetResult() throws Exception {
     Response<Result> response = getTestResponse();
     presenter.onResponse(response);
-    assertThat(controller.result).isEqualTo("Test Name");
+    assertThat(controller.result.getName()).isEqualTo("Test Name");
   }
 
   @Test
@@ -46,10 +48,10 @@ public class PlaceAutocompletePresenterTest {
   }
 
   private static class TestPlaceAutocompleteController implements PlaceAutocompleteController {
-    private String result = null;
+    private Place result = null;
     private boolean isFinishing = false;
 
-    @Override public void setResult(String result) {
+    @Override public void setResult(Place result, Status status) {
       this.result = result;
     }
 

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -1,9 +1,12 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.LatLng;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
 import org.junit.Test;
@@ -37,6 +40,27 @@ public class PlaceAutocompletePresenterTest {
     assertThat(controller.isFinishing).isTrue();
   }
 
+  @Test
+  public void getBoundingBox_shouldReturnCorrectBox() {
+    BoundingBox boundingBox = presenter.getBoundingBox();
+    assertThat(boundingBox.getMinLat()).isEqualTo(0.0);
+    assertThat(boundingBox.getMinLon()).isEqualTo(0.0);
+    assertThat(boundingBox.getMaxLat()).isEqualTo(50.0);
+    assertThat(boundingBox.getMaxLon()).isEqualTo(100.0);
+  }
+
+  @Test
+  public void getLat_shouldReturnCorrectLat() {
+    double lat = presenter.getLat();
+    assertThat(lat).isEqualTo(25.0);
+  }
+
+  @Test
+  public void getLon_shouldReturnCorrectLon() {
+    double lat = presenter.getLon();
+    assertThat(lat).isEqualTo(50.0);
+  }
+
   @NonNull private Response<Result> getTestResponse() {
     Result result = new Result();
     Feature feature = new Feature();
@@ -50,6 +74,9 @@ public class PlaceAutocompletePresenterTest {
   private static class TestPlaceAutocompleteController implements PlaceAutocompleteController {
     private Place result = null;
     private boolean isFinishing = false;
+    LatLng sw = new LatLng(0.0, 0.0);
+    LatLng ne = new LatLng(50.0, 100.0);
+    LatLngBounds bounds = new LatLngBounds(sw, ne);
 
     @Override public void setResult(Place result, Status status) {
       this.result = result;
@@ -57,6 +84,10 @@ public class PlaceAutocompletePresenterTest {
 
     @Override public void finish() {
       isFinishing = true;
+    }
+
+    @Override public LatLngBounds getBounds() {
+      return bounds;
     }
   }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.places.api.Place;
 import com.mapzen.tangram.LngLat;
 
 import org.junit.Before;
@@ -30,6 +31,12 @@ public class PlacePickerPresenterTest {
 
   @Test public void onPlaceConfirmed_shouldFinishActivity() {
     presenter.onPlaceConfirmed();
+    assertThat(controller.finished).isTrue();
+  }
+
+  @Test public void onAutocompletePlacePicked_shouldFinishActivity() {
+    Place place = new PlaceImpl.Builder().build();
+    presenter.onAutocompletePlacePicked(place);
     assertThat(controller.finished).isTrue();
   }
 }


### PR DESCRIPTION
### Overview
This adds more functionality to the `PlaceAutocomplete` API. Developers can set a bounding box to limit autocomplete results and use the static methods in `PlaceAutocomplete` to launch the autocomplete activity and retrieve place results. This also integrates the autocomplete UI into the `PlacePicker` UI.

### Proposed Changes
The autocomplete search view has been refactored into `PlaceAutocompleteView`. `AutocompleteFilter` is now `Parcelable` so that it can be passed as an intent extra. `PlaceAutocompleteActivity` respects any `BoundingBox` set. The autocomplete fragment and presenter are now passing around a proper `Place` object and there is a `PlaceSelectionListener` to handle notifying relevant objects when a `Place` has been selected from the autocomplete fragment.


There will be a follow up PR with more changes as per: https://github.com/mapzen/android/issues/196
