### PR TITLE
Adds custom build and install gradle tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,31 @@ allprojects {
 task clean(type: Delete) {
   delete rootProject.buildDir
 }
+
+task installSdk {
+  description 'Builds and installs the Mapzen Android SDK to the local maven repository'
+  dependsOn ':core:verify',
+      ':core:install',
+      ':mapzen-android-sdk:verify',
+      ':mapzen-android-sdk:install'
+}
+
+task installPlaces {
+  description 'Builds and installs the Mapzen Places API to the local maven repository'
+  dependsOn ':core:verify',
+      ':core:install',
+      ':mapzen-places-api:verify',
+      ':mapzen-places-api:install'
+}
+
+task installSdkDemo {
+  description 'Builds and installs the Mapzen Android SDK demo to a connected emulator or device'
+  dependsOn 'installSdk',
+      ':samples_mapzen-android-sdk-sample:installDebug'
+}
+
+task installPlacesDemo {
+  description 'Builds and installs the Mapzen Places API demo to a connected emulator or device'
+  dependsOn 'installPlaces',
+      ':samples_mapzen-places-api-sample:installDebug'
+}

--- a/samples/mapzen-android-sdk-sample/build.gradle
+++ b/samples/mapzen-android-sdk-sample/build.gradle
@@ -36,7 +36,8 @@ task checkstyle(type: Checkstyle) {
   classpath = files()
 }
 
-task verify(dependsOn: ['test',
+task verify(dependsOn: ['compileDebugSources',
+                        'test',
                         'checkstyle',
                         'lint'])
 


### PR DESCRIPTION
### Overview

Adds custom build and install gradle tasks

### Proposed Changes

Adds custom gradle tasks for `installSdk`, `installPlaces`, `installSdkDemo`, and `installPlacesDemo` to ensure dependencies are built in the proper order and installed to the local maven repository. These tasks also run all tests and codestyle checks associated with the relevant modules.