### PR TITLE
Use dynamic version property for core module dependency

### DIFF
--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -57,7 +57,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile 'com.mapzen:mapzen-core:1.3.0-rc1'
+  compile "com.mapzen:mapzen-core:$version"
   compile ('com.mapzen:on-the-road:1.2.0-rc1') {
     exclude group: 'com.squareup.retrofit2', module: 'converter-gson'
   }

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -55,7 +55,7 @@ task checkstyle(type: Checkstyle) {
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.mapzen:mapzen-core:1.3.0-rc1'
+  compile "com.mapzen:mapzen-core:$version"
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:1.7.1'


### PR DESCRIPTION
### Overview

Use dynamic `version` property when declaring core module dependency in sdk and places modules.

### Proposed Changes

Update `mapzen-android-sdk/build.gradle` and `mapzen-places-api/build.gradle` to use dynamic version number from `gradle.properties` when including `mapzen-core` dependency.