### PR TITLE
Deploy javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,6 @@ subprojects {
       showStandardStreams true
     }
   }
-
-  tasks.withType(Javadoc).all { enabled = false }
 }
 
 task clean(type: Delete) {

--- a/docs/javadoc.md
+++ b/docs/javadoc.md
@@ -1,0 +1,10 @@
+# Javadoc
+
+### [Mapzen Core](http://mapzen.github.io/android/mapzen-core/)
+Shared module with common components used by both the Mapzen Android SDK and Mapzen Places API for Android.
+
+### [Mapzen Android SDK](http://mapzen.github.io/android/mapzen-android-sdk/)
+Maps, search, routing, and location services.
+
+### [Mapzen Places API](http://mapzen.github.io/android/mapzen-places-api/)
+Place autocomplete and place picker UI components.

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -23,5 +23,9 @@ The unsigned artifact will fail signature verification and should be dropped. Th
 
 ## 3. Documentation
 
-Add release name and notes to GitHub [releases page](https://github.com/mapzen/android/releases). Attach and upload AAR. Update
+Add release name and notes to GitHub [releases page](https://github.com/mapzen/android/releases). Update
 [installations page](https://github.com/mapzen/android/blob/master/docs/installation.md) to point to the new artifact.
+
+Download AARs and Javadoc JARs from Maven Central for `mapzen-core`, `mapzen-android-sdk`, and `mapzen-places-api` modules. Attach to release notes.
+
+Unzip Javadoc JARs in the proper folders of the `gh-pages` branch. Commit and push to GitHub to publish to https://mapzen.github.io/android/.


### PR DESCRIPTION
### Overview

Enables Javadoc build task. Adds documentation page with links to javadoc hosted on github pages.

### Proposed Changes

* Enable javadoc tasks in root project `build.gradle`
* Adds `docs/javadoc.md`
* Updates release notes