### PR TITLE
Autocomplete pt3

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 
   compile "com.mapzen.tangram:tangram:$tangram_version"
   compile 'com.mapzen.android:pelias-android-sdk:1.1.0-SNAPSHOT'
-  compile 'com.mapzen.android:lost:2.1.2'
+  compile 'com.mapzen.android:lost:2.1.3-SNAPSHOT'
 
   compile 'com.google.dagger:dagger:2.0'
   compile 'javax.annotation:javax.annotation-api:1.2'

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
@@ -56,9 +56,18 @@ public class AutocompleteFilter implements Parcelable {
   /**
    * Constructs a new object.
    */
-  public AutocompleteFilter(String country, int typeFilter) {
+  AutocompleteFilter(String country, int typeFilter) {
     this.country = country;
     this.typeFilter = typeFilter;
+  }
+
+  /**
+   * Return the country that results should be limited to. Will be an ISO 3166-1 Alpha-2 country
+   * code or null.
+   * @return
+   */
+  public String getCountry() {
+    return country;
   }
 
   /**
@@ -85,7 +94,7 @@ public class AutocompleteFilter implements Parcelable {
   public static class Builder {
 
     private String country;
-    private int typeFilter;
+    private int typeFilter = TYPE_FILTER_NONE;
 
     /**
      * The country to restrict results to. This should be a ISO 3166-1 Alpha-2 country code

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
@@ -14,12 +14,6 @@ public class AutocompleteFilter implements Parcelable {
   public static final int TYPE_FILTER_ADDRESS = 2;
   /**
    * Only return results that represent cities.
-   *
-   * Return will be returned for the following place types:
-   * <p><ul>
-   * <li>{@link Place#TYPE_LOCALITY}
-   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_3}
-   * </ul><p>
    */
   public static final int TYPE_FILTER_CITIES = 5;
   /**
@@ -36,17 +30,6 @@ public class AutocompleteFilter implements Parcelable {
   public static final int TYPE_FILTER_NONE = 0;
   /**
    * Only return results that represent regions.
-   *
-   * Results will be returned for the following place types:
-   * <p><ul>
-   * <li>{@link Place#TYPE_LOCALITY}
-   * <li>{@link Place#TYPE_SUBLOCALITY}
-   * <li>{@link Place#TYPE_POSTAL_CODE}
-   * <li>{@link Place#TYPE_COUNTRY}
-   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_1}
-   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_2}
-   * </ul><p>
-   *
    */
   public static final int TYPE_FILTER_REGIONS = 4;
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/AutocompleteFilter.java
@@ -9,10 +9,125 @@ import android.os.Parcelable;
 public class AutocompleteFilter implements Parcelable {
 
   /**
+   * Only return geocoding results with a precise address.
+   */
+  public static final int TYPE_FILTER_ADDRESS = 2;
+  /**
+   * Only return results that represent cities.
+   *
+   * Return will be returned for the following place types:
+   * <p><ul>
+   * <li>{@link Place#TYPE_LOCALITY}
+   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_3}
+   * </ul><p>
+   */
+  public static final int TYPE_FILTER_CITIES = 5;
+  /**
+   * Only return results that are classified as businesses.
+   */
+  public static final int TYPE_FILTER_ESTABLISHMENT = 34;
+  /**
+   * Only return geocoding results, rather than business results.
+   */
+  public static final int TYPE_FILTER_GEOCODE = 1007;
+  /**
+   * An empty type filter.
+   */
+  public static final int TYPE_FILTER_NONE = 0;
+  /**
+   * Only return results that represent regions.
+   *
+   * Results will be returned for the following place types:
+   * <p><ul>
+   * <li>{@link Place#TYPE_LOCALITY}
+   * <li>{@link Place#TYPE_SUBLOCALITY}
+   * <li>{@link Place#TYPE_POSTAL_CODE}
+   * <li>{@link Place#TYPE_COUNTRY}
+   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_1}
+   * <li>{@link Place#TYPE_ADMINISTRATIVE_AREA_LEVEL_2}
+   * </ul><p>
+   *
+   */
+  public static final int TYPE_FILTER_REGIONS = 4;
+
+  private final String country;
+  private final int typeFilter;
+
+  /**
    * Constructs a new object.
    */
-  public AutocompleteFilter() {
+  public AutocompleteFilter(String country, int typeFilter) {
+    this.country = country;
+    this.typeFilter = typeFilter;
+  }
 
+  /**
+   * Return the filter used to restrict autocomplete results.
+   *
+   * Possible values:
+   * <p><ul>
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_ADDRESS}
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_CITIES}
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_ESTABLISHMENT}
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_GEOCODE}
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_NONE}
+   * <li>{@link AutocompleteFilter#TYPE_FILTER_REGIONS}
+   * </ul><p>
+   * @return
+   */
+  public int getTypeFilter() {
+    return typeFilter;
+  }
+
+  /**
+   * Builder for {@link AutocompleteFilter}.
+   */
+  public static class Builder {
+
+    private String country;
+    private int typeFilter;
+
+    /**
+     * The country to restrict results to. This should be a ISO 3166-1 Alpha-2 country code
+     * (case insensitive). If this is not set, no country filtering will take place.
+     * @param country
+     * @return
+     */
+    public Builder setCountry(String country) {
+      this.country = country;
+      return this;
+    }
+
+    /**
+     * Allows you to restrict the result set of a PlaceAutocomplete request.
+     *
+     * Valid values are:
+     * <p><ul>
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_ADDRESS}
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_CITIES}
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_ESTABLISHMENT}
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_GEOCODE}
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_NONE}
+     * <li>{@link AutocompleteFilter#TYPE_FILTER_REGIONS}
+     * </ul><p>
+     *
+     * @param typeFilter
+     * @return
+     */
+    public Builder setTypeFilter(int typeFilter) {
+      this.typeFilter = typeFilter;
+      return this;
+    }
+
+    /**
+     * Returns an AutocompleteFilter that can be passed to
+     * {@link GeoDataApi#getAutocompletePredictions(com.mapzen.android.lost.api.LostApiClient,
+     * String, LatLngBounds, AutocompleteFilter}.
+     * @return
+     */
+    public AutocompleteFilter build() {
+      return new AutocompleteFilter(country, typeFilter);
+    }
   }
 
   /**
@@ -20,6 +135,8 @@ public class AutocompleteFilter implements Parcelable {
    * @param in
    */
   protected AutocompleteFilter(Parcel in) {
+    country = in.readString();
+    typeFilter = in.readInt();
   }
 
   public static final Creator<AutocompleteFilter> CREATOR = new Creator<AutocompleteFilter>() {
@@ -37,5 +154,7 @@ public class AutocompleteFilter implements Parcelable {
   }
 
   @Override public void writeToParcel(Parcel parcel, int i) {
+    parcel.writeString(country);
+    parcel.writeInt(typeFilter);
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
@@ -11,14 +11,6 @@ import java.util.Locale;
  */
 public interface Place extends Parcelable {
 
-  public static final int TYPE_LOCALITY = 1009;
-  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_3 = 1003;
-  public static final int TYPE_SUBLOCALITY = 1022;
-  public static final int TYPE_POSTAL_CODE = 1015;
-  public static final int TYPE_COUNTRY = 1005;
-  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_1 = 1001;
-  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_2 = 1002;
-
   /**
    * Returns human readable address for this place.
    * @return

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
@@ -11,6 +11,14 @@ import java.util.Locale;
  */
 public interface Place extends Parcelable {
 
+  public static final int TYPE_LOCALITY = 1009;
+  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_3 = 1003;
+  public static final int TYPE_SUBLOCALITY = 1022;
+  public static final int TYPE_POSTAL_CODE = 1015;
+  public static final int TYPE_COUNTRY = 1005;
+  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_1 = 1001;
+  public static final int TYPE_ADMINISTRATIVE_AREA_LEVEL_2 = 1002;
+
   /**
    * Returns human readable address for this place.
    * @return

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
@@ -1,6 +1,7 @@
 package com.mapzen.places.api;
 
 import android.net.Uri;
+import android.os.Parcelable;
 
 import java.util.List;
 import java.util.Locale;
@@ -8,7 +9,7 @@ import java.util.Locale;
 /**
  * Represents a physical place selected from a {@link com.mapzen.android.graphics.MapzenMap}.
  */
-public interface Place {
+public interface Place extends Parcelable {
 
   /**
    * Returns human readable address for this place.

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
@@ -1,8 +1,6 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
-import com.mapzen.android.lost.internal.DialogDisplayer;
-import com.mapzen.android.lost.internal.SettingsDialogDisplayer;
 import com.mapzen.places.api.Place;
 
 /**
@@ -12,7 +10,6 @@ import com.mapzen.places.api.Place;
 class AutocompleteDetailFetchListener implements OnPlaceDetailsFetchedListener {
 
   final PlaceAutocompleteController controller;
-  final DialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   /**
    * Construct new {@link AutocompleteDetailFetchListener} and set its controller.
@@ -23,12 +20,12 @@ class AutocompleteDetailFetchListener implements OnPlaceDetailsFetchedListener {
   }
 
   @Override public void onFetchSuccess(Place place, String details) {
-    Status status = new Status(Status.SUCCESS, dialogDisplayer);
+    Status status = new Status(Status.SUCCESS);
     setResultAndFinish(place, details, status);
   }
 
   @Override public void onFetchFailure() {
-    Status status = new Status(Status.INTERNAL_ERROR, dialogDisplayer);
+    Status status = new Status(Status.INTERNAL_ERROR);
     setResultAndFinish(null, null, status);
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
@@ -1,6 +1,8 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.android.lost.internal.DialogDisplayer;
+import com.mapzen.android.lost.internal.SettingsDialogDisplayer;
 import com.mapzen.places.api.Place;
 
 /**
@@ -10,6 +12,7 @@ import com.mapzen.places.api.Place;
 class AutocompleteDetailFetchListener implements OnPlaceDetailsFetchedListener {
 
   final PlaceAutocompleteController controller;
+  final DialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   /**
    * Construct new {@link AutocompleteDetailFetchListener} and set its controller.
@@ -20,12 +23,12 @@ class AutocompleteDetailFetchListener implements OnPlaceDetailsFetchedListener {
   }
 
   @Override public void onFetchSuccess(Place place, String details) {
-    Status status = new Status(Status.SUCCESS);
+    Status status = new Status(Status.SUCCESS, dialogDisplayer);
     setResultAndFinish(place, details, status);
   }
 
   @Override public void onFetchFailure() {
-    Status status = new Status(Status.INTERNAL_ERROR);
+    Status status = new Status(Status.INTERNAL_ERROR, dialogDisplayer);
     setResultAndFinish(null, null, status);
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListener.java
@@ -1,0 +1,36 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.Place;
+
+/**
+ * Handles notifying the {@link PlaceAutocompleteController} after a place's details have either
+ * been successfully retrieved or failed to be retrieved.
+ */
+class AutocompleteDetailFetchListener implements OnPlaceDetailsFetchedListener {
+
+  final PlaceAutocompleteController controller;
+
+  /**
+   * Construct new {@link AutocompleteDetailFetchListener} and set its controller.
+   * @param controller
+   */
+  AutocompleteDetailFetchListener(PlaceAutocompleteController controller) {
+    this.controller = controller;
+  }
+
+  @Override public void onFetchSuccess(Place place, String details) {
+    Status status = new Status(Status.SUCCESS);
+    setResultAndFinish(place, details, status);
+  }
+
+  @Override public void onFetchFailure() {
+    Status status = new Status(Status.INTERNAL_ERROR);
+    setResultAndFinish(null, null, status);
+  }
+
+  private void setResultAndFinish(Place place, String details, Status status) {
+    controller.setResult(place, details, status);
+    controller.finish();
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
@@ -3,6 +3,8 @@ package com.mapzen.places.api.internal;
 import com.mapzen.android.lost.api.PendingResult;
 import com.mapzen.android.lost.api.ResultCallback;
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.android.lost.internal.DialogDisplayer;
+import com.mapzen.android.lost.internal.SettingsDialogDisplayer;
 import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Result;
@@ -32,6 +34,7 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
   private final String query;
   private final LatLngBounds bounds;
   private final AutocompleteFilter filter;
+  private final DialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   /**
    * Constructs a new object given a pelias instance, a query, a lat/lng bounds, and an autocomplete
@@ -71,7 +74,7 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
     LatLng center = bounds.getCenter();
     pelias.suggest(query, center.getLatitude(), center.getLongitude(), new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {
-        Status status = new Status(Status.SUCCESS);
+        Status status = new Status(Status.SUCCESS, dialogDisplayer);
 
         final ArrayList<AutocompletePrediction> predictions = new ArrayList<>();
         final List<Feature> features = response.body().getFeatures();
@@ -86,7 +89,7 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
       }
 
       @Override public void onFailure(Call<Result> call, Throwable t) {
-        Status status = new Status(Status.INTERNAL_ERROR);
+        Status status = new Status(Status.INTERNAL_ERROR, dialogDisplayer);
         AutocompletePredictionBuffer buffer = new AutocompletePredictionBuffer(status, null);
         callback.onResult(buffer);
       }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/AutocompletePendingResult.java
@@ -3,8 +3,6 @@ package com.mapzen.places.api.internal;
 import com.mapzen.android.lost.api.PendingResult;
 import com.mapzen.android.lost.api.ResultCallback;
 import com.mapzen.android.lost.api.Status;
-import com.mapzen.android.lost.internal.DialogDisplayer;
-import com.mapzen.android.lost.internal.SettingsDialogDisplayer;
 import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Result;
@@ -34,7 +32,6 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
   private final String query;
   private final LatLngBounds bounds;
   private final AutocompleteFilter filter;
-  private final DialogDisplayer dialogDisplayer = new SettingsDialogDisplayer();
 
   /**
    * Constructs a new object given a pelias instance, a query, a lat/lng bounds, and an autocomplete
@@ -74,7 +71,7 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
     LatLng center = bounds.getCenter();
     pelias.suggest(query, center.getLatitude(), center.getLongitude(), new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {
-        Status status = new Status(Status.SUCCESS, dialogDisplayer);
+        Status status = new Status(Status.SUCCESS);
 
         final ArrayList<AutocompletePrediction> predictions = new ArrayList<>();
         final List<Feature> features = response.body().getFeatures();
@@ -89,7 +86,7 @@ class AutocompletePendingResult extends PendingResult<AutocompletePredictionBuff
       }
 
       @Override public void onFailure(Call<Result> call, Throwable t) {
-        Status status = new Status(Status.INTERNAL_ERROR, dialogDisplayer);
+        Status status = new Status(Status.INTERNAL_ERROR);
         AutocompletePredictionBuffer buffer = new AutocompletePredictionBuffer(status, null);
         callback.onResult(buffer);
       }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/FilterMapper.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/FilterMapper.java
@@ -1,0 +1,14 @@
+package com.mapzen.places.api.internal;
+
+/**
+ * Maps internal filter values to external, {@link com.mapzen.places.api.AutocompleteFilter} values.
+ */
+public interface FilterMapper {
+  /**
+   * Given a type filter defined in {@link com.mapzen.places.api.AutocompleteFilter}, return the
+   * internal filter value so that autocomplete results can be properly limited.
+   * @param autocompleteFilter
+   * @return
+   */
+  String getInternalFilter(int autocompleteFilter);
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/OnPlaceDetailsFetchedListener.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/OnPlaceDetailsFetchedListener.java
@@ -1,5 +1,7 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.places.api.Place;
+
 /**
  * Listener that is invoked by {@link PlaceDetailFetcher} when details for a place are retrieved.
  */
@@ -8,5 +10,10 @@ interface OnPlaceDetailsFetchedListener {
    * Called when details for a place have been fetched.
    * @param details
    */
-  void onPlaceDetailsFetched(String details);
+  void onFetchSuccess(Place place, String details);
+
+  /**
+   * Called when details for a place fail to be fetched.
+   */
+  void onFetchFailure();
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFilterMapper.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFilterMapper.java
@@ -1,0 +1,67 @@
+package com.mapzen.places.api.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ADDRESS;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_CITIES;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ESTABLISHMENT;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_GEOCODE;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_NONE;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_REGIONS;
+
+/**
+ * Maps internal filter values to {@link com.mapzen.places.api.AutocompleteFilter} values for the
+ * {@link PlaceAutocompletePresenter}.
+ */
+public class PeliasFilterMapper implements FilterMapper {
+
+  private static final String PELIAS_FILTER_ADDRESS = "address";
+  private static final String PELIAS_FILTER_LOCALITY = "locality";
+  private static final String PELIAS_FILTER_VENUE = "venue";
+  private static final String PELIAS_FILTER_COARSE = "coarse";
+  private static final String PELIAS_FILTER_NONE = "";
+  private static final String PELIAS_FILTER_COUNTRY = "country";
+  private static final String PELIAS_FILTER_MACRO_COUNTY = "macrocounty";
+  private static final String PELIAS_FILTER_COUNTY = "county";
+  private static final String PELIAS_FILTER_LOCAL_ADMIN = "localadmin";
+  private static final String PELIAS_FILTER_BOROUGH = "borough";
+  private static final String PELIAS_FILTER_NEIGHBOURHOOD = "neighbourhood";
+
+  private static final Map<Integer, String> MAPZEN_PLACES_TO_PELIAS_FILTERS;
+  static {
+    MAPZEN_PLACES_TO_PELIAS_FILTERS = new HashMap();
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ADDRESS, PELIAS_FILTER_ADDRESS);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_CITIES, PELIAS_FILTER_LOCALITY);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ESTABLISHMENT, PELIAS_FILTER_VENUE);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_GEOCODE, PELIAS_FILTER_COARSE);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_NONE, PELIAS_FILTER_NONE);
+    List<String> regionFilters = new ArrayList<String>() { {
+      add(PELIAS_FILTER_COUNTRY);
+      add(PELIAS_FILTER_MACRO_COUNTY);
+      add(PELIAS_FILTER_LOCALITY);
+      add(PELIAS_FILTER_COUNTY);
+      add(PELIAS_FILTER_LOCAL_ADMIN);
+      add(PELIAS_FILTER_BOROUGH);
+      add(PELIAS_FILTER_NEIGHBOURHOOD);
+    } };
+    String peliasRegionFilters = buildCommaSeparated(regionFilters);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_REGIONS, peliasRegionFilters);
+  }
+
+  @Override public String getInternalFilter(int autocompleteFilter) {
+    return MAPZEN_PLACES_TO_PELIAS_FILTERS.get(autocompleteFilter);
+  }
+
+  private static String buildCommaSeparated(List<String> strings) {
+    StringBuilder builder = new StringBuilder(strings.size() * 2 - 1);
+    for (int i = 0; i < strings.size() - 2; i++) {
+      builder.append(strings.get(i));
+      builder.append(",");
+    }
+    builder.append(strings.get(strings.size() - 1));
+    return builder.toString();
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
@@ -32,6 +32,7 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
    */
   public PeliasPlaceDetailFetcher() {
     pelias = new Pelias();
+    pelias.setDebug(true);
   }
 
   @Override public void fetchDetails(LngLat coordinates, final Map<String, String> properties,
@@ -58,6 +59,11 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
   @Override public void fetchDetails(String gid, final OnPlaceDetailsFetchedListener listener) {
     pelias.place(gid, new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {
+        if (response.body() == null || response.body().getFeatures() == null ||
+            response.body().getFeatures().isEmpty()) {
+          listener.onFetchFailure();
+          return;
+        }
         Feature feature = response.body().getFeatures().get(0);
         String title = feature.properties.name;
         Place place = getFetchedPlace(feature);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
@@ -26,9 +26,6 @@ import retrofit2.Response;
 class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
 
   private Pelias pelias;
-  private Feature feature;
-  private LngLat coordinates;
-  private Map<String, String> properties;
 
   /**
    * Constructs a new object.
@@ -39,34 +36,48 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
 
   @Override public void fetchDetails(LngLat coordinates, final Map<String, String> properties,
       final OnPlaceDetailsFetchedListener listener) {
-    this.coordinates = coordinates;
-    this.properties = properties;
     pelias.reverse(coordinates.latitude, coordinates.longitude, new Callback<Result>() {
           @Override public void onResponse(Call<Result> call, Response<Result> response) {
             String title = properties.get(PROPERTY_NAME);
             for (Feature feature : response.body().getFeatures()) {
               if (feature.properties.name.equals(title)) {
-                PeliasPlaceDetailFetcher.this.feature = feature;
-                String label = feature.properties.label;
-                label = label.replace(title + ",", "").trim();
-                listener.onPlaceDetailsFetched(title + "\n" + label);
+                Place place = getFetchedPlace(feature);
+                String details = getDetails(feature, title);
+                listener.onFetchSuccess(place, details);
               }
             }
           }
 
           @Override public void onFailure(Call<Result> call, Throwable t) {
-
+            listener.onFetchFailure();
           }
         }
     );
   }
 
+  @Override public void fetchDetails(String gid, final OnPlaceDetailsFetchedListener listener) {
+    pelias.place(gid, new Callback<Result>() {
+      @Override public void onResponse(Call<Result> call, Response<Result> response) {
+        Feature feature = response.body().getFeatures().get(0);
+        String title = feature.properties.name;
+        Place place = getFetchedPlace(feature);
+        String details = getDetails(feature, title);
+        listener.onFetchSuccess(place, details);
+      }
+
+      @Override public void onFailure(Call<Result> call, Throwable t) {
+        listener.onFetchFailure();
+      }
+    });
+  }
+
   //TODO: fill in missing values
-  @Override public Place getFetchedPlace() {
+  private Place getFetchedPlace(Feature feature) {
     final CharSequence address = feature.properties.label;
     final CharSequence attributions = "";
     final String id = feature.properties.id;
-    final LatLng latLng = new LatLng(coordinates.latitude, coordinates.longitude);
+    final LatLng latLng = new LatLng(feature.geometry.coordinates.get(1),
+        feature.geometry.coordinates.get(0));
     final Locale locale = Locale.US;
     final CharSequence name = feature.properties.name;
     final CharSequence phoneNumber = "";
@@ -89,5 +100,11 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
         .setViewPort(viewport)
         .setWebsiteUri(websiteUri)
         .build();
+  }
+
+  private String getDetails(Feature feature, String title) {
+    String label = feature.properties.label;
+    label = label.replace(title + ",", "").trim();
+    return title + "\n" + label;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -51,8 +51,9 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher();
     OnPlaceDetailsFetchedListener detailFetchListener = new AutocompleteDetailFetchListener(this);
     FilterMapper filterMapper = new PeliasFilterMapper();
-    presenter = new PlaceAutocompletePresenter(this, detailFetcher, detailFetchListener,
-        filterMapper);
+    presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
+    presenter.setBounds((LatLngBounds) safeGetExtra(EXTRA_BOUNDS));
+    presenter.setFilter((AutocompleteFilter) safeGetExtra(EXTRA_FILTER));
 
     AutoCompleteListView listView = (AutoCompleteListView) findViewById(R.id.list_view);
     AutoCompleteAdapter autocompleteAdapter =
@@ -119,14 +120,6 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     if (getIntent().getExtras() != null) {
       peliasSearchView.setQuery(getIntent().getExtras().getCharSequence(EXTRA_TEXT), false);
     }
-  }
-
-  @Override public LatLngBounds getBounds() {
-    return (LatLngBounds) safeGetExtra(EXTRA_BOUNDS);
-  }
-
-  @Override public AutocompleteFilter getAutocompleteFilter() {
-    return (AutocompleteFilter) safeGetExtra(EXTRA_FILTER);
   }
 
   @Override public void setResult(Place place, String details, Status status) {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -24,6 +24,7 @@ import android.widget.ImageView;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_DETAILS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_STATUS;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -107,8 +108,7 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     final Intent intent = new Intent();
     intent.putExtra(EXTRA_PLACE, place);
     intent.putExtra(EXTRA_DETAILS, details);
-    //TODO: update LOST, make Status Parcelable
-    //intent.putExtra(EXTRA_STATUS, (Parcelable) status);
+    intent.putExtra(EXTRA_STATUS, status);
     setResult(RESULT_OK, intent);
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -29,6 +29,7 @@ import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_DETAILS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_FILTER;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_STATUS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_TEXT;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -115,6 +116,9 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
         return "wof,osm,oa,gn";
       }
     });
+    if (getIntent().getExtras() != null) {
+      peliasSearchView.setQuery(getIntent().getExtras().getCharSequence(EXTRA_TEXT), false);
+    }
   }
 
   @Override public LatLngBounds getBounds() {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -19,6 +19,8 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
@@ -58,6 +60,13 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
 
       @Override public void onFailure(Call<Result> call, Throwable t) {
         Log.e(TAG, "Error fetching results", t);
+      }
+    });
+    ImageView searchMagBtn = (ImageView) peliasSearchView.findViewById(R.id.search_mag_icon);
+    searchMagBtn.setImageResource(R.drawable.abc_ic_ab_back_material);
+    searchMagBtn.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View view) {
+        finish();
       }
     });
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -14,7 +14,6 @@ import com.mapzen.places.api.R;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -23,6 +22,7 @@ import android.view.View;
 import android.widget.ImageView;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_DETAILS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -42,7 +42,9 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     setContentView(R.layout.place_autcomplete_activity);
 
     // TODO inject
-    presenter = new PlaceAutocompletePresenter(this);
+    PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher();
+    OnPlaceDetailsFetchedListener detailFetchListener = new AutocompleteDetailFetchListener(this);
+    presenter = new PlaceAutocompletePresenter(this, detailFetcher, detailFetchListener);
 
     AutoCompleteListView listView = (AutoCompleteListView) findViewById(R.id.list_view);
     AutoCompleteAdapter autocompleteAdapter =
@@ -54,8 +56,6 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     peliasSearchView.setCallback(new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {
         presenter.onResponse(response);
-
-        finish();
       }
 
       @Override public void onFailure(Call<Result> call, Throwable t) {
@@ -103,9 +103,10 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     return getIntent().getExtras().getParcelable(EXTRA_BOUNDS);
   }
 
-  @Override public void setResult(Place place, Status status) {
+  @Override public void setResult(Place place, String details, Status status) {
     final Intent intent = new Intent();
-    intent.putExtra(EXTRA_PLACE, (Parcelable) place);
+    intent.putExtra(EXTRA_PLACE, place);
+    intent.putExtra(EXTRA_DETAILS, details);
     //TODO: update LOST, make Status Parcelable
     //intent.putExtra(EXTRA_STATUS, (Parcelable) status);
     setResult(RESULT_OK, intent);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
@@ -1,8 +1,6 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
-import com.mapzen.places.api.AutocompleteFilter;
-import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
 /**
@@ -21,17 +19,4 @@ interface PlaceAutocompleteController {
    * Finish place autocomplete wrapper activity and return to calling application.
    */
   void finish();
-
-  /**
-   * Return the bounds for this controller so that it can be converted to a
-   * {@link com.mapzen.pelias.BoundingBox} by the presenter.
-   * @return
-   */
-  LatLngBounds getBounds();
-
-  /**
-   * Return the filter that should be used to limit autocomplete results.
-   * @return
-   */
-  AutocompleteFilter getAutocompleteFilter();
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
@@ -1,6 +1,7 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 
@@ -27,4 +28,10 @@ interface PlaceAutocompleteController {
    * @return
    */
   LatLngBounds getBounds();
+
+  /**
+   * Return the filter that should be used to limit autocomplete results.
+   * @return
+   */
+  AutocompleteFilter getAutocompleteFilter();
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteController.java
@@ -14,7 +14,7 @@ interface PlaceAutocompleteController {
    * @param result Selected{@code Place} object.
    * @param status Selection status.
    */
-  void setResult(Place result, Status status);
+  void setResult(Place result, String details, Status status);
 
   /**
    * Finish place autocomplete wrapper activity and return to calling application.

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -3,6 +3,7 @@ package com.mapzen.places.api.internal;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.LatLngBounds;
 
 import retrofit2.Response;
@@ -14,16 +15,19 @@ class PlaceAutocompletePresenter {
   private final PlaceAutocompleteController controller;
   private final PlaceDetailFetcher detailFetcher;
   private final OnPlaceDetailsFetchedListener detailFetchListener;
+  private final FilterMapper filterMapper;
 
   /**
    * Creates a new instance with reference to controller.
    * @param controller place autocomplete wrapper Activity.
    */
   PlaceAutocompletePresenter(PlaceAutocompleteController controller,
-      PlaceDetailFetcher detailFetcher, OnPlaceDetailsFetchedListener detailFetchListener) {
+      PlaceDetailFetcher detailFetcher, OnPlaceDetailsFetchedListener detailFetchListener,
+      FilterMapper filterMapper) {
     this.controller = controller;
     this.detailFetcher = detailFetcher;
     this.detailFetchListener = detailFetchListener;
+    this.filterMapper = filterMapper;
   }
 
   /**
@@ -85,5 +89,30 @@ class PlaceAutocompletePresenter {
     double diff = (boundingBox.getMaxLon() - boundingBox.getMinLon()) / 2;
     double midLon = boundingBox.getMinLon() + diff;
     return midLon;
+  }
+
+  /**
+   * Return the ISO 3166-1 Alpha-2 country code that should be used to limit autocomplete results.
+   * @return
+   */
+  String getCountryFilter() {
+    AutocompleteFilter filter = controller.getAutocompleteFilter();
+    if (filter == null) {
+      return null;
+    }
+    return filter.getCountry();
+  }
+
+  /**
+   * Return the layers that should be used to limit autocomplete results.
+   * @return
+   */
+  String getLayersFilter() {
+    AutocompleteFilter filter = controller.getAutocompleteFilter();
+    if (filter == null) {
+      return null;
+    }
+    int typeFilter = filter.getTypeFilter();
+    return filterMapper.getInternalFilter(typeFilter);
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -1,11 +1,9 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
 import com.mapzen.places.api.LatLngBounds;
-import com.mapzen.places.api.Place;
 
 import retrofit2.Response;
 
@@ -14,13 +12,18 @@ import retrofit2.Response;
  */
 class PlaceAutocompletePresenter {
   private final PlaceAutocompleteController controller;
+  private final PlaceDetailFetcher detailFetcher;
+  private final OnPlaceDetailsFetchedListener detailFetchListener;
 
   /**
    * Creates a new instance with reference to controller.
    * @param controller place autocomplete wrapper Activity.
    */
-  PlaceAutocompletePresenter(PlaceAutocompleteController controller) {
+  PlaceAutocompletePresenter(PlaceAutocompleteController controller,
+      PlaceDetailFetcher detailFetcher, OnPlaceDetailsFetchedListener detailFetchListener) {
     this.controller = controller;
+    this.detailFetcher = detailFetcher;
+    this.detailFetchListener = detailFetchListener;
   }
 
   /**
@@ -28,17 +31,9 @@ class PlaceAutocompletePresenter {
    * @param response parsed result returned by the service.
    */
   void onResponse(Response<Result> response) {
-    // TODO: Fetch place details.
     Properties properties = response.body().getFeatures().get(0).properties;
-    String name = properties.name;
-    String address = properties.label;
-    Place place = new PlaceImpl.Builder()
-        .setName(name)
-        .setAddress(address)
-        .build();
-    Status status = new Status(Status.SUCCESS);
-    controller.setResult(place, status);
-    controller.finish();
+    String gid = properties.gid;
+    detailFetcher.fetchDetails(gid, detailFetchListener);
   }
 
   /**

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -12,22 +12,28 @@ import retrofit2.Response;
  * Place autocomplete presenter to handle non-Android logic.
  */
 class PlaceAutocompletePresenter {
-  private final PlaceAutocompleteController controller;
   private final PlaceDetailFetcher detailFetcher;
   private final OnPlaceDetailsFetchedListener detailFetchListener;
   private final FilterMapper filterMapper;
+  private LatLngBounds bounds;
+  private AutocompleteFilter filter;
 
   /**
-   * Creates a new instance with reference to controller.
-   * @param controller place autocomplete wrapper Activity.
+   * Creates a new instance.
    */
-  PlaceAutocompletePresenter(PlaceAutocompleteController controller,
-      PlaceDetailFetcher detailFetcher, OnPlaceDetailsFetchedListener detailFetchListener,
-      FilterMapper filterMapper) {
-    this.controller = controller;
+  PlaceAutocompletePresenter(PlaceDetailFetcher detailFetcher,
+      OnPlaceDetailsFetchedListener detailFetchListener, FilterMapper filterMapper) {
     this.detailFetcher = detailFetcher;
     this.detailFetchListener = detailFetchListener;
     this.filterMapper = filterMapper;
+  }
+
+  void setBounds(LatLngBounds bounds) {
+    this.bounds = bounds;
+  }
+
+  void setFilter(AutocompleteFilter filter) {
+    this.filter = filter;
   }
 
   /**
@@ -47,7 +53,6 @@ class PlaceAutocompletePresenter {
    * @return
    */
   BoundingBox getBoundingBox() {
-    LatLngBounds bounds = controller.getBounds();
     if (bounds == null) {
       //TODO: retrieve device's last known location
       return new BoundingBox(40.7011375427, -74.0193099976, 40.8774528503, -73.9104537964);
@@ -96,7 +101,6 @@ class PlaceAutocompletePresenter {
    * @return
    */
   String getCountryFilter() {
-    AutocompleteFilter filter = controller.getAutocompleteFilter();
     if (filter == null) {
       return null;
     }
@@ -108,7 +112,6 @@ class PlaceAutocompletePresenter {
    * @return
    */
   String getLayersFilter() {
-    AutocompleteFilter filter = controller.getAutocompleteFilter();
     if (filter == null) {
       return null;
     }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -46,7 +46,7 @@ class PlaceAutocompletePresenter {
     LatLngBounds bounds = controller.getBounds();
     if (bounds == null) {
       //TODO: retrieve device's last known location
-      return null;
+      return new BoundingBox(40.7011375427, -74.0193099976, 40.8774528503, -73.9104537964);
     }
     double minLat = bounds.getSouthwest().getLatitude();
     double minLon = bounds.getSouthwest().getLongitude();
@@ -66,7 +66,8 @@ class PlaceAutocompletePresenter {
     if (boundingBox == null) {
       return 40.7443;
     }
-    double midLat = (boundingBox.getMaxLat() - boundingBox.getMinLat()) / 2;
+    double diff = (boundingBox.getMaxLat() - boundingBox.getMinLat()) / 2;
+    double midLat = boundingBox.getMinLat() + diff;
     return midLat;
   }
 
@@ -81,7 +82,8 @@ class PlaceAutocompletePresenter {
     if (boundingBox == null) {
       return -73.9903;
     }
-    double midLon = (boundingBox.getMaxLon() - boundingBox.getMinLon()) / 2;
+    double diff = (boundingBox.getMaxLon() - boundingBox.getMinLon()) / 2;
+    double midLon = boundingBox.getMinLon() + diff;
     return midLon;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteView.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteView.java
@@ -1,5 +1,7 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.places.api.AutocompleteFilter;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.R;
 
 import android.app.Activity;
@@ -12,12 +14,19 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_FILTER;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_TEXT;
+
 /**
  * Compound view which displays search icon, autocomplete text view and clear button.
  */
 public class PlaceAutocompleteView extends LinearLayout {
 
-  TextView input;
+  private TextView input;
+  private AutocompleteFilter filter;
+  private LatLngBounds bounds;
+  private CharSequence text;
 
   /**
    * Public constructor.
@@ -66,8 +75,7 @@ public class PlaceAutocompleteView extends LinearLayout {
     input = (TextView) findViewById(R.id.place_autocomplete_search_input);
     input.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
-        activity.startActivityForResult(new Intent(activity.getBaseContext(),
-            PlaceAutocompleteActivity.class), 0);
+        activity.startActivityForResult(constructIntent(activity), 0);
       }
     });
   }
@@ -82,17 +90,49 @@ public class PlaceAutocompleteView extends LinearLayout {
     input = (TextView) findViewById(R.id.place_autocomplete_search_input);
     input.setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
-        fragment.startActivityForResult(new Intent(fragment.getActivity().getBaseContext(),
-            PlaceAutocompleteActivity.class), 0);
+        fragment.startActivityForResult(constructIntent(fragment.getActivity()), 0);
       }
     });
   }
 
+  private Intent constructIntent(Activity activity) {
+    Intent intent = new Intent(activity.getBaseContext(), PlaceAutocompleteActivity.class);
+    intent.putExtra(EXTRA_FILTER, filter);
+    intent.putExtra(EXTRA_BOUNDS, bounds);
+    intent.putExtra(EXTRA_TEXT, text);
+    return intent;
+  }
+
   /**
-   * Sets the view input text.
+   * Sets the view input text and the launched {@link PlaceAutocompleteActivity}'s input text.
    * @param s
    */
-  public void setText(String s) {
+  public void setText(CharSequence s) {
+    this.text = s;
     input.setText(s);
+  }
+
+  /**
+   * Sets the view input hint text.
+   * @param hint
+   */
+  public void setHint(CharSequence hint) {
+    input.setHint(hint);
+  }
+
+  /**
+   * Sets the launched {@link PlaceAutocompleteActivity}'s autocomplete filter.
+   * @param filter
+   */
+  public void setFilter(AutocompleteFilter filter) {
+    this.filter = filter;
+  }
+
+  /**
+   * Sets the launched {@link PlaceAutocompleteActivity}'s autocomplete bounds bias.
+   * @param bounds
+   */
+  public void setBoundsBias(LatLngBounds bounds) {
+    this.bounds = bounds;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDetailFetcher.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDetailFetcher.java
@@ -1,6 +1,5 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.places.api.Place;
 import com.mapzen.tangram.LngLat;
 
 import java.util.Map;
@@ -11,8 +10,8 @@ import java.util.Map;
 interface PlaceDetailFetcher {
 
   /**
-   * Called when details for a place should be retrieved. Currently, Pelias is used as the
-   * underlying data source but this will soon be migrated to WOF.
+   * Called when details for a place selected from the map should be retrieved. Currently, Pelias is
+   * used as the underlying data source but this will soon be migrated to WOF.
    * @param coordinates
    * @param properties
    * @param listener
@@ -21,8 +20,10 @@ interface PlaceDetailFetcher {
       OnPlaceDetailsFetchedListener listener);
 
   /**
-   * Return a {@link Place} for the fetched details.
-   * @return
+   * Called when details for a place selected from autocomplete should be retrieved. Currently,
+   * Pelias is used as the underlying data source but this will soon be migrated to WOF.
+   * @param gid
+   * @param listener
    */
-  Place getFetchedPlace();
+  void fetchDetails(String gid, OnPlaceDetailsFetchedListener listener);
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
@@ -10,4 +10,5 @@ public class PlaceIntentConsts {
   public static final String EXTRA_STATUS = "extra_status";
   public static final String EXTRA_FILTER = "extra_filter";
   public static final String EXTRA_DETAILS = "extra_details";
+  public static final String EXTRA_TEXT = "extra_text";
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceIntentConsts.java
@@ -9,4 +9,5 @@ public class PlaceIntentConsts {
   public static final String EXTRA_BOUNDS = "extra_bounds";
   public static final String EXTRA_STATUS = "extra_status";
   public static final String EXTRA_FILTER = "extra_filter";
+  public static final String EXTRA_DETAILS = "extra_details";
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -21,6 +21,7 @@ import android.graphics.PointF;
 import android.os.Bundle;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
+import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_DETAILS;
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_PLACE;
 
 /**
@@ -101,7 +102,8 @@ public class PlacePickerActivity extends Activity implements
   @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (resultCode == RESULT_OK) {
       Place place = PlaceAutocomplete.getPlace(this, data);
-      presenter.onAutocompletePlacePicked(place);
+      String details = data.getExtras().getString(EXTRA_DETAILS);
+      presenter.onAutocompletePlacePicked(place, details);
     }
   }
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
@@ -32,5 +32,5 @@ interface PlacePickerPresenter {
    * Called when a {@link Place} is selected from the PlaceAutocomplete UI.
    * @param place
    */
-  void onAutocompletePlacePicked(Place place);
+  void onAutocompletePlacePicked(Place place, String details);
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -15,6 +15,7 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
 
   PlacePickerViewController controller;
   PlaceDetailFetcher detailFetcher;
+  Place place;
 
   /**
    * Construct a new object.
@@ -33,8 +34,13 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
 
     detailFetcher.fetchDetails(coordinates, properties,
         new OnPlaceDetailsFetchedListener() {
-          @Override public void onPlaceDetailsFetched(String details) {
+          @Override public void onFetchSuccess(Place place, String details) {
+            PlacePickerPresenterImpl.this.place = place;
             controller.updateDialog(id, details);
+          }
+
+          @Override public void onFetchFailure() {
+
           }
         }
     );
@@ -43,11 +49,13 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
   }
 
   @Override public void onPlaceConfirmed() {
-    Place place = detailFetcher.getFetchedPlace();
     controller.finishWithPlace(place);
   }
 
-  @Override public void onAutocompletePlacePicked(Place place) {
-    controller.finishWithPlace(place);
+  @Override public void onAutocompletePlacePicked(Place place, String details) {
+    this.place = place;
+    controller.showDialog(place.getId(), details);
+    //TODO:dialog change location should bring back autocomplete ui
+    //TODO:hide map ui and just have dialog visible
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -1,5 +1,7 @@
 package com.mapzen.places.api.ui;
 
+import com.mapzen.places.api.AutocompleteFilter;
+import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
 import com.mapzen.places.api.R;
 import com.mapzen.places.api.internal.PlaceAutocompleteView;
@@ -48,4 +50,35 @@ public class PlaceAutocompleteFragment extends Fragment {
     this.listener = listener;
   }
 
+  /**
+   * Set the {@link PlaceAutocompleteView}'s bounds bias.
+   * @param boundsBias
+   */
+  public void setBoundsBias(LatLngBounds boundsBias) {
+    autocompleteView.setBoundsBias(boundsBias);
+  }
+
+  /**
+   * Set the {@link PlaceAutocompleteView}'s filter.
+   * @param filter
+   */
+  public void setFilter(AutocompleteFilter filter) {
+    autocompleteView.setFilter(filter);
+  }
+
+  /**
+   * Set the {@link PlaceAutocompleteView}'s hint.
+   * @param hint
+   */
+  public void setHint(CharSequence hint) {
+    autocompleteView.setHint(hint);
+  }
+
+  /**
+   * Set the {@link PlaceAutocompleteView}'s text.
+   * @param text
+   */
+  public void setText(CharSequence text) {
+    autocompleteView.setText(text);
+  }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/AutocompletePredictionBufferTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/AutocompletePredictionBufferTest.java
@@ -17,7 +17,7 @@ public class AutocompletePredictionBufferTest {
   List<AutocompletePrediction> predictions;
 
   @Before public void setup() {
-    status = new Status(Status.SUCCESS);
+    status = new Status(Status.SUCCESS, null);
     predictions = new ArrayList<>();
     predictions.add(new AutocompletePrediction("test", "test"));
     buffer = new AutocompletePredictionBuffer(status, predictions);

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListenerTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/AutocompleteDetailFetchListenerTest.java
@@ -1,0 +1,59 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.android.lost.api.Status;
+import com.mapzen.places.api.Place;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class AutocompleteDetailFetchListenerTest {
+
+  PlaceAutocompleteController controller = mock(PlaceAutocompleteController.class);
+  OnPlaceDetailsFetchedListener listener = new AutocompleteDetailFetchListener(controller);
+
+  @Test public void onFetchSuccess_shouldSetResult() throws Exception {
+    Place place = mock(Place.class);
+    String details = "details";
+    listener.onFetchSuccess(place, details);
+    verify(controller).setResult(eq(place), eq(details), any(Status.class));
+  }
+
+  @Test public void onFetchSuccess_shouldHaveSuccessStatus() throws Exception {
+    Place place = mock(Place.class);
+    String details = "details";
+    ArgumentCaptor<Status> status = ArgumentCaptor.forClass(Status.class);
+    listener.onFetchSuccess(place, details);
+    verify(controller).setResult(eq(place), eq(details), status.capture());
+    assertEquals(Status.SUCCESS, status.getValue().getStatusCode());
+  }
+
+  @Test public void onFetchSuccess_shouldFinish() throws Exception {
+    Place place = mock(Place.class);
+    listener.onFetchSuccess(place, "details");
+    verify(controller).finish();
+  }
+
+  @Test public void onFetchFailure_shouldSetResult() throws Exception {
+    listener.onFetchFailure();
+    verify(controller).setResult(isNull(Place.class), isNull(String.class), any(Status.class));
+  }
+
+  @Test public void onFetchFailure_shouldHaveInternalErrorStatus() throws Exception {
+    ArgumentCaptor<Status> status = ArgumentCaptor.forClass(Status.class);
+    listener.onFetchFailure();
+    verify(controller).setResult(isNull(Place.class), isNull(String.class), status.capture());
+    assertEquals(Status.INTERNAL_ERROR, status.getValue().getStatusCode());
+  }
+
+  @Test public void onFetchFailure_shouldFinish() throws Exception {
+    listener.onFetchFailure();
+    verify(controller).finish();
+  }
+}

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -5,6 +5,7 @@ import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
@@ -25,7 +26,7 @@ public class PlaceAutocompletePresenterTest {
   private OnPlaceDetailsFetchedListener detailFetchListener = mock(
       OnPlaceDetailsFetchedListener.class);
   private PlaceAutocompletePresenter presenter = new PlaceAutocompletePresenter(controller,
-      detailFetcher, detailFetchListener);
+      detailFetcher, detailFetchListener, null);
 
   @Test
   public void shouldNotBeNull() throws Exception {
@@ -88,6 +89,10 @@ public class PlaceAutocompletePresenterTest {
 
     @Override public LatLngBounds getBounds() {
       return bounds;
+    }
+
+    @Override public AutocompleteFilter getAutocompleteFilter() {
+      return null;
     }
   }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -1,14 +1,11 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
-import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
-import com.mapzen.places.api.Place;
 
 import org.junit.Test;
 
@@ -21,12 +18,11 @@ import retrofit2.Response;
 
 public class PlaceAutocompletePresenterTest {
 
-  private TestPlaceAutocompleteController controller = new TestPlaceAutocompleteController();
   private PlaceDetailFetcher detailFetcher = mock(PlaceDetailFetcher.class);
   private OnPlaceDetailsFetchedListener detailFetchListener = mock(
       OnPlaceDetailsFetchedListener.class);
-  private PlaceAutocompletePresenter presenter = new PlaceAutocompletePresenter(controller,
-      detailFetcher, detailFetchListener, null);
+  private PlaceAutocompletePresenter presenter = new PlaceAutocompletePresenter(detailFetcher,
+      detailFetchListener, null);
 
   @Test
   public void shouldNotBeNull() throws Exception {
@@ -42,6 +38,9 @@ public class PlaceAutocompletePresenterTest {
 
   @Test
   public void getBoundingBox_shouldReturnCorrectBox() throws Exception {
+    LatLng sw = new LatLng(0.0, 0.0);
+    LatLng ne = new LatLng(50.0, 100.0);
+    presenter.setBounds(new LatLngBounds(sw, ne));
     BoundingBox boundingBox = presenter.getBoundingBox();
     assertThat(boundingBox.getMinLat()).isEqualTo(0.0);
     assertThat(boundingBox.getMinLon()).isEqualTo(0.0);
@@ -51,12 +50,18 @@ public class PlaceAutocompletePresenterTest {
 
   @Test
   public void getLat_shouldReturnCorrectLat() throws Exception {
+    LatLng sw = new LatLng(0.0, 0.0);
+    LatLng ne = new LatLng(50.0, 100.0);
+    presenter.setBounds(new LatLngBounds(sw, ne));
     double lat = presenter.getLat();
     assertThat(lat).isEqualTo(25.0);
   }
 
   @Test
   public void getLon_shouldReturnCorrectLon() throws Exception {
+    LatLng sw = new LatLng(0.0, 0.0);
+    LatLng ne = new LatLng(50.0, 100.0);
+    presenter.setBounds(new LatLngBounds(sw, ne));
     double lat = presenter.getLon();
     assertThat(lat).isEqualTo(50.0);
   }
@@ -72,27 +77,4 @@ public class PlaceAutocompletePresenterTest {
     return Response.success(result);
   }
 
-  private static class TestPlaceAutocompleteController implements PlaceAutocompleteController {
-    private Place result = null;
-    private boolean isFinishing = false;
-    LatLng sw = new LatLng(0.0, 0.0);
-    LatLng ne = new LatLng(50.0, 100.0);
-    LatLngBounds bounds = new LatLngBounds(sw, ne);
-
-    @Override public void setResult(Place result, String details, Status status) {
-      this.result = result;
-    }
-
-    @Override public void finish() {
-      isFinishing = true;
-    }
-
-    @Override public LatLngBounds getBounds() {
-      return bounds;
-    }
-
-    @Override public AutocompleteFilter getAutocompleteFilter() {
-      return null;
-    }
-  }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -14,12 +14,18 @@ import org.junit.Test;
 import android.support.annotation.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import retrofit2.Response;
 
 public class PlaceAutocompletePresenterTest {
 
   private TestPlaceAutocompleteController controller = new TestPlaceAutocompleteController();
-  private PlaceAutocompletePresenter presenter = new PlaceAutocompletePresenter(controller);
+  private PlaceDetailFetcher detailFetcher = mock(PlaceDetailFetcher.class);
+  private OnPlaceDetailsFetchedListener detailFetchListener = mock(
+      OnPlaceDetailsFetchedListener.class);
+  private PlaceAutocompletePresenter presenter = new PlaceAutocompletePresenter(controller,
+      detailFetcher, detailFetchListener);
 
   @Test
   public void shouldNotBeNull() throws Exception {
@@ -27,21 +33,14 @@ public class PlaceAutocompletePresenterTest {
   }
 
   @Test
-  public void onResponse_shouldSetResult() throws Exception {
+  public void onResponse_shouldFetchPlaceDetails() throws Exception {
     Response<Result> response = getTestResponse();
     presenter.onResponse(response);
-    assertThat(controller.result.getName()).isEqualTo("Test Name");
+    verify(detailFetcher).fetchDetails("123abc", detailFetchListener);
   }
 
   @Test
-  public void onResponse_shouldFinish() throws Exception {
-    Response<Result> response = getTestResponse();
-    presenter.onResponse(response);
-    assertThat(controller.isFinishing).isTrue();
-  }
-
-  @Test
-  public void getBoundingBox_shouldReturnCorrectBox() {
+  public void getBoundingBox_shouldReturnCorrectBox() throws Exception {
     BoundingBox boundingBox = presenter.getBoundingBox();
     assertThat(boundingBox.getMinLat()).isEqualTo(0.0);
     assertThat(boundingBox.getMinLon()).isEqualTo(0.0);
@@ -50,13 +49,13 @@ public class PlaceAutocompletePresenterTest {
   }
 
   @Test
-  public void getLat_shouldReturnCorrectLat() {
+  public void getLat_shouldReturnCorrectLat() throws Exception {
     double lat = presenter.getLat();
     assertThat(lat).isEqualTo(25.0);
   }
 
   @Test
-  public void getLon_shouldReturnCorrectLon() {
+  public void getLon_shouldReturnCorrectLon() throws Exception {
     double lat = presenter.getLon();
     assertThat(lat).isEqualTo(50.0);
   }
@@ -65,6 +64,7 @@ public class PlaceAutocompletePresenterTest {
     Result result = new Result();
     Feature feature = new Feature();
     Properties properties = new Properties();
+    properties.gid = "123abc";
     properties.name = "Test Name";
     feature.properties = properties;
     result.getFeatures().add(feature);
@@ -78,7 +78,7 @@ public class PlaceAutocompletePresenterTest {
     LatLng ne = new LatLng(50.0, 100.0);
     LatLngBounds bounds = new LatLngBounds(sw, ne);
 
-    @Override public void setResult(Place result, Status status) {
+    @Override public void setResult(Place result, String details, Status status) {
       this.result = result;
     }
 

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
@@ -34,9 +34,9 @@ public class PlacePickerPresenterTest {
     assertThat(controller.finished).isTrue();
   }
 
-  @Test public void onAutocompletePlacePicked_shouldFinishActivity() {
+  @Test public void onAutocompletePlacePicked_shouldShowDialog() {
     Place place = new PlaceImpl.Builder().build();
-    presenter.onAutocompletePlacePicked(place);
-    assertThat(controller.finished).isTrue();
+    presenter.onAutocompletePlacePicked(place, "details");
+    assertThat(controller.dialogShown).isTrue();
   }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlaceDetailFetcher.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlaceDetailFetcher.java
@@ -1,6 +1,5 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.places.api.Place;
 import com.mapzen.tangram.LngLat;
 
 import java.util.Map;
@@ -13,7 +12,7 @@ public class TestPlaceDetailFetcher implements PlaceDetailFetcher {
 
   }
 
-  @Override public Place getFetchedPlace() {
-    return new PlaceImpl.Builder().build();
+  @Override public void fetchDetails(String gid, OnPlaceDetailsFetchedListener listener) {
+
   }
 }

--- a/samples/mapzen-places-api-sample/build.gradle
+++ b/samples/mapzen-places-api-sample/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'checkstyle'
 
 android {
   compileSdkVersion 24
@@ -19,6 +20,15 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
+}
+
+task checkstyle(type: Checkstyle) {
+  configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
+  source 'src'
+  include '**/*.java'
+  exclude '**/gen/**'
+
+  classpath = files()
 }
 
 dependencies {

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
@@ -1,65 +1,40 @@
 package com.mapzen.places.api.sample;
 
+import com.mapzen.android.lost.api.Status;
 import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.Place;
-import com.mapzen.places.api.ui.PlaceAutocomplete;
+import com.mapzen.places.api.ui.PlaceAutocompleteFragment;
+import com.mapzen.places.api.ui.PlaceSelectionListener;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.view.View;
-import android.widget.Button;
-import android.widget.TextView;
 
 import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ADDRESS;
-import static com.mapzen.places.api.ui.PlaceAutocomplete.MODE_OVERLAY;
 
 /**
  * Demonstrates how to launch the Places Autocomplete UI.
  */
-public class AutocompleteDemoActivity extends AppCompatActivity {
-
-  private static final int AUTOCOMPLETE_REQUEST_CODE = 1;
-
-  private Intent autoCompleteIntent;
-  private Button launchAutocompleteBtn;
-  private TextView placeNameText;
-  private TextView placeAddressText;
+public class AutocompleteDemoActivity extends AppCompatActivity implements PlaceSelectionListener {
 
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_autocomplete);
-    setupBtn();
-    setupTextViews();
 
+    PlaceAutocompleteFragment fragment = (PlaceAutocompleteFragment) getFragmentManager().
+        findFragmentById(R.id.place_autocomplete_fragment);
     AutocompleteFilter filter = new AutocompleteFilter.Builder()
         .setTypeFilter(TYPE_FILTER_ADDRESS)
         .build();
-   autoCompleteIntent = new PlaceAutocomplete.IntentBuilder(MODE_OVERLAY)
-        .setFilter(filter)
-        .build(this);
+    fragment.setPlaceSelectionListener(this);
+    fragment.setFilter(filter);
   }
 
-  @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    if (requestCode == AUTOCOMPLETE_REQUEST_CODE && resultCode == RESULT_OK) {
-      Place place = PlaceAutocomplete.getPlace(this, data);
-      placeNameText.setText(place.getName());
-      placeAddressText.setText(place.getAddress());
-    }
+  @Override public void onPlaceSelected(Place place) {
+    // Do something with selected place
   }
 
-  private void setupBtn() {
-    launchAutocompleteBtn = (Button) findViewById(R.id.launch_autocomplete_btn);
-    launchAutocompleteBtn.setOnClickListener(new View.OnClickListener() {
-      @Override public void onClick(View view) {
-        startActivityForResult(autoCompleteIntent, AUTOCOMPLETE_REQUEST_CODE);
-      }
-    });
-  }
+  @Override public void onError(Status status) {
 
-  private void setupTextViews() {
-    placeNameText = (TextView) findViewById(R.id.place_name_text);
-    placeAddressText = (TextView) findViewById(R.id.place_address_text);
   }
 }

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
@@ -13,11 +13,11 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ADDRESS;
-import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ESTABLISHMENT;
-import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_GEOCODE;
-import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_REGIONS;
 import static com.mapzen.places.api.ui.PlaceAutocomplete.MODE_OVERLAY;
 
+/**
+ * Demonstrates how to launch the Places Autocomplete UI.
+ */
 public class AutocompleteDemoActivity extends AppCompatActivity {
 
   private static final int AUTOCOMPLETE_REQUEST_CODE = 1;

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/AutocompleteDemoActivity.java
@@ -1,12 +1,65 @@
 package com.mapzen.places.api.sample;
 
+import com.mapzen.places.api.AutocompleteFilter;
+import com.mapzen.places.api.Place;
+import com.mapzen.places.api.ui.PlaceAutocomplete;
+
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ADDRESS;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ESTABLISHMENT;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_GEOCODE;
+import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_REGIONS;
+import static com.mapzen.places.api.ui.PlaceAutocomplete.MODE_OVERLAY;
 
 public class AutocompleteDemoActivity extends AppCompatActivity {
+
+  private static final int AUTOCOMPLETE_REQUEST_CODE = 1;
+
+  private Intent autoCompleteIntent;
+  private Button launchAutocompleteBtn;
+  private TextView placeNameText;
+  private TextView placeAddressText;
+
   @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_autocomplete);
+    setupBtn();
+    setupTextViews();
+
+    AutocompleteFilter filter = new AutocompleteFilter.Builder()
+        .setTypeFilter(TYPE_FILTER_ADDRESS)
+        .build();
+   autoCompleteIntent = new PlaceAutocomplete.IntentBuilder(MODE_OVERLAY)
+        .setFilter(filter)
+        .build(this);
+  }
+
+  @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    if (requestCode == AUTOCOMPLETE_REQUEST_CODE && resultCode == RESULT_OK) {
+      Place place = PlaceAutocomplete.getPlace(this, data);
+      placeNameText.setText(place.getName());
+      placeAddressText.setText(place.getAddress());
+    }
+  }
+
+  private void setupBtn() {
+    launchAutocompleteBtn = (Button) findViewById(R.id.launch_autocomplete_btn);
+    launchAutocompleteBtn.setOnClickListener(new View.OnClickListener() {
+      @Override public void onClick(View view) {
+        startActivityForResult(autoCompleteIntent, AUTOCOMPLETE_REQUEST_CODE);
+      }
+    });
+  }
+
+  private void setupTextViews() {
+    placeNameText = (TextView) findViewById(R.id.place_name_text);
+    placeAddressText = (TextView) findViewById(R.id.place_address_text);
   }
 }

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/GeoDataApiActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/GeoDataApiActivity.java
@@ -21,7 +21,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 /**
- * Demonstrates use of the {@link com.mapzen.places.GeoDataApi}
+ * Demonstrates use of the {@link com.mapzen.places.api.GeoDataApi}.
  */
 public class GeoDataApiActivity extends AppCompatActivity {
 

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
@@ -16,6 +16,9 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.TextView;
 import android.widget.Toast;
 
+/**
+ * Demonstrates how to launch the Places PlacePicker UI.
+ */
 public class PlacePickerDemoActivity extends AppCompatActivity {
 
   private static final int PERMISSIONS_REQUEST_CODE = 1;

--- a/samples/mapzen-places-api-sample/src/main/res/layout/activity_autocomplete.xml
+++ b/samples/mapzen-places-api-sample/src/main/res/layout/activity_autocomplete.xml
@@ -1,18 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     >
 
-  <fragment
-      android:id="@+id/place_autocomplete_fragment"
-      android:name="com.mapzen.places.api.ui.PlaceAutocompleteFragment"
-      android:layout_width="match_parent"
+  <Button
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:id="@+id/launch_autocomplete_btn"
+      android:text="@string/launch_autocomplete"
+      />
+
+  <TextView
+      android:id="@+id/place_name_text"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       />
 
-</FrameLayout>
+  <TextView
+      android:id="@+id/place_address_text"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      />
+
+</LinearLayout>

--- a/samples/mapzen-places-api-sample/src/main/res/layout/activity_autocomplete.xml
+++ b/samples/mapzen-places-api-sample/src/main/res/layout/activity_autocomplete.xml
@@ -9,23 +9,10 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     >
 
-  <Button
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:id="@+id/launch_autocomplete_btn"
-      android:text="@string/launch_autocomplete"
-      />
-
-  <TextView
-      android:id="@+id/place_name_text"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      />
-
-  <TextView
-      android:id="@+id/place_address_text"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      />
+  <fragment
+      android:id="@+id/place_autocomplete_fragment"
+      android:name="com.mapzen.places.api.ui.PlaceAutocompleteFragment"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/samples/mapzen-places-api-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-places-api-sample/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
   <string name="sample_place_picker_description">Select a place from the map using the Mapzen Place Picker</string>
   <string name="sample_autocomplete_label">Autocomplete</string>
   <string name="sample_autocomplete_description">Search for a place using the Mapzen Search autocomplete widget</string>
+  <string name="launch_autocomplete">Launch Autocomplete</string>
 </resources>


### PR DESCRIPTION
### Overview
This PR adds support for fetching details about a `Place` when using the Autocomplete API. It also allows setting a `BoundingBox` when launching this UI. The LOST library has been updated to make `Status` objects `Parcelable`, this PR now passes them back in the `Intent` data. Lastly, this adds support for filtering results using the `AutocompleteFilter` object.

### Proposed Changes
'OnPlaceDetailsFetchedListener' interface has been updated to pass a `Place` object back. `AutocompleteDetailFetchListener` has been added to handle notifying the controller when place details are successfully fetched (or fail to be fetched). `AutocompleteFilter` has been built out and and made functional. `PeliasFilterMapper` handles mapping `AutocompleteFilter` filters to parameters accepted by `Pelias`.

