### PR TITLE
Upgrade Tangram to 0.6.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ group = GROUP
 version = VERSION_NAME
 project.archivesBaseName = POM_ARTIFACT_ID
 
-ext.tangram_version = "0.5.1"
+ext.tangram_version = "0.6.2"
 
 android {
   compileSdkVersion 25


### PR DESCRIPTION
### Overview
- Minor Tangram update which enables loading fallback fonts on versions of android < 5.0 as well as a few other fixes listed here: https://github.com/tangrams/tangram-es/releases/tag/0.6.2

Closes #362 
