### PR TITLE
Place picker map position

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -40,6 +40,7 @@ public class MapView extends RelativeLayout {
   TextView attribution;
 
   private int overlayMode = OVERLAY_MODE_SDK;
+  private MapzenMap mapzenMap;
 
   /**
    * Create new instance.
@@ -241,6 +242,11 @@ public class MapView extends RelativeLayout {
    * You must call this method from the parent Activity/Fragment's corresponding method.
    */
   public void onDestroy() {
+    mapzenMap.onDestroy();
     getTangramMapView().onDestroy();
+  }
+
+  void setMapzenMap(MapzenMap mapzenMap) {
+    this.mapzenMap = mapzenMap;
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -834,6 +834,9 @@ public class MapzenMap {
     setCameraType(mapStateManager.getCameraType());
   }
 
+  /**
+   * Invoked by {@link MapView} when the parent activity or fragment is destroyed.
+   */
   void onDestroy() {
     mapStateManager.setPosition(mapController.getPosition());
     mapStateManager.setZoom(mapController.getZoom());

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -835,5 +835,6 @@ public class MapzenMap {
   }
 
   void onDestroy() {
+    mapStateManager.setPosition(mapController.getPosition());
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -836,5 +836,8 @@ public class MapzenMap {
 
   void onDestroy() {
     mapStateManager.setPosition(mapController.getPosition());
+    mapStateManager.setZoom(mapController.getZoom());
+    mapStateManager.setRotation(mapController.getRotation());
+    mapStateManager.setTilt(mapController.getTilt());
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -136,6 +136,7 @@ public class MapzenMap {
     this.overlayManager = overlayManager;
     this.mapStateManager = mapStateManager;
     this.labelPickHandler = labelPickHandler;
+    mapView.setMapzenMap(this);
     mapController.setPanResponder(internalPanResponder);
     mapController.setRotateResponder(internalRotateResponder);
     overlayManager.restoreMapData();
@@ -831,5 +832,8 @@ public class MapzenMap {
     setRotation(mapStateManager.getRotation());
     setTilt(mapStateManager.getTilt());
     setCameraType(mapStateManager.getCameraType());
+  }
+
+  void onDestroy() {
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
@@ -91,6 +91,13 @@ public class MapViewTest {
     assertThat(layoutInflater.getRoot()).isEqualTo(mapView);
   }
 
+  @Test public void onDestroy_shouldDestroyMapzenMap() throws Exception {
+    MapzenMap map = mock(MapzenMap.class);
+    mapView.setMapzenMap(map);
+    mapView.onDestroy();
+    verify(map).onDestroy();
+  }
+
   private void initMockAttributes(Context context, TypedArray typedArray,
       TestLayoutInflater layoutInflater, int overlayMode) {
     when(context.obtainStyledAttributes(any(AttributeSet.class), eq(R.styleable.MapView)))

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -57,6 +57,12 @@ public class MapzenMapTest {
     doCallRealMethod().when(mapController).getSceneUpdate();
     doCallRealMethod().when(mapController).setPosition(any(LngLat.class));
     doCallRealMethod().when(mapController).getPosition();
+    doCallRealMethod().when(mapController).setZoom(anyFloat());
+    doCallRealMethod().when(mapController).getZoom();
+    doCallRealMethod().when(mapController).setRotation(anyFloat());
+    doCallRealMethod().when(mapController).getRotation();
+    doCallRealMethod().when(mapController).setTilt(anyFloat());
+    doCallRealMethod().when(mapController).getTilt();
     overlayManager = mock(OverlayManager.class);
     mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
@@ -535,6 +541,24 @@ public class MapzenMapTest {
     mapController.setPosition(position);
     map.onDestroy();
     assertThat(mapStateManager.getPosition()).isEqualTo(position);
+  }
+
+  @Test public void onDestroy_shouldPersistMapZoom() throws Exception {
+    mapController.setZoom(15);
+    map.onDestroy();
+    assertThat(mapStateManager.getZoom()).isEqualTo(15);
+  }
+
+  @Test public void onDestroy_shouldPersistMapRotation() throws Exception {
+    mapController.setRotation(3.14f);
+    map.onDestroy();
+    assertThat(mapStateManager.getRotation()).isEqualTo(3.14f);
+  }
+
+  @Test public void onDestroy_shouldPersistMapTilt() throws Exception {
+    mapController.setTilt(1.57f);
+    map.onDestroy();
+    assertThat(mapStateManager.getTilt()).isEqualTo(1.57f);
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -45,6 +45,7 @@ public class MapzenMapTest {
   private TestMapController mapController;
   private OverlayManager overlayManager;
   private LabelPickHandler labelPickHandler;
+  private MapStateManager mapStateManager;
 
   @Before public void setUp() throws Exception {
     mapView = new TestMapView();
@@ -54,8 +55,10 @@ public class MapzenMapTest {
     doCallRealMethod().when(mapController).pickFeature(anyFloat(), anyFloat());
     doCallRealMethod().when(mapController).queueSceneUpdate(any(SceneUpdate.class));
     doCallRealMethod().when(mapController).getSceneUpdate();
+    doCallRealMethod().when(mapController).setPosition(any(LngLat.class));
+    doCallRealMethod().when(mapController).getPosition();
     overlayManager = mock(OverlayManager.class);
-    MapStateManager mapStateManager = new MapStateManager();
+    mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
     map = new MapzenMap(mapView, mapController, overlayManager, mapStateManager, labelPickHandler);
   }
@@ -525,6 +528,13 @@ public class MapzenMapTest {
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
     verify(mapController).applySceneUpdates();
+  }
+
+  @Test public void onDestroy_shouldPersistMapPosition() throws Exception {
+    LngLat position = new LngLat(1, 2);
+    mapController.setPosition(position);
+    map.onDestroy();
+    assertThat(mapStateManager.getPosition()).isEqualTo(position);
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/TestMapController.java
+++ b/core/src/test/java/com/mapzen/android/graphics/TestMapController.java
@@ -28,6 +28,11 @@ public class TestMapController extends MapController {
     super(new GLSurfaceView(getMockContext()));
   }
 
+  @Override public void setPosition(LngLat position) {
+    longitude = position.longitude;
+    latitude = position.latitude;
+  }
+
   @Override public void setPositionEased(LngLat lngLat, int duration) {
     longitude = lngLat.longitude;
     latitude = lngLat.latitude;

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -152,6 +152,9 @@ public class PlacePickerActivity extends Activity implements
   }
 
   private void initMapView() {
+    // The calculation below fails if map.getZoom() returns 0 so set a reasonable default zoom.
+    map.setZoom(15);
+
     Bundle extras = getIntent().getExtras();
     if (extras != null) {
       LatLngBounds bounds = (LatLngBounds) extras.get(EXTRA_BOUNDS);

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerActivity.java
@@ -39,6 +39,8 @@ public class PlacePickerActivity extends Activity implements
   AlertDialog dialog;
   String dialogPlaceId;
 
+  private boolean mapInitComplete = false;
+
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.place_picker_activity);
@@ -53,6 +55,10 @@ public class PlacePickerActivity extends Activity implements
         callbackHandler));
     presenter.setController(this);
 
+    if (savedInstanceState != null) {
+      mapInitComplete = true;
+    }
+
     mapView = (MapView) findViewById(R.id.mz_map_view);
     mapView.getMapAsync(this);
   }
@@ -65,6 +71,15 @@ public class PlacePickerActivity extends Activity implements
   @Override protected void onResume() {
     super.onResume();
     presenter.onShowView();
+  }
+
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(new Bundle());
   }
 
   @Override public void setMyLocationEnabled(boolean enabled) {
@@ -130,7 +145,13 @@ public class PlacePickerActivity extends Activity implements
   private void initializeMap() {
     map.setMyLocationEnabled(true);
     map.setLabelPickListener(this);
+    map.setPersistMapState(true);
+    if (!mapInitComplete) {
+      initMapView();
+    }
+  }
 
+  private void initMapView() {
     Bundle extras = getIntent().getExtras();
     if (extras != null) {
       LatLngBounds bounds = (LatLngBounds) extras.get(EXTRA_BOUNDS);

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
@@ -77,6 +77,7 @@ public class BasicMapzenActivity extends BaseDemoActivity
 
     map.setCompassButtonEnabled(true);
     map.setZoomButtonsEnabled(true);
+    map.setPersistMapState(true);
   }
 
   @Override protected void onPause() {


### PR DESCRIPTION
### Overview

This change set fixes two issues:

1. The map position and zoom level were not properly set when the place picker map is first initialized.

2. If the user panned or zoomed the place picker map the view state would not be maintained on device rotation.

### Proposed Changes

* Forward MapView#onDestroy() events to MapzenMap
* MapzenMap saves current map position, zoom, rotation, and tilt when destroyed
* The place picker map is not be re-initailized after device rotation but rather restored to the prior state.
* Adds a default zoom level of 15 to use when making initial map position and zoom calculations.

Fixes #326 