### PR TITLE
One more try using project dependency for core module

### DIFF
--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -57,7 +57,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile "com.mapzen:mapzen-core:$version"
+  compile project(':core')
   compile ('com.mapzen:on-the-road:1.2.0-rc1') {
     exclude group: 'com.squareup.retrofit2', module: 'converter-gson'
   }

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -54,8 +54,8 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
+  compile project(':core')
   compile 'com.android.support:appcompat-v7:25.1.0'
-  compile "com.mapzen:mapzen-core:$version"
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.assertj:assertj-core:1.7.1'


### PR DESCRIPTION
### Overview

Use a project dependency for `core` in the sdk and places modules.

### Proposed Changes

Replace core module remote dependency with project dependency in sdk and places modules. This will not replace needing to deploy the `mapzen-core` module to maven central but rather should make local development workflow simpler and resolve build issues on Circle CI when version number is updated.

Also transitive dependencies seem to get resolved correctly for the core module when a snapshot is deployed locally now that the `gradle-release` plugin config has been updated.