### PR TITLE
Update tangram to use 0.5.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ group = GROUP
 version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
 
-ext.tangram_version = "0.5.1"
+ext.tangram_version = "0.5.2"
 
 android {
   compileSdkVersion 25


### PR DESCRIPTION
- has a bunch of bug fixes for older android devices


Not updated to 0.6.2, has thats a major upgrade and will require more testing and probably more changes. Will create an issue for that though.
