### PR TITLE
Improve build performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ subprojects {
       showStandardStreams true
     }
   }
+
+  tasks.withType(Javadoc).all { enabled = false }
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,21 @@ allprojects {
   }
 }
 
+subprojects {
+  task verify(dependsOn: ['compileDebugSources',
+                          'testDebugUnitTest',
+                          'checkstyle',
+                          'lint'])
+
+  tasks.withType(Test) {
+    testLogging {
+      exceptionFormat "full"
+      events "skipped", "passed", "failed"
+      showStandardStreams true
+    }
+  }
+}
+
 task clean(type: Delete) {
   delete rootProject.buildDir
 }

--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,6 @@ dependencies:
     - echo y | android update sdk --all --no-ui --force --filter "build-tools-25.0.2"
     - echo y | android update sdk --all --no-ui --force --filter "android-25"
     - echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"
-    - sudo apt-get update; sudo apt-get install s3cmd
-    - printf "[default]\naccess_key = $S3_ACCESS_KEY\n secret_key = $S3_SECRET_KEY" > ~/.s3cfg
 
 test:
   override:
@@ -29,8 +27,7 @@ deployment:
     branch: master
     commands:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
-      - scripts/deploy-android-sdk-sample-app.sh
-      - scripts/deploy-places-api-sample-app.sh
       - ./gradlew aarSize countReleaseDexMethods permissions mapzen-android-sdk:dependencies --configuration compile
+      - scripts/deploy-samples.sh
       - pip install 'Circle-Tickler == 1.0.1'
       - tickle-circle mapzen documentation master $CIRCLE_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ machine:
   python:
     version: 2.7.10
   environment:
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     TEST_FLAGS: "--configure-on-demand -PdisablePreDex"
 
 checkout:

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ dependencies:
     - echo y | android update sdk --all --no-ui --force --filter "build-tools-25.0.2"
     - echo y | android update sdk --all --no-ui --force --filter "android-25"
     - echo y | android update sdk --all --no-ui --force --filter "extra-android-m2repository"
+    - ./gradlew :core:install
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -29,5 +29,4 @@ deployment:
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - ./gradlew aarSize countReleaseDexMethods permissions mapzen-android-sdk:dependencies --configuration compile
       - scripts/deploy-samples.sh
-      - pip install 'Circle-Tickler == 1.0.1'
-      - tickle-circle mapzen documentation master $CIRCLE_TOKEN
+      - scripts/publish-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
 
 deployment:
   master:
-    branch: master
+    branch: /^(?!master).*$/
     commands:
       - ./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
       - ./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify --configure-on-demand
+    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify --configure-on-demand -PdisablePreDex
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     version: oraclejdk8
   python:
     version: 2.7.10
+  environment:
+    TEST_FLAGS: "--configure-on-demand -PdisablePreDex"
 
 checkout:
   post:
@@ -19,7 +21,8 @@ dependencies:
 
 test:
   override:
-    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify --configure-on-demand -PdisablePreDex
+    - case $CIRCLE_NODE_INDEX in 0) ./gradlew :core:verify $TEST_FLAGS ;; 1) ./gradlew :mapzen-android-sdk:verify $TEST_FLAGS ;; 2) ./gradlew :mapzen-places-api:verify $TEST_FLAGS ;; esac:
+        parallel: true
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 general:
-  - "samples/mapzen-android-sdk-sample/build/outputs/apk"
-  - "samples/mapzen-places-api-sample/build/outputs/apk"
+  artifacts:
+    - "samples/mapzen-android-sdk-sample/build/outputs/apk"
+    - "samples/mapzen-places-api-sample/build/outputs/apk"
 
 machine:
   java:

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
 
 test:
   override:
-    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify
+    - ./gradlew clean :core:install :core:verify :mapzen-android-sdk:verify :mapzen-places-api:verify --configure-on-demand
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ test:
 
 deployment:
   master:
-    branch: /^(?!master).*$/
+    branch: master
     commands:
       - ./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
       - ./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,9 @@ test:
   override:
     - case $CIRCLE_NODE_INDEX in 0) ./gradlew :core:verify $TEST_FLAGS ;; 1) ./gradlew :mapzen-android-sdk:verify $TEST_FLAGS ;; 2) ./gradlew :mapzen-places-api:verify $TEST_FLAGS ;; esac:
         parallel: true
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
 deployment:
   master:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+general:
+  - /home/ubuntu/mapzen-android-sdk/samples/mapzen-android-sdk-sample/build/outputs/apk/
+  - /home/ubuntu/mapzen-android-sdk/samples/mapzen-places-api-sample/build/outputs/apk/
+
 machine:
   java:
     version: oraclejdk8
@@ -30,6 +34,8 @@ deployment:
   master:
     branch: master
     commands:
+      - ./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
+      - ./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - ./gradlew aarSize countReleaseDexMethods permissions mapzen-android-sdk:dependencies --configuration compile
       - scripts/deploy-samples.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 general:
-  - /home/ubuntu/mapzen-android-sdk/samples/mapzen-android-sdk-sample/build/outputs/apk/
-  - /home/ubuntu/mapzen-android-sdk/samples/mapzen-places-api-sample/build/outputs/apk/
+  - "samples/mapzen-android-sdk-sample/build/outputs/apk"
+  - "samples/mapzen-places-api-sample/build/outputs/apk"
 
 machine:
   java:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     classpath 'net.researchgate:gradle-release:2.4.0'
   }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -60,14 +60,6 @@ android {
   }
 }
 
-tasks.withType(Test) {
-  testLogging {
-    exceptionFormat "full"
-    events "started", "skipped", "passed", "failed"
-    showStandardStreams true
-  }
-}
-
 task checkstyle(type: Checkstyle) {
   configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
   source 'src'
@@ -76,11 +68,6 @@ task checkstyle(type: Checkstyle) {
 
   classpath = files()
 }
-
-task verify(dependsOn: ['compileDebugSources',
-                        'test',
-                        'checkstyle',
-                        'lint'])
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -58,14 +58,6 @@ android {
   }
 }
 
-tasks.withType(Test) {
-  testLogging {
-    exceptionFormat "full"
-    events "started", "skipped", "passed", "failed"
-    showStandardStreams true
-  }
-}
-
 task checkstyle(type: Checkstyle) {
   configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
   source 'src'
@@ -74,11 +66,6 @@ task checkstyle(type: Checkstyle) {
 
   classpath = files()
 }
-
-task verify(dependsOn: ['compileDebugSources',
-                        'test',
-                        'checkstyle',
-                        'lint'])
 
 dependencies {
   compile 'com.mapzen:mapzen-core:1.3.0-SNAPSHOT'

--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     classpath 'net.researchgate:gradle-release:2.4.0'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
   }

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -55,14 +55,6 @@ android {
   }
 }
 
-tasks.withType(Test) {
-  testLogging {
-    exceptionFormat "full"
-    events "started", "skipped", "passed", "failed"
-    showStandardStreams true
-  }
-}
-
 task checkstyle(type: Checkstyle) {
   configFile file("${project.rootDir}/config/checkstyle/checkstyle.xml")
   source 'src'
@@ -71,11 +63,6 @@ task checkstyle(type: Checkstyle) {
 
   classpath = files()
 }
-
-task verify(dependsOn: ['compileDebugSources',
-                        'test',
-                        'checkstyle',
-                        'lint'])
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     classpath 'net.researchgate:gradle-release:2.4.0'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
   }

--- a/samples/mapzen-android-sdk-sample/build.gradle
+++ b/samples/mapzen-android-sdk-sample/build.gradle
@@ -36,11 +36,6 @@ task checkstyle(type: Checkstyle) {
   classpath = files()
 }
 
-task verify(dependsOn: ['compileDebugSources',
-                        'test',
-                        'checkstyle',
-                        'lint'])
-
 dependencies {
   compile(project(':mapzen-android-sdk')) {
     transitive = true;

--- a/scripts/deploy-android-sdk-sample-app.sh
+++ b/scripts/deploy-android-sdk-sample-app.sh
@@ -2,6 +2,6 @@
 #
 # Builds mapzen android sdk sample app and uploads APK to s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/.
 
-./gradlew assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
+./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-latest.apk
 s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/mapzen-android-sdk-sample-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy-android-sdk-sample-app.sh
+++ b/scripts/deploy-android-sdk-sample-app.sh
@@ -2,6 +2,5 @@
 #
 # Builds mapzen android sdk sample app and uploads APK to s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/.
 
-./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-latest.apk
 s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/mapzen-android-sdk-sample-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy-places-api-sample-app.sh
+++ b/scripts/deploy-places-api-sample-app.sh
@@ -2,6 +2,6 @@
 #
 # Builds mapzen places api sample app and uploads APK to s3://android.mapzen.com/mapzen-places-api-sample-snapshots/.
 
-./gradlew assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
+./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/mapzen-places-api-sample-latest.apk
 s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/places-api-sample-snapshots/mapzen-places-api-sample-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy-places-api-sample-app.sh
+++ b/scripts/deploy-places-api-sample-app.sh
@@ -2,6 +2,5 @@
 #
 # Builds mapzen places api sample app and uploads APK to s3://android.mapzen.com/mapzen-places-api-sample-snapshots/.
 
-./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/mapzen-places-api-sample-latest.apk
 s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/places-api-sample-snapshots/mapzen-places-api-sample-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy-samples.sh
+++ b/scripts/deploy-samples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Builds and uploads sample apps to S3 on release build only.
+
+if [[ ${PERFORM_RELEASE} ]]
+  then
+    sudo apt-get update; sudo apt-get install s3cmd
+    printf "[default]\naccess_key = $S3_ACCESS_KEY\n secret_key = $S3_SECRET_KEY" > ~/.s3cfg
+    scripts/deploy-android-sdk-sample-app.sh
+    scripts/deploy-places-api-sample-app.sh
+fi

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Triggers mapzen docs build to publish to https://mapzen.com/documentation/.
+
+if [[ ${PERFORM_RELEASE} ]]
+  then
+    pip install 'Circle-Tickler == 1.0.1'
+    tickle-circle mapzen documentation master $CIRCLE_TOKEN
+fi


### PR DESCRIPTION
### Overview

Improves build performance on Circle CI. Reduces build time by 1-2 min for dev builds and 4-5 min for full master builds (includes sample apps). Prevents OOM errors on Circle CI container.

### Proposed Changes

* Updates Gradle options to limit memory use and dump heap on OOM error.
* Runs unit tests against debug build only and reduces console output.
* Upgrades Gradle to version 3.3 and gradle-android-maven-plugin to version 1.5.
* Adds `--configure-on-demand` and `-PdisablePreDex` options to circle.yml.
* Runs tests for each module in parallel using 3 Circle CI containers instead of 1.
* Archives sample app APKs on Circle CI and deploys to AWS on release build only.
* Publishes documentation to Mapzen website on release build only.
* Installs `core` module to local .m2 repo before resolving dependencies.
* Disables Javadoc tasks for all modules. May need to be re-enabled for production AARs.

Fixes #297 