### PR TITLE
Fixed crash when mapzenMap field was not set in MapView instance

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -242,7 +242,9 @@ public class MapView extends RelativeLayout {
    * You must call this method from the parent Activity/Fragment's corresponding method.
    */
   public void onDestroy() {
-    mapzenMap.onDestroy();
+    if (mapzenMap != null) {
+      mapzenMap.onDestroy();
+    }
     getTangramMapView().onDestroy();
   }
 


### PR DESCRIPTION
### Overview
Fixed crash when mapzenMap field was not set in MapView instance. This caused crash in my app when `MapzenMap` wasn't initialized because my app uses Google Maps API and Mapzen Android SDK and only one of them can be active at a time causing that one of them won't be initialized at app startup.

### Proposed Changes
Add null pointer check to `onDestroy()` method in `MapView` class.