### PR TITLE
Deploy release directly from Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,5 +40,10 @@ deployment:
       - ./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
       - ./gradlew uploadArchives -PsonatypeUsername=$SONATYPE_NEXUS_SNAPSHOTS_USERNAME -PsonatypePassword=$SONATYPE_NEXUS_SNAPSHOTS_PASSWORD
       - ./gradlew aarSize countReleaseDexMethods permissions mapzen-android-sdk:dependencies --configuration compile
+  release:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    owner: mapzen
+    commands:
+      - scripts/deploy-staging.sh
       - scripts/deploy-samples.sh
       - scripts/publish-docs.sh

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,8 +30,6 @@ release {
   newVersionCommitMessage = '[Gradle Release Plugin] - core new version commit:'
 }
 
-afterReleaseBuild.dependsOn uploadArchives
-
 android {
   compileSdkVersion 25
   buildToolsVersion '25.0.2'

--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -30,8 +30,6 @@ release {
   newVersionCommitMessage = '[Gradle Release Plugin] - mapzen-android-sdk new version commit:'
 }
 
-afterReleaseBuild.dependsOn uploadArchives
-
 android {
   compileSdkVersion 25
   buildToolsVersion '25.0.2'

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -29,8 +29,6 @@ release {
   newVersionCommitMessage = '[Gradle Release Plugin] - mapzen-places-api new version commit:'
 }
 
-afterReleaseBuild.dependsOn uploadArchives
-
 android {
   compileSdkVersion 25
   buildToolsVersion '25.0.2'

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -4,10 +4,14 @@ Steps to build a new release version AAR and deploy to [Maven Central](http://se
 
 ## 1. Build and deploy to staging repository
 
-Build release and deploy to the Sonatype staging repository.
+Run the gradle-release plugin to update version number, build locally, and push a new tag to GitHub.
 ```bash
 $ ./gradlew clean release --refresh-dependencies
 ```
+
+Wait for [Circle CI](https://circleci.com/gh/mapzen/android) to pick up the new tag, build and deploy the release artifacts to the Sonatype staging repository.
+
+There should be three (3) bundles deployed: `mapzen-core`, `mapzen-android-sdk`, and `mapzen-places-api`.
 
 ## 2. Promote release artifact
 

--- a/scripts/deploy-android-sdk-sample-app.sh
+++ b/scripts/deploy-android-sdk-sample-app.sh
@@ -2,5 +2,6 @@
 #
 # Builds mapzen android sdk sample app and uploads APK to s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/.
 
+./gradlew :samples_mapzen-android-sdk-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-latest.apk
-s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-snapshots/mapzen-android-sdk-sample-$CIRCLE_BUILD_NUM.apk
+s3cmd put samples/mapzen-android-sdk-sample/build/outputs/apk/samples_mapzen-android-sdk-sample-debug.apk s3://android.mapzen.com/mapzen-android-sdk-sample-releases/mapzen-android-sdk-sample-$CIRCLE_TAG.apk

--- a/scripts/deploy-places-api-sample-app.sh
+++ b/scripts/deploy-places-api-sample-app.sh
@@ -2,5 +2,6 @@
 #
 # Builds mapzen places api sample app and uploads APK to s3://android.mapzen.com/mapzen-places-api-sample-snapshots/.
 
+./gradlew :samples_mapzen-place-api-sample:assembleDebug -PmapzenApiKey=$MAPZEN_API_KEY
 s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/mapzen-places-api-sample-latest.apk
-s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/places-api-sample-snapshots/mapzen-places-api-sample-$CIRCLE_BUILD_NUM.apk
+s3cmd put samples/mapzen-places-api-sample/build/outputs/apk/samples_mapzen-places-api-sample-debug.apk s3://android.mapzen.com/places-api-sample-releases/mapzen-places-api-sample-$CIRCLE_TAG.apk

--- a/scripts/deploy-samples.sh
+++ b/scripts/deploy-samples.sh
@@ -2,10 +2,7 @@
 #
 # Builds and uploads sample apps to S3 on release build only.
 
-if [[ ${PERFORM_RELEASE} ]]
-  then
-    sudo apt-get update; sudo apt-get install s3cmd
-    printf "[default]\naccess_key = $S3_ACCESS_KEY\n secret_key = $S3_SECRET_KEY" > ~/.s3cfg
-    scripts/deploy-android-sdk-sample-app.sh
-    scripts/deploy-places-api-sample-app.sh
-fi
+sudo apt-get update; sudo apt-get install s3cmd
+printf "[default]\naccess_key = $S3_ACCESS_KEY\n secret_key = $S3_SECRET_KEY" > ~/.s3cfg
+scripts/deploy-android-sdk-sample-app.sh
+scripts/deploy-places-api-sample-app.sh

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Builds, signs, and uploads release AARs to https://oss.sonatype.org/#stagingRepositories.
+#
+
+echo -e "machine github.com\n  login $GITHUB_USERNAME\n  password $GITHUB_PASSWORD" >> ~/.netrc
+git clone https://github.com/mapzen/android-config.git
+./gradlew uploadArchives -PsonatypeUsername="$SONATYPE_USERNAME" \
+    -PsonatypePassword="$SONATYPE_PASSWORD" \
+    -Psigning.keyId="$SIGNING_KEY_ID" \
+    -Psigning.password="$SIGNING_PASSWORD" \
+    -Psigning.secretKeyRingFile="$SIGNING_SECRET_KEY_RING_FILE"

--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -2,8 +2,5 @@
 #
 # Triggers mapzen docs build to publish to https://mapzen.com/documentation/.
 
-if [[ ${PERFORM_RELEASE} ]]
-  then
-    pip install 'Circle-Tickler == 1.0.1'
-    tickle-circle mapzen documentation master $CIRCLE_TOKEN
-fi
+pip install 'Circle-Tickler == 1.0.1'
+tickle-circle mapzen documentation master $CIRCLE_TOKEN


### PR DESCRIPTION
### Overview

Updates build config to deploy release AARs directly to Maven Central from Circle CI when a new release tag is pushed to GitHub.

### Proposed Changes

* Adds `release` deployment config to `circle.yml`.
* Adds `deploy-staging.sh` to build, sign, and deploy release AARs to Sonatype staging repository.
* Deploys sample apps to s3 and triggers documentation build on release only.
* Removes `afterReleaseBuild.dependsOn uploadArchives` given we don't want to upload artifacts from the local build only when its run on Circle CI.