### PR TITLE
Provide overlay manager configuration options

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew clean verify
+    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify
 
 deployment:
   master:

--- a/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
@@ -3,11 +3,16 @@ package com.mapzen.android.graphics;
 import com.mapzen.R;
 import com.mapzen.android.graphics.model.MapStyle;
 
+import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_SDK;
 
 /**
  * A map component in an app. This fragment is the simplest way to place a map in an application.
@@ -16,10 +21,27 @@ import android.view.ViewGroup;
 public class MapFragment extends Fragment {
   MapView mapView;
 
+  private int overlayMode = OVERLAY_MODE_SDK;
+
   @Override public View onCreateView(LayoutInflater inflater, ViewGroup container,
       Bundle savedInstanceState) {
-    mapView = (MapView) inflater.inflate(R.layout.mz_fragment_map, container, false);
+    int layout = R.layout.mz_fragment_map;
+    if (overlayMode == MapView.OVERLAY_MODE_CLASSIC) {
+      layout = R.layout.mz_fragment_map_classic;
+    }
+
+    mapView = (MapView) inflater.inflate(layout, container, false);
     return mapView;
+  }
+
+  @Override public void onInflate(Context context, AttributeSet attrs, Bundle savedInstanceState) {
+    super.onInflate(context, attrs, savedInstanceState);
+    TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MapFragment);
+    try {
+      overlayMode = a.getInteger(R.styleable.MapFragment_overlayMode, OVERLAY_MODE_SDK);
+    } finally {
+      a.recycle();
+    }
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -60,7 +60,7 @@ public class MapView extends RelativeLayout {
     LayoutInflater inflater =
         (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     if (inflater != null) {
-      inflater.inflate(R.layout.mz_view_map, this);
+      inflater.inflate(R.layout.mz_view_map_classic, this);
     }
   }
 

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -6,6 +6,7 @@ import com.mapzen.android.graphics.model.MapStyle;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.TypedArray;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
@@ -24,6 +25,9 @@ public class MapView extends RelativeLayout {
 
   private static final String MAPZEN_RIGHTS = "https://mapzen.com/rights/";
 
+  public static final int OVERLAY_MODE_SDK = 0;
+  public static final int OVERLAY_MODE_CLASSIC = 1;
+
   @Inject MapInitializer mapInitializer;
 
   TangramMapView tangramMapView;
@@ -32,6 +36,8 @@ public class MapView extends RelativeLayout {
   ImageButton zoomIn;
   ImageButton zoomOut;
   TextView attribution;
+
+  private int overlayMode = OVERLAY_MODE_SDK;
 
   /**
    * Create new instance.
@@ -47,6 +53,13 @@ public class MapView extends RelativeLayout {
    */
   public MapView(Context context, AttributeSet attrs) {
     super(context, attrs);
+    final TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MapView);
+    try {
+      overlayMode = a.getInteger(R.styleable.MapView_overlayMode, OVERLAY_MODE_SDK);
+    } finally {
+      a.recycle();
+    }
+
     initDI(context);
     initViews(context);
   }
@@ -57,10 +70,14 @@ public class MapView extends RelativeLayout {
   }
 
   private void initViews(Context context) {
-    LayoutInflater inflater =
+    final LayoutInflater inflater =
         (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     if (inflater != null) {
-      inflater.inflate(R.layout.mz_view_map_classic, this);
+      if (overlayMode == OVERLAY_MODE_SDK) {
+        inflater.inflate(R.layout.mz_view_map, this);
+      } else {
+        inflater.inflate(R.layout.mz_view_map_classic, this);
+      }
     }
   }
 

--- a/core/src/main/res/layout/mz_fragment_map_classic.xml
+++ b/core/src/main/res/layout/mz_fragment_map_classic.xml
@@ -3,5 +3,5 @@
     android:id="@+id/mz_map_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    mapzen:overlayMode="sdk"
+    mapzen:overlayMode="classic"
     />

--- a/core/src/main/res/layout/mz_view_map_classic.xml
+++ b/core/src/main/res/layout/mz_view_map_classic.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+  <com.mapzen.android.graphics.TangramMapView
+      android:id="@+id/mz_tangram_map"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
+
+  <com.mapzen.android.graphics.CompassView
+      android:id="@+id/mz_compass"
+      android:layout_width="@dimen/mz_compass_button_width"
+      android:layout_height="@dimen/mz_compass_button_height"
+      android:layout_alignParentRight="true"
+      android:layout_alignParentTop="true"
+      android:layout_marginRight="@dimen/mz_compass_button_margin_left"
+      android:layout_marginTop="@dimen/mz_compass_button_margin_top"
+      android:visibility="gone"
+      android:src="@drawable/mz_compass"
+      android:contentDescription="@string/mz_compass"
+      tools:ignore="RtlHardcoded"
+      />
+
+  <ImageButton
+      android:id="@+id/mz_find_me"
+      android:layout_width="@dimen/mz_find_me_button_width"
+      android:layout_height="@dimen/mz_find_me_button_height"
+      android:layout_alignParentRight="true"
+      android:layout_alignParentBottom="true"
+      android:layout_marginRight="@dimen/mz_find_me_button_margin_right"
+      android:layout_marginBottom="@dimen/mz_find_me_button_margin_top"
+      android:background="@drawable/mz_bg_white_gray_border"
+      android:visibility="gone"
+      android:src="@drawable/mz_find_me"
+      android:contentDescription="@string/mz_find_me"
+      tools:ignore="RtlHardcoded"
+      />
+
+  <ImageButton
+      android:id="@+id/mz_zoom_in"
+      android:layout_width="@dimen/mz_zoom_in_button_width"
+      android:layout_height="@dimen/mz_zoom_in_button_height"
+      android:layout_alignParentLeft="true"
+      android:layout_alignParentTop="true"
+      android:layout_marginLeft="@dimen/mz_zoom_in_button_margin_left"
+      android:layout_marginTop="@dimen/mz_zoom_in_button_margin_top"
+      android:background="@drawable/mz_bg_white_gray_border"
+      android:visibility="gone"
+      android:src="@drawable/mz_zoom_in"
+      android:contentDescription="@string/mz_zoom_in"
+      tools:ignore="RtlHardcoded"
+      />
+
+  <ImageButton
+      android:id="@+id/mz_zoom_out"
+      android:layout_width="@dimen/mz_zoom_out_button_width"
+      android:layout_height="@dimen/mz_zoom_out_button_height"
+      android:layout_alignParentLeft="true"
+      android:layout_below="@+id/mz_zoom_in"
+      android:layout_marginLeft="@dimen/mz_zoom_out_button_margin_left"
+      android:background="@drawable/mz_bg_white_gray_border"
+      android:visibility="gone"
+      android:src="@drawable/mz_zoom_out"
+      android:contentDescription="@string/mz_zoom_out"
+      tools:ignore="RtlHardcoded"
+      />
+
+  <TextView
+      android:id="@+id/mz_attribution"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:textColor="#444444"
+      android:textSize="@dimen/mz_attribution_font_size"
+      android:text="@string/mz_attribution"
+      android:layout_alignParentBottom="true"
+      android:layout_alignParentLeft="true"
+      android:layout_marginLeft="@dimen/mz_attribution_margin_left"
+      android:layout_marginBottom="@dimen/mz_attribution_margin_bottom"
+      tools:ignore="RtlHardcoded"
+      />
+
+</merge>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <attr format="enum" name="overlayMode">
+    <enum name="sdk" value="0"/>
+    <enum name="classic" value="1"/>
+  </attr>
+
+  <declare-styleable name="MapView">
+    <attr name="overlayMode" />
+  </declare-styleable>
+
+  <declare-styleable name="MapFragment">
+    <attr name="overlayMode" />
+  </declare-styleable>
+</resources>

--- a/core/src/main/res/values/dimens.xml
+++ b/core/src/main/res/values/dimens.xml
@@ -12,10 +12,14 @@
   <dimen name="mz_zoom_in_button_height">44dp</dimen>
   <dimen name="mz_zoom_in_button_margin_right">16dp</dimen>
   <dimen name="mz_zoom_in_button_margin_bottom">55dp</dimen>
+  <dimen name="mz_zoom_in_button_margin_left">16dp</dimen>
+  <dimen name="mz_zoom_in_button_margin_top">16dp</dimen>
   <dimen name="mz_zoom_out_button_width">44dp</dimen>
   <dimen name="mz_zoom_out_button_height">44dp</dimen>
   <dimen name="mz_zoom_out_button_margin_right">16dp</dimen>
   <dimen name="mz_zoom_out_button_margin_bottom">16dp</dimen>
+  <dimen name="mz_zoom_out_button_margin_left">16dp</dimen>
+  <dimen name="mz_zoom_out_button_margin_top">55dp</dimen>
   <dimen name="mz_attribution_margin_left">16dp</dimen>
   <dimen name="mz_attribution_margin_bottom">16dp</dimen>
   <dimen name="mz_attribution_font_size">10sp</dimen>

--- a/core/src/test/java/com/mapzen/android/graphics/MapFragmentTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapFragmentTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.R;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,10 +9,17 @@ import org.powermock.core.classloader.annotations.SuppressStaticInitializationFo
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
 
+import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_CLASSIC;
+import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_SDK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -48,5 +57,45 @@ public class MapFragmentTest {
     TestCallback callback = new TestCallback();
     mapFragment.getMapAsync(callback);
     verify(callback.map.getMapController(), times(1)).setHttpHandler((TileHttpHandler) any());
+  }
+
+  @Test public void shouldInflateLayoutWithOverlayModeSdk() throws Exception {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    ViewGroup viewGroup = mock(ViewGroup.class);
+    TestLayoutInflater layoutInflater = new TestLayoutInflater(context);
+    initMockAttributes(context, typedArray, layoutInflater, OVERLAY_MODE_SDK);
+
+    mapFragment = new MapFragment();
+    mapFragment.onInflate(context, mock(AttributeSet.class), null);
+    mapFragment.onCreateView(layoutInflater, viewGroup, null);
+
+    assertThat(layoutInflater.getResId()).isEqualTo(R.layout.mz_fragment_map);
+    assertThat(layoutInflater.getRoot()).isEqualTo(viewGroup);
+  }
+
+  @Test public void shouldInflateLayoutWithOverlayModeClassic() throws Exception {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    ViewGroup viewGroup = mock(ViewGroup.class);
+    TestLayoutInflater layoutInflater = new TestLayoutInflater(context);
+    initMockAttributes(context, typedArray, layoutInflater, OVERLAY_MODE_CLASSIC);
+
+    mapFragment = new MapFragment();
+    mapFragment.onInflate(context, mock(AttributeSet.class), null);
+    mapFragment.onCreateView(layoutInflater, viewGroup, null);
+
+    assertThat(layoutInflater.getResId()).isEqualTo(R.layout.mz_fragment_map_classic);
+    assertThat(layoutInflater.getRoot()).isEqualTo(viewGroup);
+  }
+
+  private void initMockAttributes(Context context, TypedArray typedArray,
+      TestLayoutInflater layoutInflater, int overlayMode) {
+    when(context.obtainStyledAttributes(any(AttributeSet.class), eq(R.styleable.MapFragment)))
+        .thenReturn(typedArray);
+    when(context.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
+        .thenReturn(layoutInflater);
+    when(typedArray.getInteger(R.styleable.MapFragment_overlayMode, OVERLAY_MODE_SDK))
+        .thenReturn(overlayMode);
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
@@ -1,13 +1,22 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.R;
 import com.mapzen.android.graphics.model.RefillStyle;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+
 import static com.mapzen.TestHelper.getMockContext;
+import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_CLASSIC;
+import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_SDK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,5 +67,39 @@ public class MapViewTest {
     assertThat(mapView.mapInitializer.httpHandler.getApiKey()).isEqualTo("apikey");
     assertThat(mapView.mapInitializer.mapStateManager.getMapStyle()).isInstanceOf(
         RefillStyle.class);
+  }
+
+  @Test public void shouldInflateLayoutWithOverlayModeSdk() throws Exception {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    TestLayoutInflater layoutInflater = new TestLayoutInflater(context);
+    initMockAttributes(context, typedArray, layoutInflater, OVERLAY_MODE_SDK);
+
+    MapView mapView = new MapView(context, mock(AttributeSet.class));
+
+    assertThat(layoutInflater.getResId()).isEqualTo(R.layout.mz_view_map);
+    assertThat(layoutInflater.getRoot()).isEqualTo(mapView);
+  }
+
+  @Test public void shouldInflateLayoutWithOverlayModeClassic() throws Exception {
+    Context context = mock(Context.class);
+    TypedArray typedArray = mock(TypedArray.class);
+    TestLayoutInflater layoutInflater = new TestLayoutInflater(context);
+    initMockAttributes(context, typedArray, layoutInflater, OVERLAY_MODE_CLASSIC);
+
+    MapView mapView = new MapView(context, mock(AttributeSet.class));
+
+    assertThat(layoutInflater.getResId()).isEqualTo(R.layout.mz_view_map_classic);
+    assertThat(layoutInflater.getRoot()).isEqualTo(mapView);
+  }
+
+  private void initMockAttributes(Context context, TypedArray typedArray,
+      TestLayoutInflater layoutInflater, int overlayMode) {
+    when(context.obtainStyledAttributes(any(AttributeSet.class), eq(R.styleable.MapView)))
+        .thenReturn(typedArray);
+    when(context.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
+        .thenReturn(layoutInflater);
+    when(typedArray.getInteger(R.styleable.MapView_overlayMode, OVERLAY_MODE_SDK))
+        .thenReturn(overlayMode);
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/TestLayoutInflater.java
+++ b/core/src/test/java/com/mapzen/android/graphics/TestLayoutInflater.java
@@ -1,0 +1,39 @@
+package com.mapzen.android.graphics;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+class TestLayoutInflater extends LayoutInflater {
+  private int resource;
+  private ViewGroup root;
+
+  TestLayoutInflater(Context context) {
+    super(context);
+  }
+
+  @Override public View inflate(int resource, ViewGroup root) {
+    this.resource = resource;
+    this.root = root;
+    return null;
+  }
+
+  @Override public View inflate(int resource, ViewGroup root, boolean attachToRoot) {
+    this.resource = resource;
+    this.root = root;
+    return null;
+  }
+
+  @Override public LayoutInflater cloneInContext(Context newContext) {
+    return null;
+  }
+
+  int getResId() {
+    return resource;
+  }
+
+  ViewGroup getRoot() {
+    return root;
+  }
+}

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
@@ -75,6 +75,9 @@ public class BasicMapzenActivity extends AppCompatActivity
             .show();
       }
     });
+
+    map.setCompassButtonEnabled(true);
+    map.setZoomButtonsEnabled(true);
   }
 
   @Override protected void onPause() {

--- a/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_spinner.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_spinner.xml
@@ -36,6 +36,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       app:layout_behavior="@string/appbar_scrolling_view_behavior"
+      app:overlayMode="classic"
       />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
## Overview

Provides two configuration options for map control overlays (find me, compass, and zoom buttons). "SDK" mode configures the map controls similar to other popular SDKs. "Classic" mode configures the map controls the way the Mapzen SDK (and Eraser Map) have worked in the past.

### "SDK" overlay mode

![7318383267764097217-account_id 1](https://cloud.githubusercontent.com/assets/464123/22267843/46944d6e-e253-11e6-9f53-cfea30121d09.png)

### "Classic" overlay mode

![2034890413358344899-account_id 1](https://cloud.githubusercontent.com/assets/464123/22267859/58834a0c-e253-11e6-8e33-723b389af472.png)

## Proposed Changes

Configuration of the overlay controls is set using new custom view attributes on either `MapView` or `MapFragment`.

Based on this attribute one of two layout files is loaded when the view is inflated.

"SDK" layout mode is the new default mode.