### PR TITLE
Exposes method to set language via `MapzenRouter`

### DIFF
--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
@@ -62,6 +62,19 @@ public class MapzenRouter {
   }
 
   /**
+   * Set route narrative language.
+   *
+   * @param language language to be used for written and verbal instructions. A list of supported
+   * languages can be found at:
+   * <p />
+   * https://github.com/valhalla/valhalla-docs/blob/master/api-reference.md#directions-options.
+   */
+  public MapzenRouter setLanguage(Router.Language language) {
+    internalRouter.setLanguage(language);
+    return this;
+  }
+
+  /**
    * The router can fetch different types of directions. Set the type to be biking.
    * @return
    */

--- a/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterTest.java
+++ b/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterTest.java
@@ -48,6 +48,11 @@ public class MapzenRouterTest {
     verify(router.getRouter()).setDistanceUnits(Router.DistanceUnits.MILES);
   }
 
+  @Test public void setLanguage_shouldInvokeInternalRouter() throws Exception {
+    router.setLanguage(Router.Language.FR_FR);
+    verify(router.getRouter()).setLanguage(Router.Language.FR_FR);
+  }
+
   @Test public void setBiking_shouldInvokeInternalRouter() {
     router.setBiking();
     verify(router.getRouter()).setBiking();


### PR DESCRIPTION
### Overview

Exposes wrapper method to set language via `MapzenRouter`.

### Proposed Changes

Adds `MapzenRouter#setLanguage(Router.Language language)` using On the Road language codes.

Updated On the Road to use default Locale when none is specified here:

https://github.com/mapzen/on-the-road_android/pull/108

Closes #291 