### PR TITLE
249 api key rename

### DIFF
--- a/core/src/main/java/com/mapzen/android/core/ApiKeyConstants.java
+++ b/core/src/main/java/com/mapzen/android/core/ApiKeyConstants.java
@@ -4,7 +4,7 @@ package com.mapzen.android.core;
  * Api key constants.
  */
 public class ApiKeyConstants {
-  public static final String API_KEY_RES_NAME = "api_key";
+  public static final String API_KEY_RES_NAME = "mapzen_api_key";
   public static final String API_KEY_RES_TYPE = "string";
   public static final String API_KEY = "api_key";
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -92,7 +92,7 @@ public class MapView extends RelativeLayout {
 
   /**
    * Load map asynchronously using APK key declared in XML resources. For example:
-   * {@code <string name="api_key">[YOUR_API_KEY]</string>}
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
    *
    * @param callback listener to be invoked when map is initialized and ready to use.
    */
@@ -102,7 +102,7 @@ public class MapView extends RelativeLayout {
 
   /**
    * Load map asynchronously using APK key declared in XML resources. For example:
-   * {@code <string name="api_key">[YOUR_API_KEY]</string>}
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
    *
    * @param callback listener to be invoked when map is initialized and ready to use.
    * @param mapStyle mapStyle that should be set

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Sign up for an API key from the [Mapzen developer portal](https://mapzen.com/dev
 
 ```xml
 <resources>
-    <string name="api_key">[YOUR_MAPZEN_API_KEY]</string>
+    <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
 </resources>
 ```
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -18,7 +18,7 @@ public class MySearchActivity extends Activity {
 
 ```xml
 <resources>
-  <string name="api_key">[YOUR_MAPZEN_API_KEY]</string>
+  <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
 </resources>
 ```
 

--- a/docs/turn-by-turn.md
+++ b/docs/turn-by-turn.md
@@ -13,7 +13,7 @@ MapzenRouter router = new MapzenRouter(this, [YOUR_MAPZEN_API_KEY]);
 
 **mapzen.xml**
 ```xml
-<string name="api_key">[YOUR_MAPZEN_API_KEY]</string>
+<string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
 ```
 
 ```java

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/mapzen.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/mapzen.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="api_key">[YOUR_MAPZEN_API_KEY]</string>
+  <string name="mapzen_api_key">mapzen-MxD3a8w</string>
 </resources>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/mapzen.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/mapzen.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="mapzen_api_key">mapzen-MxD3a8w</string>
+  <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
 </resources>

--- a/samples/mapzen-places-api-sample/src/main/res/values/mapzen.xml
+++ b/samples/mapzen-places-api-sample/src/main/res/values/mapzen.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="api_key">[YOUR_MAPZEN_API_KEY]</string>
+  <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
 </resources>


### PR DESCRIPTION
### Overview
Makes API key resource name Mapzen-specific and updates documentation around how to setup API key to include more specific examples

### Proposed Changes
- "api_key" -> "mapzen_api_key" when set via `mapzen.xml`
- Update javadocs and `docs/` files
- Update sample apps

Closes #249 