### PR TITLE
adding a beacon watch to android

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -50,3 +50,5 @@ deployment:
       - scripts/deploy-staging.sh
       - scripts/deploy-samples.sh
       - scripts/publish-docs.sh
+      - pip install 'Circle-Beacon == 2.0.0'
+      - alert-circle mapzen documentation master $CIRCLE_TOKEN


### PR DESCRIPTION
adding beacon (AKA tickler) to watch for changes when a release happens for Android. 


