### PR TITLE
Support Place placeType

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
@@ -11,6 +11,19 @@ import java.util.Locale;
  */
 public interface Place extends Parcelable {
 
+  int TYPE_COUNTRY = 1005;
+  int TYPE_LOCALITY = 1009;
+  int TYPE_POINT_OF_INTEREST = 1013;
+  int TYPE_ESTABLISHMENT = 34;
+  int TYPE_STREET_ADDRESS = 1021;
+  int TYPE_POLITICAL = 1012;
+  int TYPE_SUBLOCALITY = 1022;
+  int TYPE_SUBLOCALITY_LEVEL_1 = 1023;
+  int TYPE_NEIGHBORHOOD = 1011;
+  int TYPE_ROUTE = 1020;
+  int TYPE_ADMINISTRATIVE_AREA_LEVEL_1 = 1001;
+
+
   /**
    * Returns human readable address for this place.
    * @return

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/Place.java
@@ -32,6 +32,9 @@ public interface Place extends Parcelable {
 
   /**
    * Returns the attributions to be shown to the user if data from the Place is used.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   abstract CharSequence getAttributions();
@@ -62,6 +65,9 @@ public interface Place extends Parcelable {
 
   /**
    * Returns the place's phone number in international format.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   abstract CharSequence getPhoneNumber();
@@ -74,12 +80,18 @@ public interface Place extends Parcelable {
 
   /**
    * Returns the price level for this place on a scale from 0 (cheapest) to 4.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   abstract int getPriceLevel();
 
   /**
    * Returns the place's rating, from 1.0 to 5.0, based on aggregated user reviews.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   abstract float getRating();
@@ -92,6 +104,9 @@ public interface Place extends Parcelable {
 
   /**
    * Returns website uri for this place.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   abstract Uri getWebsiteUri();

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasCallbackHandler.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasCallbackHandler.java
@@ -1,0 +1,79 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.Place;
+
+import java.util.List;
+
+import retrofit2.Response;
+
+/**
+ * Handles choosing which {@link Feature} should be used to notify listeners of successful
+ * {@link Place} retrieval as well as when to notify listeners that a {@link Place} has failed to be
+ * retrieved.
+ */
+class PeliasCallbackHandler {
+
+  private PeliasFeatureToPlaceConverter converter;
+
+  /**
+   * Constructor.
+   */
+  PeliasCallbackHandler() {
+    converter = new PeliasFeatureToPlaceConverter();
+  }
+
+  /**
+   * Creates a {@link Place} from a {@link Feature} with a name that matches the given title and
+   * notifies the listener that a place has been successfully retrieved.
+   * @param title
+   * @param features
+   * @param listener
+   */
+  public void handleSuccess(String title, List<Feature> features,
+      OnPlaceDetailsFetchedListener listener) {
+    for (Feature feature : features) {
+      if (feature.properties.name.equals(title)) {
+        Place place = converter.getFetchedPlace(feature);
+        String details = getDetails(feature, title);
+        listener.onFetchSuccess(place, details);
+      }
+    }
+  }
+
+  /**
+   * Creates a {@link Place} from the first feature in the response (there should only be one
+   * feature in the response) and notifies the listener that a place has been successfully
+   * retrieved. If the response body or response body features do not exist, the listener is
+   * notified of a fetch failure.
+   * @param response
+   * @param listener
+   */
+  public void handleSuccess(Response<Result> response, OnPlaceDetailsFetchedListener listener) {
+    if (response.body() == null || response.body().getFeatures() == null ||
+        response.body().getFeatures().isEmpty()) {
+      listener.onFetchFailure();
+      return;
+    }
+    Feature feature = response.body().getFeatures().get(0);
+    String title = feature.properties.name;
+    Place place = converter.getFetchedPlace(feature);
+    String details = getDetails(feature, title);
+    listener.onFetchSuccess(place, details);
+  }
+
+  /**
+   * Notify the listener of a fetch failure.
+   * @param listener
+   */
+  public void handleFailure(OnPlaceDetailsFetchedListener listener) {
+    listener.onFetchFailure();
+  }
+
+  private String getDetails(Feature feature, String title) {
+    String label = feature.properties.label;
+    label = label.replace(title + ",", "").trim();
+    return title + "\n" + label;
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverter.java
@@ -1,0 +1,60 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.places.api.LatLng;
+import com.mapzen.places.api.LatLngBounds;
+import com.mapzen.places.api.Place;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Handles converting Pelias {@link Feature} objects into {@link Place} objects for
+ * {@link PeliasCallbackHandler}.
+ */
+class PeliasFeatureToPlaceConverter {
+
+  private PeliasLayerToPlaceTypeConverter layerConverter;
+
+  /**
+   * Constructor.
+   */
+  PeliasFeatureToPlaceConverter() {
+    layerConverter = new PeliasLayerToPlaceTypeConverter();
+  }
+
+  /**
+   * Construct a {@link Place} object from the given feature.
+   * @param feature
+   * @return
+   */
+  Place getFetchedPlace(Feature feature) {
+    //TODO: fill in missing values
+    final CharSequence address = feature.properties.label;
+    final String id = feature.properties.id;
+    final LatLng latLng = new LatLng(feature.geometry.coordinates.get(1),
+        feature.geometry.coordinates.get(0));
+    final Locale locale = Locale.US;
+    final CharSequence name = feature.properties.name;
+    final List<Integer> placeTypes = new ArrayList<>();
+    if (feature.properties.layer != null) {
+      placeTypes.addAll(layerConverter.getPlaceTypes(feature.properties.layer));
+    }
+    final LatLngBounds viewport = new LatLngBounds(latLng, latLng);
+    return new PlaceImpl.Builder()
+        .setAddress(address)
+        .setAttributions(null)
+        .setId(id)
+        .setLatLng(latLng)
+        .setLocale(locale)
+        .setName(name)
+        .setPhoneNumber(null)
+        .setPlaceTypes(placeTypes)
+        .setPriceLevel(0)
+        .setRating(0)
+        .setViewPort(viewport)
+        .setWebsiteUri(null)
+        .build();
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverter.java
@@ -16,12 +16,14 @@ import java.util.Locale;
 class PeliasFeatureToPlaceConverter {
 
   private PeliasLayerToPlaceTypeConverter layerConverter;
+  private PointToBoundsConverter pointConverter;
 
   /**
    * Constructor.
    */
   PeliasFeatureToPlaceConverter() {
     layerConverter = new PeliasLayerToPlaceTypeConverter();
+    pointConverter = new PointToBoundsConverter();
   }
 
   /**
@@ -33,15 +35,15 @@ class PeliasFeatureToPlaceConverter {
     //TODO: fill in missing values
     final CharSequence address = feature.properties.label;
     final String id = feature.properties.id;
-    final LatLng latLng = new LatLng(feature.geometry.coordinates.get(1),
-        feature.geometry.coordinates.get(0));
     final Locale locale = Locale.US;
     final CharSequence name = feature.properties.name;
     final List<Integer> placeTypes = new ArrayList<>();
     if (feature.properties.layer != null) {
       placeTypes.addAll(layerConverter.getPlaceTypes(feature.properties.layer));
     }
-    final LatLngBounds viewport = new LatLngBounds(latLng, latLng);
+    final LatLng latLng = new LatLng(feature.geometry.coordinates.get(1),
+        feature.geometry.coordinates.get(0));
+    final LatLngBounds viewport = pointConverter.boundsFromPoint(latLng);
     return new PlaceImpl.Builder()
         .setAddress(address)
         .setAttributions(null)

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFilterMapper.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFilterMapper.java
@@ -11,6 +11,17 @@ import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_ESTABLISHMENT
 import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_GEOCODE;
 import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_NONE;
 import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_REGIONS;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_ADDRESS;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_BOROUGH;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COARSE;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTRY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCALITY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCAL_ADMIN;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_MACRO_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_NEIGHBOURHOOD;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_NONE;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_VENUE;
 
 /**
  * Maps internal filter values to {@link com.mapzen.places.api.AutocompleteFilter} values for the
@@ -18,34 +29,22 @@ import static com.mapzen.places.api.AutocompleteFilter.TYPE_FILTER_REGIONS;
  */
 public class PeliasFilterMapper implements FilterMapper {
 
-  private static final String PELIAS_FILTER_ADDRESS = "address";
-  private static final String PELIAS_FILTER_LOCALITY = "locality";
-  private static final String PELIAS_FILTER_VENUE = "venue";
-  private static final String PELIAS_FILTER_COARSE = "coarse";
-  private static final String PELIAS_FILTER_NONE = "";
-  private static final String PELIAS_FILTER_COUNTRY = "country";
-  private static final String PELIAS_FILTER_MACRO_COUNTY = "macrocounty";
-  private static final String PELIAS_FILTER_COUNTY = "county";
-  private static final String PELIAS_FILTER_LOCAL_ADMIN = "localadmin";
-  private static final String PELIAS_FILTER_BOROUGH = "borough";
-  private static final String PELIAS_FILTER_NEIGHBOURHOOD = "neighbourhood";
-
   private static final Map<Integer, String> MAPZEN_PLACES_TO_PELIAS_FILTERS;
   static {
     MAPZEN_PLACES_TO_PELIAS_FILTERS = new HashMap();
-    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ADDRESS, PELIAS_FILTER_ADDRESS);
-    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_CITIES, PELIAS_FILTER_LOCALITY);
-    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ESTABLISHMENT, PELIAS_FILTER_VENUE);
-    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_GEOCODE, PELIAS_FILTER_COARSE);
-    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_NONE, PELIAS_FILTER_NONE);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ADDRESS, PELIAS_LAYER_ADDRESS);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_CITIES, PELIAS_LAYER_LOCALITY);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_ESTABLISHMENT, PELIAS_LAYER_VENUE);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_GEOCODE, PELIAS_LAYER_COARSE);
+    MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_NONE, PELIAS_LAYER_NONE);
     List<String> regionFilters = new ArrayList<String>() { {
-      add(PELIAS_FILTER_COUNTRY);
-      add(PELIAS_FILTER_MACRO_COUNTY);
-      add(PELIAS_FILTER_LOCALITY);
-      add(PELIAS_FILTER_COUNTY);
-      add(PELIAS_FILTER_LOCAL_ADMIN);
-      add(PELIAS_FILTER_BOROUGH);
-      add(PELIAS_FILTER_NEIGHBOURHOOD);
+      add(PELIAS_LAYER_COUNTRY);
+      add(PELIAS_LAYER_MACRO_COUNTY);
+      add(PELIAS_LAYER_LOCALITY);
+      add(PELIAS_LAYER_COUNTY);
+      add(PELIAS_LAYER_LOCAL_ADMIN);
+      add(PELIAS_LAYER_BOROUGH);
+      add(PELIAS_LAYER_NEIGHBOURHOOD);
     } };
     String peliasRegionFilters = buildCommaSeparated(regionFilters);
     MAPZEN_PLACES_TO_PELIAS_FILTERS.put(TYPE_FILTER_REGIONS, peliasRegionFilters);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerConsts.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerConsts.java
@@ -1,0 +1,21 @@
+package com.mapzen.places.api.internal;
+
+/**
+ * Layers available in the Pelias service.
+ */
+class PeliasLayerConsts {
+  static final String PELIAS_LAYER_ADDRESS = "address";
+  static final String PELIAS_LAYER_LOCALITY = "locality";
+  static final String PELIAS_LAYER_VENUE = "venue";
+  static final String PELIAS_LAYER_COARSE = "coarse";
+  static final String PELIAS_LAYER_NONE = "";
+  static final String PELIAS_LAYER_COUNTRY = "country";
+  static final String PELIAS_LAYER_MACRO_COUNTY = "macrocounty";
+  static final String PELIAS_LAYER_COUNTY = "county";
+  static final String PELIAS_LAYER_LOCAL_ADMIN = "localadmin";
+  static final String PELIAS_LAYER_BOROUGH = "borough";
+  static final String PELIAS_LAYER_NEIGHBOURHOOD = "neighbourhood";
+  static final String PELIAS_LAYER_STREET = "street";
+  static final String PELIAS_LAYER_REGION = "region";
+  static final String PELIAS_LAYER_MACRO_REGION = "macroregion";
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverter.java
@@ -1,0 +1,78 @@
+package com.mapzen.places.api.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.mapzen.places.api.Place.TYPE_ADMINISTRATIVE_AREA_LEVEL_1;
+import static com.mapzen.places.api.Place.TYPE_COUNTRY;
+import static com.mapzen.places.api.Place.TYPE_ESTABLISHMENT;
+import static com.mapzen.places.api.Place.TYPE_LOCALITY;
+import static com.mapzen.places.api.Place.TYPE_NEIGHBORHOOD;
+import static com.mapzen.places.api.Place.TYPE_POINT_OF_INTEREST;
+import static com.mapzen.places.api.Place.TYPE_POLITICAL;
+import static com.mapzen.places.api.Place.TYPE_ROUTE;
+import static com.mapzen.places.api.Place.TYPE_STREET_ADDRESS;
+import static com.mapzen.places.api.Place.TYPE_SUBLOCALITY;
+import static com.mapzen.places.api.Place.TYPE_SUBLOCALITY_LEVEL_1;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_ADDRESS;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_BOROUGH;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTRY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCALITY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCAL_ADMIN;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_MACRO_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_MACRO_REGION;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_NEIGHBOURHOOD;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_REGION;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_STREET;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_VENUE;
+
+/**
+ * Converts a "layer" returned from Pelias into a list of {@link com.mapzen.places.api.Place} types
+ * for {@link PeliasFeatureToPlaceConverter}.
+ */
+class PeliasLayerToPlaceTypeConverter {
+
+  private static final Map<String, List<Integer>> PELIAS_LAYER_TO_PLACE_TYPE;
+  static {
+      PELIAS_LAYER_TO_PLACE_TYPE = new HashMap();
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_LOCALITY, listOf(TYPE_LOCALITY, TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_COUNTRY, listOf(TYPE_COUNTRY, TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_VENUE, listOf(TYPE_POINT_OF_INTEREST,
+          TYPE_ESTABLISHMENT));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_ADDRESS, listOf(TYPE_STREET_ADDRESS));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_MACRO_COUNTY, listOf(TYPE_LOCALITY,
+          TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_COUNTY, listOf(TYPE_LOCALITY, TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_LOCAL_ADMIN, listOf(TYPE_LOCALITY,
+          TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_BOROUGH, listOf(TYPE_SUBLOCALITY,
+          TYPE_SUBLOCALITY_LEVEL_1, TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_NEIGHBOURHOOD, listOf(TYPE_NEIGHBORHOOD,
+          TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_STREET, listOf(TYPE_ROUTE));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_REGION, listOf(TYPE_ADMINISTRATIVE_AREA_LEVEL_1,
+          TYPE_POLITICAL));
+      PELIAS_LAYER_TO_PLACE_TYPE.put(PELIAS_LAYER_MACRO_REGION, listOf(
+          TYPE_ADMINISTRATIVE_AREA_LEVEL_1, TYPE_POLITICAL));
+  }
+
+  /**
+   * Returns a list of {@link Place} types corresponding to a given Pelias layer.
+   * @param layer
+   * @return
+   */
+  List<Integer> getPlaceTypes(String layer) {
+    return PELIAS_LAYER_TO_PLACE_TYPE.get(layer);
+  }
+
+  private static List<Integer> listOf(int... args) {
+    List<Integer> list = new ArrayList<>();
+    for (int i = 0; i < args.length; ++i) {
+      list.add(args[i]);
+    }
+    return list;
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcher.java
@@ -1,18 +1,9 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.pelias.Pelias;
-import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Result;
-import com.mapzen.places.api.LatLng;
-import com.mapzen.places.api.LatLngBounds;
-import com.mapzen.places.api.Place;
 import com.mapzen.tangram.LngLat;
 
-import android.net.Uri;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static com.mapzen.places.api.internal.PlacePickerPresenterImpl.PROPERTY_NAME;
@@ -26,12 +17,14 @@ import retrofit2.Response;
 class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
 
   private Pelias pelias;
+  private PeliasCallbackHandler callbackHandler;
 
   /**
    * Constructs a new object.
    */
-  public PeliasPlaceDetailFetcher() {
-    pelias = new Pelias();
+  public PeliasPlaceDetailFetcher(Pelias pelias, PeliasCallbackHandler callbackHandler) {
+    this.pelias = pelias;
+    this.callbackHandler = callbackHandler;
     pelias.setDebug(true);
   }
 
@@ -39,18 +32,12 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
       final OnPlaceDetailsFetchedListener listener) {
     pelias.reverse(coordinates.latitude, coordinates.longitude, new Callback<Result>() {
           @Override public void onResponse(Call<Result> call, Response<Result> response) {
-            String title = properties.get(PROPERTY_NAME);
-            for (Feature feature : response.body().getFeatures()) {
-              if (feature.properties.name.equals(title)) {
-                Place place = getFetchedPlace(feature);
-                String details = getDetails(feature, title);
-                listener.onFetchSuccess(place, details);
-              }
-            }
+            callbackHandler.handleSuccess(properties.get(PROPERTY_NAME),
+                response.body().getFeatures(), listener);
           }
 
           @Override public void onFailure(Call<Result> call, Throwable t) {
-            listener.onFetchFailure();
+            callbackHandler.handleFailure(listener);
           }
         }
     );
@@ -59,58 +46,12 @@ class PeliasPlaceDetailFetcher implements PlaceDetailFetcher {
   @Override public void fetchDetails(String gid, final OnPlaceDetailsFetchedListener listener) {
     pelias.place(gid, new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {
-        if (response.body() == null || response.body().getFeatures() == null ||
-            response.body().getFeatures().isEmpty()) {
-          listener.onFetchFailure();
-          return;
-        }
-        Feature feature = response.body().getFeatures().get(0);
-        String title = feature.properties.name;
-        Place place = getFetchedPlace(feature);
-        String details = getDetails(feature, title);
-        listener.onFetchSuccess(place, details);
+        callbackHandler.handleSuccess(response, listener);
       }
 
       @Override public void onFailure(Call<Result> call, Throwable t) {
-        listener.onFetchFailure();
+        callbackHandler.handleFailure(listener);
       }
     });
-  }
-
-  //TODO: fill in missing values
-  private Place getFetchedPlace(Feature feature) {
-    final CharSequence address = feature.properties.label;
-    final CharSequence attributions = "";
-    final String id = feature.properties.id;
-    final LatLng latLng = new LatLng(feature.geometry.coordinates.get(1),
-        feature.geometry.coordinates.get(0));
-    final Locale locale = Locale.US;
-    final CharSequence name = feature.properties.name;
-    final CharSequence phoneNumber = "";
-    final List<Integer> placeTypes = new ArrayList<>();
-    final int priceLevel = 0;
-    final float rating = 0;
-    final LatLngBounds viewport = new LatLngBounds(latLng, latLng);
-    final Uri websiteUri = new Uri.Builder().build();
-    return new PlaceImpl.Builder()
-        .setAddress(address)
-        .setAttributions(attributions)
-        .setId(id)
-        .setLatLng(latLng)
-        .setLocale(locale)
-        .setName(name)
-        .setPhoneNumber(phoneNumber)
-        .setPlaceTypes(placeTypes)
-        .setPriceLevel(priceLevel)
-        .setRating(rating)
-        .setViewPort(viewport)
-        .setWebsiteUri(websiteUri)
-        .build();
-  }
-
-  private String getDetails(Feature feature, String title) {
-    String label = feature.properties.label;
-    label = label.replace(title + ",", "").trim();
-    return title + "\n" + label;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -4,7 +4,6 @@ import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.api.Status;
 import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.pelias.BoundingBox;
-import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.PeliasLocationProvider;
 import com.mapzen.pelias.SuggestFilter;
 import com.mapzen.pelias.gson.Result;
@@ -67,10 +66,26 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
       setContentView(R.layout.place_autocomplete_activity_overlay);
     }
 
+    MapzenSearch mapzenSearch = new MapzenSearch(this);
+    mapzenSearch.getPelias().setDebug(true);
+    mapzenSearch.setLocationProvider(new PeliasLocationProvider() {
+      @Override public double getLat() {
+        return presenter.getLat();
+      }
+
+      @Override public double getLon() {
+        return presenter.getLon();
+      }
+
+      @Override public BoundingBox getBoundingBox() {
+        return presenter.getBoundingBox();
+      }
+    });
+
     // TODO inject
-    Pelias pelias = new Pelias();
     PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
-    PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher(pelias, callbackHandler);
+    PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher(mapzenSearch.getPelias(),
+        callbackHandler);
     OnPlaceDetailsFetchedListener detailFetchListener = new AutocompleteDetailFetchListener(this);
     FilterMapper filterMapper = new PeliasFilterMapper();
     presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
@@ -115,22 +130,6 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
       getSupportActionBar().setCustomView(peliasSearchView, lp);
       getSupportActionBar().setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
     }
-
-    MapzenSearch mapzenSearch = new MapzenSearch(this);
-    mapzenSearch.getPelias().setDebug(true);
-    mapzenSearch.setLocationProvider(new PeliasLocationProvider() {
-      @Override public double getLat() {
-        return presenter.getLat();
-      }
-
-      @Override public double getLon() {
-        return presenter.getLon();
-      }
-
-      @Override public BoundingBox getBoundingBox() {
-        return presenter.getBoundingBox();
-      }
-    });
 
     peliasSearchView.setAutoCompleteListView(listView);
     peliasSearchView.setPelias(mapzenSearch.getPelias());

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -4,6 +4,7 @@ import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.api.Status;
 import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.pelias.BoundingBox;
+import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.PeliasLocationProvider;
 import com.mapzen.pelias.SuggestFilter;
 import com.mapzen.pelias.gson.Result;
@@ -67,7 +68,9 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     }
 
     // TODO inject
-    PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher();
+    Pelias pelias = new Pelias();
+    PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
+    PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher(pelias, callbackHandler);
     OnPlaceDetailsFetchedListener detailFetchListener = new AutocompleteDetailFetchListener(this);
     FilterMapper filterMapper = new PeliasFilterMapper();
     presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
@@ -116,7 +119,6 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     MapzenSearch mapzenSearch = new MapzenSearch(this);
     mapzenSearch.getPelias().setDebug(true);
     mapzenSearch.setLocationProvider(new PeliasLocationProvider() {
-
       @Override public double getLat() {
         return presenter.getLat();
       }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompletePresenter.java
@@ -18,13 +18,13 @@ import retrofit2.Response;
  */
 class PlaceAutocompletePresenter {
   private static final String TAG = "MapzenPlaces";
-  private static final double BOUNDS_RADIUS = 0.02;
   private static final double LAT_DEFAULT = 0.0;
   private static final double LON_DEFAULT = 0.0;
 
   private final PlaceDetailFetcher detailFetcher;
   private final OnPlaceDetailsFetchedListener detailFetchListener;
   private final FilterMapper filterMapper;
+  private final PointToBoundsConverter pointConverter;
   private LatLngBounds bounds;
   private AutocompleteFilter filter;
   private LostApiClient client;
@@ -37,6 +37,7 @@ class PlaceAutocompletePresenter {
     this.detailFetcher = detailFetcher;
     this.detailFetchListener = detailFetchListener;
     this.filterMapper = filterMapper;
+    this.pointConverter = new PointToBoundsConverter();
   }
 
   void setBounds(LatLngBounds bounds) {
@@ -86,11 +87,7 @@ class PlaceAutocompletePresenter {
         }
       }
       if (location != null) {
-        double minLat = location.getLatitude() - BOUNDS_RADIUS;
-        double minLon = location.getLongitude() - BOUNDS_RADIUS;
-        double maxLat = location.getLatitude() + BOUNDS_RADIUS;
-        double maxLon = location.getLongitude() + BOUNDS_RADIUS;
-        return new BoundingBox(minLat, minLon, maxLat, maxLon);
+        return pointConverter.boundingBoxFromPoint(location.getLatitude(), location.getLongitude());
       }
       return new BoundingBox(LAT_DEFAULT, LON_DEFAULT, LAT_DEFAULT, LON_DEFAULT);
     }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceImpl.java
@@ -219,10 +219,13 @@ public class PlaceImpl implements Place, Parcelable {
 
   /**
    * Returns the attributions to be shown to the user if data from the Place is used.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   @Override public CharSequence getAttributions() {
-    return attributions;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   /**
@@ -259,10 +262,13 @@ public class PlaceImpl implements Place, Parcelable {
 
   /**
    * Returns the place's phone number in international format.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   @Override public CharSequence getPhoneNumber() {
-    return phoneNumber;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   /**
@@ -275,18 +281,24 @@ public class PlaceImpl implements Place, Parcelable {
 
   /**
    * Returns the price level for this place on a scale from 0 (cheapest) to 4.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   @Override public int getPriceLevel() {
-    return priceLevel;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   /**
    * Returns the place's rating, from 1.0 to 5.0, based on aggregated user reviews.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   @Override public float getRating() {
-    return rating;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   /**
@@ -299,6 +311,9 @@ public class PlaceImpl implements Place, Parcelable {
 
   /**
    * Returns website uri for this place.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @return
    */
   @Override public Uri getWebsiteUri() {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceImpl.java
@@ -317,7 +317,7 @@ public class PlaceImpl implements Place, Parcelable {
    * @return
    */
   @Override public Uri getWebsiteUri() {
-    return websiteUri;
+    throw new UnsupportedOperationException("Not yet implemented");
   }
 
   public static final Parcelable.Creator<Place> CREATOR

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -4,7 +4,7 @@ import com.mapzen.android.graphics.LabelPickListener;
 import com.mapzen.android.graphics.MapView;
 import com.mapzen.android.graphics.MapzenMap;
 import com.mapzen.android.graphics.OnMapReadyCallback;
-import com.mapzen.pelias.Pelias;
+import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
@@ -47,9 +47,10 @@ public class PlacePickerActivity extends Activity implements
     autocompleteView.setActivity(this);
 
     //TODO inject
-    Pelias pelias = new Pelias();
+    MapzenSearch mapzenSearch = new MapzenSearch(this);
     PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
-    presenter = new PlacePickerPresenterImpl(new PeliasPlaceDetailFetcher(pelias, callbackHandler));
+    presenter = new PlacePickerPresenterImpl(new PeliasPlaceDetailFetcher(mapzenSearch.getPelias(),
+        callbackHandler));
     presenter.setController(this);
 
     mapView = (MapView) findViewById(R.id.mz_map_view);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -4,6 +4,7 @@ import com.mapzen.android.graphics.LabelPickListener;
 import com.mapzen.android.graphics.MapView;
 import com.mapzen.android.graphics.MapzenMap;
 import com.mapzen.android.graphics.OnMapReadyCallback;
+import com.mapzen.pelias.Pelias;
 import com.mapzen.places.api.LatLng;
 import com.mapzen.places.api.LatLngBounds;
 import com.mapzen.places.api.Place;
@@ -46,7 +47,9 @@ public class PlacePickerActivity extends Activity implements
     autocompleteView.setActivity(this);
 
     //TODO inject
-    presenter = new PlacePickerPresenterImpl(new PeliasPlaceDetailFetcher());
+    Pelias pelias = new Pelias();
+    PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
+    presenter = new PlacePickerPresenterImpl(new PeliasPlaceDetailFetcher(pelias, callbackHandler));
     presenter.setController(this);
 
     mapView = (MapView) findViewById(R.id.mz_map_view);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PointToBoundsConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PointToBoundsConverter.java
@@ -1,0 +1,42 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.BoundingBox;
+import com.mapzen.places.api.LatLng;
+import com.mapzen.places.api.LatLngBounds;
+
+/**
+ * Constructs a {@link LatLngBounds} given a {@link LatLng}.
+ */
+public class PointToBoundsConverter {
+
+  private static final double BOUNDS_RADIUS = 0.02;
+
+  /**
+   * Creates a bounding box with reasonable radius from the given point.
+   * @param point
+   * @return
+   */
+  public LatLngBounds boundsFromPoint(LatLng point) {
+    double minLat = point.getLatitude() - BOUNDS_RADIUS;
+    double minLon = point.getLongitude() - BOUNDS_RADIUS;
+    double maxLat = point.getLatitude() + BOUNDS_RADIUS;
+    double maxLon = point.getLongitude() + BOUNDS_RADIUS;
+    LatLng sw = new LatLng(minLat, minLon);
+    LatLng ne = new LatLng(maxLat, maxLon);
+    return new LatLngBounds(sw, ne);
+  }
+
+  /**
+   * Creates a bounding box with reasonable radius from the given point information.
+   * @param latitude
+   * @param longitude
+   * @return
+   */
+  public BoundingBox boundingBoxFromPoint(double latitude, double longitude) {
+    double minLat = latitude - BOUNDS_RADIUS;
+    double minLon = longitude - BOUNDS_RADIUS;
+    double maxLat = latitude + BOUNDS_RADIUS;
+    double maxLon = longitude + BOUNDS_RADIUS;
+    return new BoundingBox(minLat, minLon, maxLat, maxLon);
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlacePicker.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/ui/PlacePicker.java
@@ -19,6 +19,9 @@ public class PlacePicker {
 
   /**
    * Returns the place's attributions.
+   *
+   * Warning: this property is not yet implemented and will throw an
+   * {@link UnsupportedOperationException} if accessed
    * @param intent intent returned in {@link Activity#onActivityResult(int, int, Intent)}
    * @return
    */

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasCallbackHandlerTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasCallbackHandlerTest.java
@@ -1,0 +1,137 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.pelias.gson.Geometry;
+import com.mapzen.pelias.gson.Properties;
+import com.mapzen.pelias.gson.Result;
+import com.mapzen.places.api.Place;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import retrofit2.Response;
+
+public class PeliasCallbackHandlerTest {
+
+  PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
+
+  @Test
+  public void handleSuccess_titleFeatures_shouldCallListenerForMatchingTitle() throws Exception {
+    String title = "Place";
+    List<Feature> features = getTestFeatures("NotPlace", "Place");
+    TestDetailsListener listener = new TestDetailsListener();
+    callbackHandler.handleSuccess(title, features, listener);
+    assertThat(listener.place.getName()).isEqualTo(title);
+  }
+
+  @Test
+  public void handleSuccess_titleFeatures_shouldCreateCorrectDetails() throws Exception {
+    String title = "Place";
+    List<Feature> features = getTestFeatures("NotPlace", "", "Place", "Place, Label");
+    TestDetailsListener listener = new TestDetailsListener();
+    callbackHandler.handleSuccess(title, features, listener);
+    assertThat(listener.details).isEqualTo("Place\nLabel");
+  }
+
+  @Test
+  public void handleSuccess_response_shouldCallFetchSuccess() {
+    Response<Result> response = getTestResponse("Place", "OtherPlace");
+    TestDetailsListener listener = new TestDetailsListener();
+    callbackHandler.handleSuccess(response, listener);
+    assertThat(listener.place.getName()).isEqualTo("Place");
+  }
+
+  @Test
+  public void handleSuccess_response_shouldCallFetchSuccessWithCorrectDetails() {
+    Response<Result> response = getTestResponse("Place", "Place, Label", "OtherPlace", "");
+    TestDetailsListener listener = new TestDetailsListener();
+    callbackHandler.handleSuccess(response, listener);
+    assertThat(listener.details).isEqualTo("Place\nLabel");
+  }
+
+  @Test
+  public void handleSuccess_response_shouldCallFetchFailure() {
+    TestDetailsListener listener = new TestDetailsListener();
+    Place place = new PlaceImpl.Builder().build();
+    listener.place = place;
+    callbackHandler.handleSuccess(Response.<Result>success(null), listener);
+    assertThat(listener.place).isNull();
+    listener.place = place;
+    Result result = new Result();
+    callbackHandler.handleSuccess(Response.success(result), listener);
+    assertThat(listener.place).isNull();
+    listener.place = place;
+    result.setFeatures(new ArrayList<Feature>());
+    callbackHandler.handleSuccess(Response.success(result), listener);
+    assertThat(listener.place).isNull();
+  }
+
+  @Test
+  public void handleFailure_shouldCallListenerFetchFailure() {
+    TestDetailsListener listener = new TestDetailsListener();
+    Place place = new PlaceImpl.Builder().build();
+    listener.place = place;
+    callbackHandler.handleFailure(listener);
+    assertThat(listener.place).isNull();
+  }
+
+  class TestDetailsListener implements OnPlaceDetailsFetchedListener {
+
+    private Place place;
+    private String details;
+
+    @Override public void onFetchSuccess(Place place, String details) {
+      this.place = place;
+      this.details = details;
+    }
+
+    @Override public void onFetchFailure() {
+      this.place = null;
+      this.details = null;
+    }
+  }
+
+  private List<Feature> getTestFeatures(String name1, String details1, String name2,
+      String details2) {
+    List<Feature> features = new ArrayList<>();
+    features.add(getTestFeature(name1, details1));
+    features.add(getTestFeature(name2, details2));
+    return features;
+  }
+
+  private List<Feature> getTestFeatures(String name1, String name2) {
+    List<Feature> features = new ArrayList<>();
+    features.add(getTestFeature(name1, ""));
+    features.add(getTestFeature(name2, ""));
+    return features;
+  }
+
+  private Feature getTestFeature(String name, String label) {
+    Feature feature = new Feature();
+    feature.properties = new Properties();
+    feature.properties.name = name;
+    feature.properties.label = label;
+    feature.properties.layer = "venue";
+    feature.geometry = new Geometry();
+    List<Double> coords = new ArrayList<>();
+    coords.add(0.0);
+    coords.add(0.0);
+    feature.geometry.coordinates = coords;
+    return feature;
+  }
+
+  private Response<Result> getTestResponse(String name1, String name2) {
+    return getTestResponse(name1, "", name2, "");
+  }
+
+  private Response<Result> getTestResponse(String name1, String details1, String name2,
+      String details2) {
+    Result result = new Result();
+    result.setFeatures(getTestFeatures(name1, details1, name2, details2));
+    Response<Result> response = Response.success(result);
+    return response;
+  }
+}

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverterTest.java
@@ -23,11 +23,11 @@ public class PeliasFeatureToPlaceConverterTest {
     assertThat(place.getAddress()).isEqualTo("label");
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void getFetchedPlace_shouldNotHaveAttributions() throws Exception {
     Feature feature = getTestFeature();
     Place place = converter.getFetchedPlace(feature);
-    assertThat(place.getAttributions()).isNull();
+    place.getAttributions();
   }
 
   @Test
@@ -59,11 +59,11 @@ public class PeliasFeatureToPlaceConverterTest {
     assertThat(place.getName()).isEqualTo("name");
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void getFetchedPlace_shouldNotHavePhoneNumber() throws Exception {
     Feature feature = getTestFeature();
     Place place = converter.getFetchedPlace(feature);
-    assertThat(place.getPhoneNumber()).isNull();
+    place.getPhoneNumber();
   }
 
   @Test
@@ -74,18 +74,18 @@ public class PeliasFeatureToPlaceConverterTest {
     assertThat(place.getPlaceTypes()).contains(TYPE_ESTABLISHMENT);
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void getFetchedPlace_shouldNotHavePriceLevel() throws Exception {
     Feature feature = getTestFeature();
     Place place = converter.getFetchedPlace(feature);
-    assertThat(place.getPriceLevel()).isEqualTo(0);
+    place.getPriceLevel();
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void getFetchedPlace_shouldNotHaveRating() throws Exception {
     Feature feature = getTestFeature();
     Place place = converter.getFetchedPlace(feature);
-    assertThat(place.getRating()).isEqualTo(0);
+    place.getRating();
   }
 
   @Test
@@ -96,11 +96,11 @@ public class PeliasFeatureToPlaceConverterTest {
     assertThat(place.getViewport().getCenter().getLongitude()).isEqualTo(70.0);
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void getFetchedPlace_shouldNotHaveWebsiteUri() throws Exception {
     Feature feature = getTestFeature();
     Place place = converter.getFetchedPlace(feature);
-    assertThat(place.getWebsiteUri()).isNull();
+    place.getWebsiteUri();
   }
 
   private Feature getTestFeature() {

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureToPlaceConverterTest.java
@@ -1,0 +1,110 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.SimpleFeature;
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.places.api.Place;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static com.mapzen.places.api.Place.TYPE_ESTABLISHMENT;
+import static com.mapzen.places.api.Place.TYPE_POINT_OF_INTEREST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeliasFeatureToPlaceConverterTest {
+
+  PeliasFeatureToPlaceConverter converter = new PeliasFeatureToPlaceConverter();
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectAddress() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getAddress()).isEqualTo("label");
+  }
+
+  @Test
+  public void getFetchedPlace_shouldNotHaveAttributions() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getAttributions()).isNull();
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectId() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getId()).isEqualTo("id");
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectLatLng() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getLatLng().getLatitude()).isEqualTo(40.0);
+    assertThat(place.getLatLng().getLongitude()).isEqualTo(70.0);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectLocale() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getLocale()).isEqualTo(Locale.US);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectName() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getName()).isEqualTo("name");
+  }
+
+  @Test
+  public void getFetchedPlace_shouldNotHavePhoneNumber() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getPhoneNumber()).isNull();
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectPlaceTypes() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getPlaceTypes()).contains(TYPE_POINT_OF_INTEREST);
+    assertThat(place.getPlaceTypes()).contains(TYPE_ESTABLISHMENT);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldNotHavePriceLevel() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getPriceLevel()).isEqualTo(0);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldNotHaveRating() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getRating()).isEqualTo(0);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldHaveCorrectViewport() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getViewport().getCenter().getLatitude()).isEqualTo(40.0);
+    assertThat(place.getViewport().getCenter().getLongitude()).isEqualTo(70.0);
+  }
+
+  @Test
+  public void getFetchedPlace_shouldNotHaveWebsiteUri() throws Exception {
+    Feature feature = getTestFeature();
+    Place place = converter.getFetchedPlace(feature);
+    assertThat(place.getWebsiteUri()).isNull();
+  }
+
+  private Feature getTestFeature() {
+    return SimpleFeature.create("id", "gid", "name", "country", "co", "region", "reg", "county",
+        "localadmin", "locality", "neighborhood", 1.0, "label", "venue", 40.0, 70.0).toFeature();
+  }
+}

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverterTest.java
@@ -1,0 +1,118 @@
+package com.mapzen.places.api.internal;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.mapzen.places.api.Place.TYPE_ADMINISTRATIVE_AREA_LEVEL_1;
+import static com.mapzen.places.api.Place.TYPE_COUNTRY;
+import static com.mapzen.places.api.Place.TYPE_ESTABLISHMENT;
+import static com.mapzen.places.api.Place.TYPE_LOCALITY;
+import static com.mapzen.places.api.Place.TYPE_NEIGHBORHOOD;
+import static com.mapzen.places.api.Place.TYPE_POINT_OF_INTEREST;
+import static com.mapzen.places.api.Place.TYPE_POLITICAL;
+import static com.mapzen.places.api.Place.TYPE_ROUTE;
+import static com.mapzen.places.api.Place.TYPE_STREET_ADDRESS;
+import static com.mapzen.places.api.Place.TYPE_SUBLOCALITY;
+import static com.mapzen.places.api.Place.TYPE_SUBLOCALITY_LEVEL_1;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_ADDRESS;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_BOROUGH;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTRY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCALITY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_LOCAL_ADMIN;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_MACRO_COUNTY;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_MACRO_REGION;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_NEIGHBOURHOOD;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_REGION;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_STREET;
+import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_VENUE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PeliasLayerToPlaceTypeConverterTest {
+
+  PeliasLayerToPlaceTypeConverter converter = new PeliasLayerToPlaceTypeConverter();
+
+  @Test public void getPlaceTypes_shouldReturnCorrectLocalityTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_LOCALITY);
+    assertThat(types).contains(TYPE_LOCALITY);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectCountryTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_COUNTRY);
+    assertThat(types).contains(TYPE_COUNTRY);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectVenueTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_VENUE);
+    assertThat(types).contains(TYPE_POINT_OF_INTEREST);
+    assertThat(types).contains(TYPE_ESTABLISHMENT);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectAddressTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_ADDRESS);
+    assertThat(types).contains(TYPE_STREET_ADDRESS);
+    assertThat(types).hasSize(1);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectMacroCountyTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_MACRO_COUNTY);
+    assertThat(types).contains(TYPE_LOCALITY);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectCountyTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_COUNTY);
+    assertThat(types).contains(TYPE_LOCALITY);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectLocalAdminTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_LOCAL_ADMIN);
+    assertThat(types).contains(TYPE_LOCALITY);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectBoroughTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_BOROUGH);
+    assertThat(types).contains(TYPE_SUBLOCALITY);
+    assertThat(types).contains(TYPE_SUBLOCALITY_LEVEL_1);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(3);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectNeighborhoodTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_NEIGHBOURHOOD);
+    assertThat(types).contains(TYPE_NEIGHBORHOOD);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectStreetTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_STREET);
+    assertThat(types).contains(TYPE_ROUTE);
+    assertThat(types).hasSize(1);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectRegionTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_REGION);
+    assertThat(types).contains(TYPE_ADMINISTRATIVE_AREA_LEVEL_1);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+
+  @Test public void getPlaceTypes_shouldReturnCorrectMacroRegionTypes() {
+    List<Integer> types = converter.getPlaceTypes(PELIAS_LAYER_MACRO_REGION);
+    assertThat(types).contains(TYPE_ADMINISTRATIVE_AREA_LEVEL_1);
+    assertThat(types).contains(TYPE_POLITICAL);
+    assertThat(types).hasSize(2);
+  }
+}

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
@@ -1,0 +1,44 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.Pelias;
+import com.mapzen.tangram.LngLat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import retrofit2.Callback;
+
+public class PeliasPlaceDetailFetcherTest {
+
+  Pelias pelias;
+  PeliasPlaceDetailFetcher fetcher;
+
+  @Before
+  public void setup() {
+    pelias = mock(Pelias.class);
+    PeliasCallbackHandler callbackHandler = mock(PeliasCallbackHandler.class);
+    fetcher = new PeliasPlaceDetailFetcher(pelias, callbackHandler);
+  }
+
+  @Test
+  public void fetchDetails_coords_shouldCallPelias() throws Exception {
+    LngLat coords = new LngLat(1, 2);
+    Map props = new HashMap();
+    fetcher.fetchDetails(coords, props, null);
+    verify(pelias).reverse(eq(coords.latitude), eq(coords.longitude), any(Callback.class));
+  }
+
+  @Test
+  public void fetchDetails_gid_shouldCallPelias() throws Exception {
+    String gid = "123";
+    fetcher.fetchDetails(gid, null);
+    verify(pelias).place(eq(gid), any(Callback.class));
+  }
+}

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PointToBoundsConverterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PointToBoundsConverterTest.java
@@ -1,0 +1,33 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.pelias.BoundingBox;
+import com.mapzen.places.api.LatLng;
+import com.mapzen.places.api.LatLngBounds;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PointToBoundsConverterTest {
+
+  private PointToBoundsConverter pointConverter = new PointToBoundsConverter();
+
+  @Test public void boundsFromPoint_shouldCreateCorrectBounds() throws Exception {
+    LatLng point = new LatLng(40.0, 70.0);
+    LatLngBounds bounds = pointConverter.boundsFromPoint(point);
+    assertThat(bounds.getCenter().getLatitude()).isEqualTo(40.0);
+    assertThat(bounds.getCenter().getLongitude()).isEqualTo(70.0);
+    assertThat(bounds.getSouthwest().getLatitude()).isEqualTo(39.98);
+    assertThat(bounds.getSouthwest().getLongitude()).isEqualTo(69.98);
+    assertThat(bounds.getNortheast().getLatitude()).isEqualTo(40.02);
+    assertThat(bounds.getNortheast().getLongitude()).isEqualTo(70.02);
+  }
+
+  @Test public void boundingBoxFromPoint_shouldCreateCorrectBounds() throws Exception {
+    BoundingBox bounds = pointConverter.boundingBoxFromPoint(40.0, 70.0);
+    assertThat(bounds.getMinLat()).isEqualTo(39.98);
+    assertThat(bounds.getMinLon()).isEqualTo(69.98);
+    assertThat(bounds.getMaxLat()).isEqualTo(40.02);
+    assertThat(bounds.getMaxLon()).isEqualTo(70.02);
+  }
+}

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
@@ -63,9 +63,6 @@ public class PlacePickerDemoActivity extends AppCompatActivity {
       placeName.setText(place.getName());
       placeAddress.setText(place.getAddress());
 
-      CharSequence attributions = PlacePicker.getAttributions(data);
-      placeAttribution.setText(attributions);
-
       LatLngBounds bounds = PlacePicker.getLatLngBounds(data);
       placeBounds.setText("SW lat:" + bounds.getSouthwest().getLatitude() + "\nSW lng:" +
           bounds.getSouthwest().getLongitude() + "\nNE lat:" + bounds.getNortheast().getLatitude() +


### PR DESCRIPTION
### Overview
This adds support for mapping `Pelias` layer strings returned from the server to `Place#placeType` ints expected by developers. It also refactors (and adds tests for) some of the `Place` fetch-related classes. [place-type-tests.txt](https://github.com/mapzen/android/files/733576/place-type-tests.txt) lists the `Pelias` http request I made, the name of the corresponding `GooglePlace` I selected, and the values I observed that place object to have. 

### Proposed Changes
- Adds `PeliasLayerConsts` to represent all possible layers that the server can return
- Refactors `PeliasFilterMapper`to use these layer values
- Add supported place types to `Place` interface
- Adds `PeliasLayerToPlaceTypeConverter` to handle converting layers returned by server into recognized `Place` type values. Adds test coverage for this class
- Extracts handling of successful/failed `Pelias` requests out of `PeliasPlaceDetailFetcher` and into new `PeliasCallbackHandler` class. Adds test coverage for this class
- Extracts conversion of `Pelias` `Feature` objects into `Place` objects out of `PeliasPlaceDetailFetcher` and into new `PeliasFeatureToPlaceConverter` class. Adds test coverage for this class
- Adds test coverage for `PeliasPlaceDetailFetcher`

Closes #251 