### PR TITLE
Should not extract search IME UI in landscape mode

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -24,6 +24,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.ImageView;
 
 import static com.mapzen.places.api.internal.PlaceIntentConsts.EXTRA_BOUNDS;
@@ -105,6 +106,8 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     } else {
       peliasSearchView = (PeliasSearchView) findViewById(R.id.pelias_search_view);
     }
+    peliasSearchView.setImeOptions(peliasSearchView.getImeOptions() |
+        EditorInfo.IME_FLAG_NO_EXTRACT_UI);
     peliasSearchView.setIconifiedByDefault(false);
     peliasSearchView.setCallback(new Callback<Result>() {
       @Override public void onResponse(Call<Result> call, Response<Result> response) {


### PR DESCRIPTION
### Overview

Prevents full screen extracted UI when editing search view text in landscape mode.

### Proposed Changes

Adds flag to prevent full screen edit text UI so autocomplete results are visible. Previously all results were obscured by soft keyboard and large edit text box.

Fixes #325 

![autocomplete-landscape](https://cloud.githubusercontent.com/assets/464123/23934813/3042cd5a-091e-11e7-911d-8a317cee8a87.png)
