### PR TITLE
Handle place picker dialog on configuration change

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
   pre:
     - if [ ! -e /usr/local/android-sdk-linux/build-tools/25.0.2 ]; then echo y | android update sdk --all --no-ui --filter "build-tools-25.0.2"; fi;
     - if [ ! -e /usr/local/android-sdk-linux/platforms/android-25 ]; then echo y | android update sdk --all --no-ui --filter "android-25"; fi;
-    - if ! $(grep -q "Revision=43.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --filter "extra-android-m2repository"; fi;
+    - if ! $(grep -q "Revision=45.0.0" /usr/local/android-sdk-linux/extras/android/m2repository/source.properties); then echo y | android update sdk --all --no-ui --filter "extra-android-m2repository"; fi;
   cache_directories:
     - /usr/local/android-sdk-linux/build-tools/25.0.2
     - /usr/local/android-sdk-linux/platforms/android-25

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
@@ -14,7 +14,7 @@ import android.os.Bundle;
 public class PlaceDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
   public static final String TAG = PlaceDialogFragment.class.getSimpleName();
 
-  private static final String ARG_NAME_TITLE = "title";
+  private static final String ARG_NAME_MESSAGE = "message";
 
   private AlertDialog dialog;
   private PlaceDialogListener listener;
@@ -22,19 +22,19 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
   /**
    * Create new instance of the dialog fragment.
    *
-   * @param title text to be displayed in the dialog.
+   * @param message text to be displayed in the dialog.
    * @return a new instance of the dialog fragment.
    */
-  public static PlaceDialogFragment newInstance(String title) {
+  public static PlaceDialogFragment newInstance(String message) {
     final PlaceDialogFragment fragment = new PlaceDialogFragment();
     Bundle args = new Bundle();
-    args.putString(ARG_NAME_TITLE, title);
+    args.putString(ARG_NAME_MESSAGE, message);
     fragment.setArguments(args);
     return fragment;
   }
 
   @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
-    final String title = getArguments().getString(ARG_NAME_TITLE);
+    final String title = getArguments().getString(ARG_NAME_MESSAGE);
     dialog = new AlertDialog.Builder(getActivity())
         .setTitle(R.string.use_this_place)
         .setMessage(title)
@@ -51,7 +51,7 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
    */
   public void setMessage(String detail) {
     dialog.setMessage(detail);
-    getArguments().putString(ARG_NAME_TITLE, detail);
+    getArguments().putString(ARG_NAME_MESSAGE, detail);
   }
 
   @Override public void onClick(DialogInterface dialog, int which) {

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
@@ -8,6 +8,9 @@ import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 
+/**
+ * Confirmation dialog shown to the user when a POI has been selected.
+ */
 public class PlaceDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
   public static final String TAG = PlaceDialogFragment.class.getSimpleName();
 
@@ -16,6 +19,12 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
   private AlertDialog dialog;
   private PlaceDialogListener listener;
 
+  /**
+   * Create new instance of the dialog fragment.
+   *
+   * @param title text to be displayed in the dialog.
+   * @return a new instance of the dialog fragment.
+   */
   public static PlaceDialogFragment newInstance(String title) {
     final PlaceDialogFragment fragment = new PlaceDialogFragment();
     Bundle args = new Bundle();
@@ -35,6 +44,11 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
     return dialog;
   }
 
+  /**
+   * Update text displayed in the dialog.
+   *
+   * @param detail new text to display.
+   */
   public void setMessage(String detail) {
     dialog.setMessage(detail);
     getArguments().putString(ARG_NAME_TITLE, detail);
@@ -52,12 +66,27 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
     }
   }
 
+  /**
+   * Set place dialog listener.
+   *
+   * @param listener the callbacks to invoke when the dialog is confirmed or dismissed.
+   */
   public void setListener(PlaceDialogListener listener) {
     this.listener = listener;
   }
 
+  /**
+   * Dialog listener interface.
+   */
   public interface PlaceDialogListener {
+    /**
+     * Positive button click listener.
+     */
     void onPlaceConfirmed();
+
+    /**
+     * Negative button click listener.
+     */
     void onPlaceDismissed();
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
@@ -1,0 +1,63 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.places.api.R;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+
+public class PlaceDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
+  public static final String TAG = PlaceDialogFragment.class.getSimpleName();
+
+  private static final String ARG_NAME_TITLE = "title";
+
+  private AlertDialog dialog;
+  private PlaceDialogListener listener;
+
+  public static PlaceDialogFragment newInstance(String title) {
+    final PlaceDialogFragment fragment = new PlaceDialogFragment();
+    Bundle args = new Bundle();
+    args.putString(ARG_NAME_TITLE, title);
+    fragment.setArguments(args);
+    return fragment;
+  }
+
+  @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
+    final String title = getArguments().getString(ARG_NAME_TITLE);
+    dialog = new AlertDialog.Builder(getActivity())
+        .setTitle(R.string.use_this_place)
+        .setMessage(title)
+        .setNegativeButton(R.string.change_location, this)
+        .setPositiveButton(R.string.select, this)
+        .create();
+    return dialog;
+  }
+
+  public void setMessage(String detail) {
+    dialog.setMessage(detail);
+    getArguments().putString(ARG_NAME_TITLE, detail);
+  }
+
+  @Override public void onClick(DialogInterface dialog, int which) {
+    if (listener == null) {
+      return;
+    }
+
+    if (which == DialogInterface.BUTTON_POSITIVE) {
+      listener.onPlaceConfirmed();
+    } else {
+      listener.onPlaceDismissed();
+    }
+  }
+
+  public void setListener(PlaceDialogListener listener) {
+    this.listener = listener;
+  }
+
+  public interface PlaceDialogListener {
+    void onPlaceConfirmed();
+    void onPlaceDismissed();
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceDialogFragment.java
@@ -34,10 +34,10 @@ public class PlaceDialogFragment extends DialogFragment implements DialogInterfa
   }
 
   @Override public Dialog onCreateDialog(Bundle savedInstanceState) {
-    final String title = getArguments().getString(ARG_NAME_MESSAGE);
+    final String message = getArguments().getString(ARG_NAME_MESSAGE);
     dialog = new AlertDialog.Builder(getActivity())
         .setTitle(R.string.use_this_place)
-        .setMessage(title)
+        .setMessage(message)
         .setNegativeButton(R.string.change_location, this)
         .setPositiveButton(R.string.select, this)
         .create();

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerPresenterImpl.java
@@ -15,9 +15,8 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
   private static final String PROPERTY_ID = "id";
   private static final String PROPERTY_NAME = "name";
 
-  PlacePickerViewController controller;
-  PlaceDetailFetcher detailFetcher;
-  Place place;
+  private PlacePickerViewController controller;
+  private PlaceDetailFetcher detailFetcher;
 
   /**
    * Construct a new object.
@@ -36,7 +35,7 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
 
     detailFetcher.fetchDetails(properties, new OnPlaceDetailsFetchedListener() {
       @Override public void onFetchSuccess(Place place, String details) {
-        PlacePickerPresenterImpl.this.place = place;
+        PlaceStore.instance().setCurrentSelectedPlace(place);
         controller.updateDialog(id, details);
       }
 
@@ -49,11 +48,11 @@ class PlacePickerPresenterImpl implements PlacePickerPresenter {
   }
 
   @Override public void onPlaceConfirmed() {
-    controller.finishWithPlace(place);
+    controller.finishWithPlace(PlaceStore.instance().getCurrentSelectedPlace());
   }
 
   @Override public void onAutocompletePlacePicked(Place place, String details) {
-    this.place = place;
+    PlaceStore.instance().setCurrentSelectedPlace(place);
     controller.showDialog(place.getId(), details);
     //TODO:dialog change location should bring back autocomplete ui
     //TODO:hide map ui and just have dialog visible

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceStore.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceStore.java
@@ -1,0 +1,24 @@
+package com.mapzen.places.api.internal;
+
+import com.mapzen.places.api.Place;
+
+public class PlaceStore {
+  private static PlaceStore instance = new PlaceStore();
+
+  public static PlaceStore instance() {
+    return instance;
+  }
+
+  private PlaceStore() {
+  }
+
+  private Place currentSelectedPlace;
+
+  public Place getCurrentSelectedPlace() {
+    return currentSelectedPlace;
+  }
+
+  public void setCurrentSelectedPlace(Place currentSelectedPlace) {
+    this.currentSelectedPlace = currentSelectedPlace;
+  }
+}

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceStore.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceStore.java
@@ -2,9 +2,17 @@ package com.mapzen.places.api.internal;
 
 import com.mapzen.places.api.Place;
 
+/**
+ * In-memory store used to persist data for currently selected place.
+ */
 public class PlaceStore {
   private static PlaceStore instance = new PlaceStore();
 
+  /**
+   * Return place store singleton instance.
+   *
+   * @return the place store instance.
+   */
   public static PlaceStore instance() {
     return instance;
   }

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PlacePickerPresenterTest.java
@@ -39,6 +39,15 @@ public class PlacePickerPresenterTest {
     assertThat(controller.dialogShown).isTrue();
   }
 
+  @Test public void onAutocompletePlacePicked_shouldPersistPlaceOnRotation() throws Exception {
+    Place place = new PlaceImpl.Builder().build();
+    presenter.onAutocompletePlacePicked(place, "details");
+    presenter = new PlacePickerPresenterImpl(new TestPlaceDetailFetcher());
+    presenter.setController(controller);
+    presenter.onPlaceConfirmed();
+    assertThat(controller.place).isEqualTo(place);
+  }
+
   @Test public void onHideView_shouldDisableLocationServices() throws Exception {
     controller.myLocationEnabled = true;
     presenter.onHideView();

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlacePickerController.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/TestPlacePickerController.java
@@ -8,6 +8,7 @@ class TestPlacePickerController implements PlacePickerViewController {
   String dialogTitle = null;
   boolean finished = false;
   boolean myLocationEnabled = false;
+  Place place = null;
 
   @Override public void showDialog(String id, String title) {
     dialogShown = true;
@@ -19,6 +20,7 @@ class TestPlacePickerController implements PlacePickerViewController {
   }
 
   @Override public void finishWithPlace(Place place) {
+    this.place = place;
     finished = true;
   }
 

--- a/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
+++ b/samples/mapzen-places-api-sample/src/main/java/com/mapzen/places/api/sample/PlacePickerDemoActivity.java
@@ -23,8 +23,9 @@ public class PlacePickerDemoActivity extends AppCompatActivity {
 
   private static final int PERMISSIONS_REQUEST_CODE = 1;
   private static final int NUMBER_OF_PERMISSIONS = 1;
-
   private static final int PLACE_PICKER_REQUEST = 1;
+
+  private static boolean isPickingPlace = false;
 
   TextView placeName;
   TextView placeAddress;
@@ -35,7 +36,10 @@ public class PlacePickerDemoActivity extends AppCompatActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.place_picker_demo);
     setupTextViews();
-    safeLaunchPicker();
+
+    if (!isPickingPlace) {
+      safeLaunchPicker();
+    }
   }
 
   @Override public void onRequestPermissionsResult(int requestCode, String[] permissions,
@@ -57,6 +61,7 @@ public class PlacePickerDemoActivity extends AppCompatActivity {
 
   @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     super.onActivityResult(requestCode, resultCode, data);
+    isPickingPlace = false;
 
     if (requestCode == PLACE_PICKER_REQUEST && resultCode == RESULT_OK) {
       Place place = PlacePicker.getPlace(this, data);
@@ -111,6 +116,7 @@ public class PlacePickerDemoActivity extends AppCompatActivity {
     Intent intent = new PlacePicker.IntentBuilder()
         .setLatLngBounds(new LatLngBounds(southwest, northeast))
         .build(this);
+    isPickingPlace = true;
     startActivityForResult(intent, PLACE_PICKER_REQUEST);
   }
 


### PR DESCRIPTION
### Overview

Properly handle place picker dialog on configuration change so state is persisted and dialog is not leaked.

### Proposed Changes

* Converts place picker dialog from standalone `AlertDialog` to a `DialogFragment` to maintain view state.
* Add `PlaceStore` singleton to persist current selection data through configuration change when `PlacePickerPresenter` is destroyed and recreated along with `PlacePickerActivity`.
* Updates sample app to (naively) handle configuration change by preventing launching another instance of the place picker if one is already active.

Fixes #324 