### PR TITLE
Set map label language

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
@@ -12,6 +12,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Locale;
+
 import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_SDK;
 
 /**
@@ -55,10 +57,21 @@ public class MapFragment extends Fragment {
   /**
    * Asynchronously creates the map and configures the vector tiles API key using the string
    * resource declared in the client application. Configures the stylesheet using the stylesheet
-   * parameter
+   * parameter.
    */
   public void getMapAsync(MapStyle mapStyle, final OnMapReadyCallback callback) {
     mapView.getMapAsync(mapStyle, callback);
+  }
+
+  /**
+   * Asynchronously creates the map and configures the vector tiles API key using the string
+   * resource declared in the client application. Configures the stylesheet using the stylesheet
+   * parameter.
+   *
+   * Also sets {@link Locale} used to determine default language when rendering map labels.
+   */
+  public void getMapAsync(MapStyle mapStyle, Locale locale, final OnMapReadyCallback callback) {
+    mapView.getMapAsync(mapStyle, locale, callback);
   }
 
   @Override public void onDestroy() {

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -9,6 +9,7 @@ import com.mapzen.tangram.SceneUpdate;
 import android.content.Context;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -16,6 +17,8 @@ import javax.inject.Inject;
  * Class responsible for initializing the map.
  */
 public class MapInitializer {
+  static final String STYLE_GLOBAL_VAR_API_KEY = "global.sdk_mapzen_api_key";
+  static final String STYLE_GLOBAL_VAR_LANGUAGE = "global.ux_language";
 
   private Context context;
 
@@ -24,6 +27,8 @@ public class MapInitializer {
   private MapDataManager mapDataManager;
 
   private MapStateManager mapStateManager;
+
+  private Locale locale = Locale.getDefault();
 
   /**
    * Creates a new instance.
@@ -51,6 +56,18 @@ public class MapInitializer {
     loadMap(mapView, mapStyle, true, callback);
   }
 
+  /**
+   * Initialize map for current {@link MapView} and {@link MapStyle} before notifying via
+   * {@link OnMapReadyCallback}.
+   *
+   * Also sets {@link Locale} used to determine default language when rendering map labels.
+   */
+  public void init(final MapView mapView, MapStyle mapStyle, Locale locale,
+      final OnMapReadyCallback callback) {
+    this.locale = locale;
+    loadMap(mapView, mapStyle, true, callback);
+  }
+
   private TangramMapView getTangramView(final MapView mapView) {
     return mapView.getTangramMapView();
   }
@@ -68,7 +85,8 @@ public class MapInitializer {
   private void loadMap(final MapView mapView, String sceneFile, final OnMapReadyCallback callback) {
     final ArrayList<SceneUpdate> sceneUpdates = new ArrayList<>(1);
     final String apiKey = MapzenManager.instance(context).getApiKey();
-    sceneUpdates.add(new SceneUpdate("global.sdk_mapzen_api_key", apiKey));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, apiKey));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
       @Override public void onMapReady(MapController mapController) {
         mapController.setHttpHandler(tileHttpHandler);

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -16,6 +16,8 @@ import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import java.util.Locale;
+
 import javax.inject.Inject;
 
 /**
@@ -121,11 +123,23 @@ public class MapView extends RelativeLayout {
    * Load map asynchronously using APK key declared in XML resources. For example:
    * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
    *
+   * @param mapStyle mapStyle that should be set.
    * @param callback listener to be invoked when map is initialized and ready to use.
-   * @param mapStyle mapStyle that should be set
    */
   public void getMapAsync(MapStyle mapStyle, @NonNull OnMapReadyCallback callback) {
     mapInitializer.init(this, mapStyle, callback);
+  }
+
+  /**
+   * Load map asynchronously using APK key declared in XML resources. For example:
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
+   *
+   * @param mapStyle mapStyle that should be set.
+   * @param locale used to determine language that should be used for map labels.
+   * @param callback listener to be invoked when map is initialized and ready to use.
+   */
+  public void getMapAsync(MapStyle mapStyle, Locale locale, @NonNull OnMapReadyCallback callback) {
+    mapInitializer.init(this, mapStyle, locale, callback);
   }
 
   /**

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -2,19 +2,33 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.CoreDI;
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.model.BubbleWrapStyle;
+import com.mapzen.tangram.SceneUpdate;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
 import static com.mapzen.TestHelper.getMockContext;
+import static com.mapzen.android.graphics.MapInitializer.STYLE_GLOBAL_VAR_API_KEY;
+import static com.mapzen.android.graphics.MapInitializer.STYLE_GLOBAL_VAR_LANGUAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.net.ssl.*")
@@ -39,5 +53,66 @@ public class MapInitializerTest {
     MapzenManager.instance(getMockContext()).setApiKey("fake-mapzen-api-key");
     mapInitializer.init(mapView, callback);
     assertThat(callback.map).isInstanceOf(MapzenMap.class);
+  }
+
+  @Test public void init_shouldSetDefaultMapLocale() throws Exception {
+    // Arrange
+    MapView mapView = mock(MapView.class);
+    TangramMapView tangramMapView = mock(TangramMapView.class);
+    when(mapView.getTangramMapView()).thenReturn(tangramMapView);
+    MapzenManager.instance(getMockContext()).setApiKey("fake-mapzen-api-key");
+
+    // Act
+    mapInitializer.init(mapView, new BubbleWrapStyle(), null);
+
+    // Assert
+    ArrayList<SceneUpdate> expected = new ArrayList<>();
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
+    verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
+        anyString(), argThat(new SceneUpdateMatcher(expected)));
+  }
+
+  @Test public void init_shouldSetGivenMapLocale() throws Exception {
+    // Arrange
+    MapView mapView = mock(MapView.class);
+    TangramMapView tangramMapView = mock(TangramMapView.class);
+    when(mapView.getTangramMapView()).thenReturn(tangramMapView);
+    MapzenManager.instance(getMockContext()).setApiKey("fake-mapzen-api-key");
+
+    // Act
+    mapInitializer.init(mapView, new BubbleWrapStyle(), Locale.FRENCH, null);
+
+    // Assert
+    ArrayList<SceneUpdate> expected = new ArrayList<>();
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.FRENCH.getLanguage()));
+    verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
+        anyString(), argThat(new SceneUpdateMatcher(expected)));
+  }
+
+  /**
+   * Custom Mockito matcher for a list of SceneUpdates. Verifies paths and values are all equal.
+   */
+  private class SceneUpdateMatcher extends ArgumentMatcher<List<SceneUpdate>> {
+    List<SceneUpdate> thisObject;
+
+    public SceneUpdateMatcher(List<SceneUpdate> thisObject) {
+      this.thisObject = thisObject;
+    }
+
+    @Override public boolean matches(Object argument) {
+      List<SceneUpdate> otherObject = (List<SceneUpdate>) argument;
+      for (int i = 0; i < thisObject.size(); i++) {
+        if (!thisObject.get(i).getPath().equals(otherObject.get(i).getPath())) {
+          return false;
+        }
+        if (!thisObject.get(i).getValue().equals(otherObject.get(i).getValue())) {
+          return false;
+        }
+      }
+
+      return true;
+    }
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
@@ -2,6 +2,8 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.R;
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.model.BubbleWrapStyle;
+import com.mapzen.android.graphics.model.MapStyle;
 
 import org.junit.After;
 import org.junit.Before;
@@ -11,6 +13,8 @@ import org.powermock.api.mockito.PowerMockito;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
+
+import java.util.Locale;
 
 import static com.mapzen.TestHelper.getMockContext;
 import static com.mapzen.android.graphics.MapView.OVERLAY_MODE_CLASSIC;
@@ -52,6 +56,15 @@ public class MapViewTest {
     mapView.mapInitializer = mapInitializer;
     mapView.getMapAsync(callback);
     verify(mapInitializer, times(1)).init(mapView, callback);
+  }
+
+  @Test public void getMapAsync_shouldUseGivenLocale() throws Exception {
+    final MapInitializer mapInitializer = mock(MapInitializer.class);
+    final OnMapReadyCallback callback = new TestCallback();
+    final MapStyle mapStyle = new BubbleWrapStyle();
+    mapView.mapInitializer = mapInitializer;
+    mapView.getMapAsync(mapStyle, Locale.FRENCH, callback);
+    verify(mapInitializer, times(1)).init(mapView, mapStyle, Locale.FRENCH, callback);
   }
 
   @Test public void shouldInflateLayoutWithOverlayModeSdk() throws Exception {


### PR DESCRIPTION
### Overview

Allows developer to set language for map labels when creating the map. Otherwise uses device default language for map labels. Previously each label was rendered in its "local" language which led to a mix of languages getting rendered.

### Proposed Changes

Developers can now set the map label language via `getMapAsync(...)` on both `MapView` and `MapFragment`. This `Locale` is used to set the stylesheet global variable `global.ux_language`.

If no language is set `Locale.getDefault()` is used.

**Example**
```java
mapFragment.getMapAsync(new BubbleWrapStyle(), Locale.CHINESE, callback);
```

Fixes #290 

![china](https://cloud.githubusercontent.com/assets/464123/23731084/5c2a7c18-0439-11e7-8152-463a4769d556.png)
