### PR TITLE
Fixed Bubble Wrap style yaml file path.

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/model/BubbleWrapStyle.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BubbleWrapStyle.java
@@ -9,6 +9,6 @@ public class BubbleWrapStyle extends MapStyle {
    * Creates a new instance.
    */
   public BubbleWrapStyle() {
-    super("styles/bubble-wrap/bubble-wrap.yaml");
+    super("styles/bubble-wrap/bubble-wrap-style.yaml");
   }
 }


### PR DESCRIPTION
### Overview
As in Bubble Wrap style repository name for yaml file was changed to `bubble-wrap-style.yaml` it didn't loaded in sample app. 

### Proposed Changes
Change string parameter in constructor of class `BubbleWrapStyle.java` to "styles/bubble-wrap/bubble-wrap-style.yaml".