### PR TITLE
Disable location layer when place picker is paused or finished

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -57,6 +57,22 @@ public class PlacePickerActivity extends Activity implements
     mapView.getMapAsync(this);
   }
 
+  @Override protected void onPause() {
+    super.onPause();
+    presenter.onHideView();
+  }
+
+  @Override protected void onResume() {
+    super.onResume();
+    presenter.onShowView();
+  }
+
+  @Override public void setMyLocationEnabled(boolean enabled) {
+    if (map != null) {
+      map.setMyLocationEnabled(enabled);
+    }
+  }
+
   @Override public void onMapReady(MapzenMap mapzenMap) {
     map = mapzenMap;
     initializeMap();

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenter.java
@@ -32,4 +32,14 @@ interface PlacePickerPresenter {
    * @param place
    */
   void onAutocompletePlacePicked(Place place, String details);
+
+  /**
+   * Invoked when view is hidden (i.e. Activity is sent to background or finished).
+   */
+  void onHideView();
+
+  /**
+   * Invoked when view is shown (i.e. Activity is resumed).
+   */
+  void onShowView();
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -58,4 +58,12 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
     //TODO:dialog change location should bring back autocomplete ui
     //TODO:hide map ui and just have dialog visible
   }
+
+  @Override public void onHideView() {
+    controller.setMyLocationEnabled(false);
+  }
+
+  @Override public void onShowView() {
+    controller.setMyLocationEnabled(true);
+  }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerViewController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerViewController.java
@@ -27,4 +27,12 @@ interface PlacePickerViewController {
    * {@link PlacePickerActivity}.
    */
   void finishWithPlace(Place place);
+
+  /**
+   * Toggles the connection to the location services layer. Location services should be disabled
+   * when the place picker is not visible on the screen.
+   *
+   * @param enabled {@code true} to enable the location services layer, {@code false} to disable it.
+   */
+  void setMyLocationEnabled(boolean enabled);
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
@@ -38,4 +38,16 @@ public class PlacePickerPresenterTest {
     presenter.onAutocompletePlacePicked(place, "details");
     assertThat(controller.dialogShown).isTrue();
   }
+
+  @Test public void onHideView_shouldDisableLocationServices() throws Exception {
+    controller.myLocationEnabled = true;
+    presenter.onHideView();
+    assertThat(controller.myLocationEnabled).isFalse();
+  }
+
+  @Test public void onShowView_shouldEnableLocationServices() throws Exception {
+    controller.myLocationEnabled = false;
+    presenter.onShowView();
+    assertThat(controller.myLocationEnabled).isTrue();
+  }
 }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlacePickerController.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlacePickerController.java
@@ -2,11 +2,12 @@ package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.Place;
 
-public class TestPlacePickerController implements PlacePickerViewController {
+class TestPlacePickerController implements PlacePickerViewController {
 
-  public boolean dialogShown = false;
-  public String dialogTitle = null;
-  public boolean finished = false;
+  boolean dialogShown = false;
+  String dialogTitle = null;
+  boolean finished = false;
+  boolean myLocationEnabled = false;
 
   @Override public void showDialog(String id, String title) {
     dialogShown = true;
@@ -19,5 +20,9 @@ public class TestPlacePickerController implements PlacePickerViewController {
 
   @Override public void finishWithPlace(Place place) {
     finished = true;
+  }
+
+  @Override public void setMyLocationEnabled(boolean enabled) {
+    myLocationEnabled = enabled;
   }
 }


### PR DESCRIPTION
### Overview

My location layer should be disabled when the `PlacePickerActivity` is no longer visible on the screen (i.e. paused or finished).

This resolves two issues:

1. When the place picker activity was finished location services would not be properly shutdown and the app would leak a service connection to the Lost fused location service (#301).

2. This prevents location services from running hot when the place picker activity is in the background. Location updates are only needed when the place picker is visible on the screen and the user is in the process of selecting a place.

### Proposed Changes

* Disable location services in `PlacePickerActivity#onPause()`.
* Re-enable location services in `PlacePickerActivity#onResume()`.

Fixes #301 