### PR TITLE
Fallback to Device Location

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -1,5 +1,6 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.api.Status;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.Pelias;
@@ -54,6 +55,9 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
     presenter.setBounds((LatLngBounds) safeGetExtra(EXTRA_BOUNDS));
     presenter.setFilter((AutocompleteFilter) safeGetExtra(EXTRA_FILTER));
+    LostApiClient client = new LostApiClient.Builder(this).addConnectionCallbacks(
+        presenter).build();
+    presenter.setLostClient(client);
 
     AutoCompleteListView listView = (AutoCompleteListView) findViewById(R.id.list_view);
     AutoCompleteAdapter autocompleteAdapter =

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -55,8 +55,7 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
     presenter.setBounds((LatLngBounds) safeGetExtra(EXTRA_BOUNDS));
     presenter.setFilter((AutocompleteFilter) safeGetExtra(EXTRA_FILTER));
-    LostApiClient client = new LostApiClient.Builder(this).addConnectionCallbacks(
-        presenter).build();
+    LostApiClient client = new LostApiClient.Builder(this).build();
     presenter.setLostClient(client);
 
     AutoCompleteListView listView = (AutoCompleteListView) findViewById(R.id.list_view);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -16,7 +16,7 @@ import retrofit2.Response;
 /**
  * Place autocomplete presenter to handle non-Android logic.
  */
-class PlaceAutocompletePresenter implements LostApiClient.ConnectionCallbacks {
+class PlaceAutocompletePresenter {
   private static final String TAG = "MapzenPlaces";
   private static final double BOUNDS_RADIUS = 0.02;
   private static final double LAT_DEFAULT = 0.0;
@@ -28,7 +28,6 @@ class PlaceAutocompletePresenter implements LostApiClient.ConnectionCallbacks {
   private LatLngBounds bounds;
   private AutocompleteFilter filter;
   private LostApiClient client;
-  private boolean connected = false;
 
   /**
    * Creates a new instance.
@@ -78,7 +77,7 @@ class PlaceAutocompletePresenter implements LostApiClient.ConnectionCallbacks {
   BoundingBox getBoundingBox() {
     if (bounds == null) {
       Location location = null;
-      if (connected) {
+      if (client != null && client.isConnected()) {
         try {
           location = LocationServices.FusedLocationApi.getLastLocation(client);
         } catch (SecurityException e) {
@@ -169,11 +168,4 @@ class PlaceAutocompletePresenter implements LostApiClient.ConnectionCallbacks {
     return filterMapper.getInternalFilter(typeFilter);
   }
 
-  @Override public void onConnected() {
-    connected = true;
-  }
-
-  @Override public void onConnectionSuspended() {
-    connected = false;
-  }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -1,22 +1,34 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.LocationServices;
+import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.pelias.gson.Result;
 import com.mapzen.places.api.AutocompleteFilter;
 import com.mapzen.places.api.LatLngBounds;
 
+import android.location.Location;
+import android.util.Log;
+
 import retrofit2.Response;
 
 /**
  * Place autocomplete presenter to handle non-Android logic.
  */
-class PlaceAutocompletePresenter {
+class PlaceAutocompletePresenter implements LostApiClient.ConnectionCallbacks {
+  private static final String TAG = "MapzenPlaces";
+  private static final double BOUNDS_RADIUS = 0.02;
+  private static final double LAT_DEFAULT = 0.0;
+  private static final double LON_DEFAULT = 0.0;
+
   private final PlaceDetailFetcher detailFetcher;
   private final OnPlaceDetailsFetchedListener detailFetchListener;
   private final FilterMapper filterMapper;
   private LatLngBounds bounds;
   private AutocompleteFilter filter;
+  private LostApiClient client;
+  private boolean connected = false;
 
   /**
    * Creates a new instance.
@@ -37,6 +49,17 @@ class PlaceAutocompletePresenter {
   }
 
   /**
+   * Set client to be used to retrieve device location if bounds is not set.
+   * @param client
+   */
+  void setLostClient(LostApiClient client) {
+    this.client = client;
+    if (this.client != null) {
+      client.connect();
+    }
+  }
+
+  /**
    * Invoked when the {@code PeliasSearchView} returns a successful response.
    * @param response parsed result returned by the service.
    */
@@ -54,8 +77,23 @@ class PlaceAutocompletePresenter {
    */
   BoundingBox getBoundingBox() {
     if (bounds == null) {
-      //TODO: retrieve device's last known location
-      return new BoundingBox(40.7011375427, -74.0193099976, 40.8774528503, -73.9104537964);
+      Location location = null;
+      if (connected) {
+        try {
+          location = LocationServices.FusedLocationApi.getLastLocation(client);
+        } catch (SecurityException e) {
+          Log.e(TAG, "Please specify a bounding box or request "
+              + "android.permission.ACCESS_COARSE_LOCATION in your manifest.");
+        }
+      }
+      if (location != null) {
+        double minLat = location.getLatitude() - BOUNDS_RADIUS;
+        double minLon = location.getLongitude() - BOUNDS_RADIUS;
+        double maxLat = location.getLatitude() + BOUNDS_RADIUS;
+        double maxLon = location.getLongitude() + BOUNDS_RADIUS;
+        return new BoundingBox(minLat, minLon, maxLat, maxLon);
+      }
+      return new BoundingBox(LAT_DEFAULT, LON_DEFAULT, LAT_DEFAULT, LON_DEFAULT);
     }
     double minLat = bounds.getSouthwest().getLatitude();
     double minLon = bounds.getSouthwest().getLongitude();
@@ -71,9 +109,15 @@ class PlaceAutocompletePresenter {
    * @return
    */
   double getLat() {
-    BoundingBox boundingBox = getBoundingBox();
+    BoundingBox boundingBox = null;
+    try {
+      boundingBox = getBoundingBox();
+    } catch (SecurityException e) {
+      Log.e(TAG, "Please specify a bounding box or "
+          + "request android.permission.ACCESS_COARSE_LOCATION in your manifest.");
+    }
     if (boundingBox == null) {
-      return 40.7443;
+      return LAT_DEFAULT;
     }
     double diff = (boundingBox.getMaxLat() - boundingBox.getMinLat()) / 2;
     double midLat = boundingBox.getMinLat() + diff;
@@ -87,9 +131,15 @@ class PlaceAutocompletePresenter {
    * @return
    */
   double getLon() {
-    BoundingBox boundingBox = getBoundingBox();
+    BoundingBox boundingBox = null;
+    try {
+      boundingBox = getBoundingBox();
+    } catch (SecurityException e) {
+      Log.e(TAG, "Please specify a bounding box or "
+          + "request android.permission.ACCESS_COARSE_LOCATION in your manifest.");
+    }
     if (boundingBox == null) {
-      return -73.9903;
+      return LON_DEFAULT;
     }
     double diff = (boundingBox.getMaxLon() - boundingBox.getMinLon()) / 2;
     double midLon = boundingBox.getMinLon() + diff;
@@ -117,5 +167,13 @@ class PlaceAutocompletePresenter {
     }
     int typeFilter = filter.getTypeFilter();
     return filterMapper.getInternalFilter(typeFilter);
+  }
+
+  @Override public void onConnected() {
+    connected = true;
+  }
+
+  @Override public void onConnectionSuspended() {
+    connected = false;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocomplete.java
@@ -81,8 +81,10 @@ public class PlaceAutocomplete {
     }
 
     /**
-     * Set the bounds that the Place Picker map should be centered on. If not set, the map will be
-     * centered on the user's current location.
+     * Set the bounds that the Place Picker map should be centered on. If not set, you should
+     * request android.permission.ACCESS_COARSE_LOCATION in your manifest so that the map will be
+     * centered on the user's current location. If this permission is not present results will not
+     * be limited by any bounds.
      * @param latLngBounds
      * @return
      */

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlaceAutocompleteFragment.java
@@ -51,7 +51,10 @@ public class PlaceAutocompleteFragment extends Fragment {
   }
 
   /**
-   * Set the {@link PlaceAutocompleteView}'s bounds bias.
+   * Set the {@link PlaceAutocompleteView}'s bounds bias. If not set, you should
+   * request android.permission.ACCESS_COARSE_LOCATION in your manifest so that the map will be
+   * centered on the user's current location. If this permission is not present results will not
+   * be limited by any bounds.
    * @param boundsBias
    */
   public void setBoundsBias(LatLngBounds boundsBias) {

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -1,5 +1,9 @@
 package com.mapzen.places.api.internal;
 
+import com.mapzen.android.lost.api.LocationServices;
+import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.android.lost.internal.FusedLocationProviderApiImpl;
+import com.mapzen.android.lost.internal.FusedLocationProviderService;
 import com.mapzen.pelias.BoundingBox;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Properties;
@@ -9,11 +13,13 @@ import com.mapzen.places.api.LatLngBounds;
 
 import org.junit.Test;
 
+import android.location.Location;
 import android.support.annotation.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import retrofit2.Response;
 
 public class PlaceAutocompletePresenterTest {
@@ -49,6 +55,31 @@ public class PlaceAutocompletePresenterTest {
   }
 
   @Test
+  public void getBoundingBox_lostClient_shouldReturnCorrectBox() throws Exception {
+    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
+          mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
+    FusedLocationProviderService mockService = mock(FusedLocationProviderService.class);
+      when(stubBinder.getService()).thenReturn(mockService);
+    FusedLocationProviderApiImpl impl =
+        (FusedLocationProviderApiImpl) LocationServices.FusedLocationApi;
+    impl.onServiceConnected(stubBinder);
+
+    LostApiClient client = mock(LostApiClient.class);
+    Location location = mock(Location.class);
+    when(location.getLatitude()).thenReturn(40.0);
+    when(location.getLongitude()).thenReturn(70.0);
+    when(mockService.getLastLocation(client)).thenReturn(location);
+    presenter.setLostClient(client);
+    presenter.onConnected();
+    BoundingBox boundingBox = presenter.getBoundingBox();
+    double boundsRadius = 0.02;
+    assertThat(boundingBox.getMinLat() + boundsRadius).isEqualTo(location.getLatitude());
+    assertThat(boundingBox.getMinLon() + boundsRadius).isEqualTo(location.getLongitude());
+    assertThat(boundingBox.getMaxLat() - boundsRadius).isEqualTo(location.getLatitude());
+    assertThat(boundingBox.getMaxLon() - boundsRadius).isEqualTo(location.getLongitude());
+  }
+
+  @Test
   public void getLat_shouldReturnCorrectLat() throws Exception {
     LatLng sw = new LatLng(0.0, 0.0);
     LatLng ne = new LatLng(50.0, 100.0);
@@ -58,12 +89,24 @@ public class PlaceAutocompletePresenterTest {
   }
 
   @Test
+  public void getLat_noBoundingBox_noLostClient_shouldReturnDefaultLat() throws Exception {
+    double lat = presenter.getLat();
+    assertThat(lat).isEqualTo(0.0);
+  }
+
+  @Test
   public void getLon_shouldReturnCorrectLon() throws Exception {
     LatLng sw = new LatLng(0.0, 0.0);
     LatLng ne = new LatLng(50.0, 100.0);
     presenter.setBounds(new LatLngBounds(sw, ne));
     double lat = presenter.getLon();
     assertThat(lat).isEqualTo(50.0);
+  }
+
+  @Test
+  public void getLon_noBoundingBox_noLostClient_shouldReturnDefaultLat() throws Exception {
+    double lat = presenter.getLon();
+    assertThat(lat).isEqualTo(0.0);
   }
 
   @NonNull private Response<Result> getTestResponse() {

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlaceAutocompletePresenterTest.java
@@ -70,7 +70,7 @@ public class PlaceAutocompletePresenterTest {
     when(location.getLongitude()).thenReturn(70.0);
     when(mockService.getLastLocation(client)).thenReturn(location);
     presenter.setLostClient(client);
-    presenter.onConnected();
+    when(client.isConnected()).thenReturn(true);
     BoundingBox boundingBox = presenter.getBoundingBox();
     double boundsRadius = 0.02;
     assertThat(boundingBox.getMinLat() + boundsRadius).isEqualTo(location.getLatitude());

--- a/samples/mapzen-places-api-sample/src/main/AndroidManifest.xml
+++ b/samples/mapzen-places-api-sample/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
   <application
       android:allowBackup="true"


### PR DESCRIPTION
### Overview
When neither `PlaceAutocomplete.IntentBuilder#setBoundsBias` nor `PlaceAutocompleteFragment#setBoundsBias` have  been set, we should fallback to retrieving the device's location to limit results (if the user has requested location permissions), otherwise don't restrict results.

### Proposed Changes
- Add `LostApiClient` property to `PlaceAutocompletePresenter`
- Fetch device's last known location if client is connected
- Update javadocs to notify developers that they need to request coarse location updates if bounds bias not set
- Add coarse location permission to place sample app manifest

Closes #255 