### PR TITLE
Updates place picker fetch details logic

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDetailFetcher.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDetailFetcher.java
@@ -1,7 +1,5 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.tangram.LngLat;
-
 import java.util.Map;
 
 /**
@@ -9,21 +7,26 @@ import java.util.Map;
  */
 interface PlaceDetailFetcher {
 
-  /**
-   * Called when details for a place selected from the map should be retrieved. Currently, Pelias is
-   * used as the underlying data source but this will soon be migrated to WOF.
-   * @param coordinates
-   * @param properties
-   * @param listener
-   */
-  void fetchDetails(LngLat coordinates, Map<String, String> properties,
-      OnPlaceDetailsFetchedListener listener);
+  String PROP_ID = "id";
+  String PROP_AREA = "area";
+
+  String PELIAS_GID_BASE = "openstreetmap:venue:";
+  String PELIAS_GID_NODE = "node:";
+  String PELIAS_GID_WAY = "way:";
 
   /**
-   * Called when details for a place selected from autocomplete should be retrieved. Currently,
-   * Pelias is used as the underlying data source but this will soon be migrated to WOF.
-   * @param gid
-   * @param listener
+   * Called when details for a place selected from the map should be retrieved.
+   *
+   * @param properties map properties for the given feature.
+   * @param listener callback to be notified of success or failure.
+   */
+  void fetchDetails(Map<String, String> properties, OnPlaceDetailsFetchedListener listener);
+
+  /**
+   * Called when details for a place selected from autocomplete should be retrieved.
+   *
+   * @param gid global ID for the given feature
+   * @param listener callback to be notified of success or failure.
    */
   void fetchDetails(String gid, OnPlaceDetailsFetchedListener listener);
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -66,7 +66,7 @@ public class PlacePickerActivity extends Activity implements
     if (result == null) {
       return;
     }
-    presenter.onLabelPicked(result.getCoordinates(), result.getProperties());
+    presenter.onLabelPicked(result.getProperties());
   }
 
   @Override public void showDialog(String id, String title) {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
@@ -1,7 +1,6 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.Place;
-import com.mapzen.tangram.LngLat;
 
 import java.util.Map;
 
@@ -20,7 +19,7 @@ interface PlacePickerPresenter {
    * Called when a POI on the map has been selected by the user.
    * @param properties
    */
-  void onLabelPicked(LngLat coordinates, Map<String, String> properties);
+  void onLabelPicked(Map<String, String> properties);
 
   /**
    * Called when a user confirms their selection in the alert dialog that is displayed after

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -1,7 +1,8 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.Place;
-import com.mapzen.tangram.LngLat;
+
+import android.util.Log;
 
 import java.util.Map;
 
@@ -9,9 +10,10 @@ import java.util.Map;
  * Implementation of {@link PlacePickerPresenter}.
  */
 class PlacePickerPresenterImpl implements PlacePickerPresenter {
+  private static final String TAG = "PlacePicker";
 
-  public static final String PROPERTY_ID = "id";
-  public static final String PROPERTY_NAME = "name";
+  private static final String PROPERTY_ID = "id";
+  static final String PROPERTY_NAME = "name";
 
   PlacePickerViewController controller;
   PlaceDetailFetcher detailFetcher;
@@ -20,7 +22,7 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
   /**
    * Construct a new object.
    */
-  public PlacePickerPresenterImpl(PlaceDetailFetcher fetcher) {
+  PlacePickerPresenterImpl(PlaceDetailFetcher fetcher) {
     detailFetcher = fetcher;
   }
 
@@ -28,22 +30,20 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
     this.controller = controller;
   }
 
-  @Override public void onLabelPicked(LngLat coordinates, Map<String, String> properties) {
+  @Override public void onLabelPicked(Map<String, String> properties) {
     final String id = properties.get(PROPERTY_ID);
     final String title = properties.get(PROPERTY_NAME);
 
-    detailFetcher.fetchDetails(coordinates, properties,
-        new OnPlaceDetailsFetchedListener() {
-          @Override public void onFetchSuccess(Place place, String details) {
-            PlacePickerPresenterImpl.this.place = place;
-            controller.updateDialog(id, details);
-          }
+    detailFetcher.fetchDetails(properties, new OnPlaceDetailsFetchedListener() {
+      @Override public void onFetchSuccess(Place place, String details) {
+        PlacePickerPresenterImpl.this.place = place;
+        controller.updateDialog(id, details);
+      }
 
-          @Override public void onFetchFailure() {
-
-          }
-        }
-    );
+      @Override public void onFetchFailure() {
+        Log.e(TAG, "Unable to fetch details for place: " + id);
+      }
+    });
 
     controller.showDialog(id, title);
   }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -13,7 +13,7 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
   private static final String TAG = "PlacePicker";
 
   private static final String PROPERTY_ID = "id";
-  static final String PROPERTY_NAME = "name";
+  private static final String PROPERTY_NAME = "name";
 
   PlacePickerViewController controller;
   PlaceDetailFetcher detailFetcher;

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
@@ -51,6 +51,14 @@ public class PeliasPlaceDetailFetcherTest {
     verify(pelias).place(eq(PELIAS_GID_BASE + PELIAS_GID_WAY + "123"), any(Callback.class));
   }
 
+  @Test public void fetchDetails_props_shouldConstructGidWithWayIfHasAreaYes() throws Exception {
+    Map props = new HashMap();
+    props.put(PROP_ID, "123.000");
+    props.put(PROP_AREA, "yes");
+    fetcher.fetchDetails(props, null);
+    verify(pelias).place(eq(PELIAS_GID_BASE + PELIAS_GID_WAY + "123"), any(Callback.class));
+  }
+
   @Test public void fetchDetails_props_shouldConstructGidWithNodeIfNoArea() throws Exception {
     Map props = new HashMap();
     props.put(PROP_ID, "123.000");

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasPlaceDetailFetcherTest.java
@@ -1,7 +1,6 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.pelias.Pelias;
-import com.mapzen.tangram.LngLat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,7 +8,13 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.mapzen.places.api.internal.PlaceDetailFetcher.PELIAS_GID_BASE;
+import static com.mapzen.places.api.internal.PlaceDetailFetcher.PELIAS_GID_NODE;
+import static com.mapzen.places.api.internal.PlaceDetailFetcher.PELIAS_GID_WAY;
+import static com.mapzen.places.api.internal.PlaceDetailFetcher.PROP_AREA;
+import static com.mapzen.places.api.internal.PlaceDetailFetcher.PROP_ID;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -17,28 +22,39 @@ import retrofit2.Callback;
 
 public class PeliasPlaceDetailFetcherTest {
 
-  Pelias pelias;
-  PeliasPlaceDetailFetcher fetcher;
+  private Pelias pelias;
+  private PeliasPlaceDetailFetcher fetcher;
 
-  @Before
-  public void setup() {
+  @Before public void setup() {
     pelias = mock(Pelias.class);
     PeliasCallbackHandler callbackHandler = mock(PeliasCallbackHandler.class);
     fetcher = new PeliasPlaceDetailFetcher(pelias, callbackHandler);
   }
 
-  @Test
-  public void fetchDetails_coords_shouldCallPelias() throws Exception {
-    LngLat coords = new LngLat(1, 2);
+  @Test public void fetchDetails_props_shouldCallPelias() throws Exception {
     Map props = new HashMap();
-    fetcher.fetchDetails(coords, props, null);
-    verify(pelias).reverse(eq(coords.latitude), eq(coords.longitude), any(Callback.class));
+    fetcher.fetchDetails(props, null);
+    verify(pelias).place(anyString(), any(Callback.class));
   }
 
-  @Test
-  public void fetchDetails_gid_shouldCallPelias() throws Exception {
+  @Test public void fetchDetails_gid_shouldCallPelias() throws Exception {
     String gid = "123";
     fetcher.fetchDetails(gid, null);
     verify(pelias).place(eq(gid), any(Callback.class));
+  }
+
+  @Test public void fetchDetails_props_shouldConstructGidWithWayIfHasArea() throws Exception {
+    Map props = new HashMap();
+    props.put(PROP_ID, "123.000");
+    props.put(PROP_AREA, "456.000");
+    fetcher.fetchDetails(props, null);
+    verify(pelias).place(eq(PELIAS_GID_BASE + PELIAS_GID_WAY + "123"), any(Callback.class));
+  }
+
+  @Test public void fetchDetails_props_shouldConstructGidWithNodeIfNoArea() throws Exception {
+    Map props = new HashMap();
+    props.put(PROP_ID, "123.000");
+    fetcher.fetchDetails(props, null);
+    verify(pelias).place(eq(PELIAS_GID_BASE + PELIAS_GID_NODE + "123"), any(Callback.class));
   }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
@@ -1,7 +1,6 @@
 package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.Place;
-import com.mapzen.tangram.LngLat;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +23,7 @@ public class PlacePickerPresenterTest {
   @Test public void onLabelPicked_shouldShowDialog() {
     HashMap<String, String> properties = new HashMap<>();
     properties.put("name", "Hanjan");
-    presenter.onLabelPicked(new LngLat(0.0, 0.0), properties);
+    presenter.onLabelPicked(properties);
     assertThat(controller.dialogShown).isTrue();
     assertThat(controller.dialogTitle).isEqualTo("Hanjan");
   }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlaceDetailFetcher.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlaceDetailFetcher.java
@@ -1,18 +1,14 @@
 package com.mapzen.places.api.internal;
 
-import com.mapzen.tangram.LngLat;
-
 import java.util.Map;
 
 
-public class TestPlaceDetailFetcher implements PlaceDetailFetcher {
+class TestPlaceDetailFetcher implements PlaceDetailFetcher {
 
-  @Override public void fetchDetails(LngLat coordinates, Map<String, String> properties,
+  @Override public void fetchDetails(Map<String, String> properties,
       OnPlaceDetailsFetchedListener listener) {
-
   }
 
   @Override public void fetchDetails(String gid, OnPlaceDetailsFetchedListener listener) {
-
   }
 }


### PR DESCRIPTION
### Overview

Replaces reverse geocode and string match on title with a constructed Pelias gid and /place endpoint when a map POI is selected in the place picker widget.

### Proposed Changes

If tile properties contains an `area` for the selected POI then the Pelias gid is constructed using "openstreetmap:venue:**way**:[ID]" otherwise uses "openstreetmap:venue:**node**:[ID]" to fetch details from the /place endpoint.

Fixes #295 