### PR TITLE
Improve Style Switching

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -17,4 +17,5 @@
     <suppress checks="LineLength" files="OkHttp3TestUtils.java"/>
     <suppress checks="TypeName" files="R.java" />
     <suppress checks="ConstantName" files="R.java" />
+    <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapzenMap.java"/>
 </suppressions>

--- a/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
+++ b/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
@@ -26,4 +26,12 @@ import dagger.Provides;
   @Provides @Singleton public MapStateManager providesMapStateManager() {
     return new MapStateManager();
   }
+
+  /**
+   * Returns the object used create scene updates for global variables on a {@link MapzenMap}.
+   * @return
+   */
+  @Provides @Singleton public SceneUpdateManager providesSceneUpdateManager() {
+    return new SceneUpdateManager();
+  }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BitmapMarker;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
@@ -25,6 +26,7 @@ import android.view.View;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -41,6 +43,9 @@ public class MapzenMap {
   private final MapStateManager mapStateManager;
   private final LabelPickHandler labelPickHandler;
   private final MarkerManager markerManager;
+  private final SceneUpdateManager sceneUpdateManager;
+  private final MapzenManager mapzenManager;
+  private Locale locale;
 
   boolean pickFeatureOnSingleTapConfirmed = false;
   boolean pickLabelOnSingleTapConfirmed = false;
@@ -140,13 +145,17 @@ public class MapzenMap {
    */
   MapzenMap(MapView mapView, MapController mapController, OverlayManager overlayManager,
       MapStateManager mapStateManager, LabelPickHandler labelPickHandler,
-      MarkerManager markerManager) {
+      MarkerManager markerManager, SceneUpdateManager sceneUpdateManager, Locale locale,
+      MapzenManager mapzenManager) {
     this.mapView = mapView;
     this.mapController = mapController;
     this.overlayManager = overlayManager;
     this.mapStateManager = mapStateManager;
     this.labelPickHandler = labelPickHandler;
     this.markerManager = markerManager;
+    this.sceneUpdateManager = sceneUpdateManager;
+    this.locale = locale;
+    this.mapzenManager = mapzenManager;
     mapView.setMapzenMap(this);
     mapController.setPanResponder(internalPanResponder);
     mapController.setRotateResponder(internalRotateResponder);
@@ -173,7 +182,9 @@ public class MapzenMap {
    */
   public void setStyle(MapStyle mapStyle) {
     mapStateManager.setMapStyle(mapStyle);
-    mapController.loadSceneFile(mapStyle.getSceneFile());
+    String apiKey = mapzenManager.getApiKey();
+    List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale);
+    mapController.loadSceneFile(mapStyle.getSceneFile(), globalSceneUpdates);
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
@@ -1,0 +1,29 @@
+package com.mapzen.android.graphics;
+
+import com.mapzen.tangram.SceneUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Manages creation of {@link SceneUpdate}s for api keys and languages.
+ */
+class SceneUpdateManager {
+
+  static final String STYLE_GLOBAL_VAR_API_KEY = "global.sdk_mapzen_api_key";
+  static final String STYLE_GLOBAL_VAR_LANGUAGE = "global.ux_language";
+
+  /**
+   * Creates {@link SceneUpdate}s given an api key and locale.
+   * @param apiKey user's api key.
+   * @param locale user's preferred map locale.
+   * @return scene updates for api key and locale.
+   */
+  List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale) {
+    final ArrayList<SceneUpdate> sceneUpdates = new ArrayList<>(2);
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, apiKey));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
+    return sceneUpdates;
+  }
+}

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Locale;
 
 import static com.mapzen.TestHelper.getMockContext;
-import static com.mapzen.android.graphics.MapInitializer.STYLE_GLOBAL_VAR_API_KEY;
-import static com.mapzen.android.graphics.MapInitializer.STYLE_GLOBAL_VAR_LANGUAGE;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -40,7 +40,7 @@ public class MapInitializerTest {
   @Before public void setUp() throws Exception {
     CoreDI.init(getMockContext());
     mapInitializer = new MapInitializer(mock(Context.class), mock(TileHttpHandler.class),
-        new MapDataManager(), new MapStateManager());
+        new MapDataManager(), new MapStateManager(), new SceneUpdateManager());
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -1,5 +1,6 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BitmapMarker;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
@@ -7,6 +8,7 @@ import com.mapzen.android.graphics.model.Marker;
 import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.android.graphics.model.Polygon;
 import com.mapzen.android.graphics.model.Polyline;
+import com.mapzen.android.graphics.model.WalkaboutStyle;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
@@ -25,11 +27,13 @@ import android.graphics.PointF;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -49,6 +53,9 @@ public class MapzenMapTest {
   private LabelPickHandler labelPickHandler;
   private MapStateManager mapStateManager;
   private MarkerManager markerManager;
+  private SceneUpdateManager sceneUpdateManager;
+  private Locale locale;
+  private MapzenManager mapzenManager;
 
   @Before public void setUp() throws Exception {
     mapView = new TestMapView();
@@ -73,8 +80,11 @@ public class MapzenMapTest {
     mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
     markerManager = new MarkerManager(mapController);
+    sceneUpdateManager = new SceneUpdateManager();
+    locale = new Locale("en_us");
+    mapzenManager = mock(MapzenManager.class);
     map = new MapzenMap(mapView, mapController, overlayManager, mapStateManager, labelPickHandler,
-        markerManager);
+        markerManager, sceneUpdateManager, locale, mapzenManager);
   }
 
   @Test public void shouldNotBeNull() throws Exception {
@@ -581,6 +591,12 @@ public class MapzenMapTest {
     mapController.setTilt(1.57f);
     map.onDestroy();
     assertThat(mapStateManager.getTilt()).isEqualTo(1.57f);
+  }
+
+  @Test public void setStyle_shouldSetStyleAndGlobalVariables() throws Exception {
+    map.setStyle(new WalkaboutStyle());
+    verify(mapController).loadSceneFile(
+        anyString(), any(List.class));
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
@@ -1,0 +1,33 @@
+package com.mapzen.android.graphics;
+
+import com.mapzen.tangram.SceneUpdate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SceneUpdateManagerTest {
+
+  SceneUpdateManager manager;
+  String apiKey;
+  Locale locale;
+
+  @Before public void setUp() throws Exception {
+    manager = new SceneUpdateManager();
+    apiKey = "test_key";
+    locale = new Locale("fr_fr");
+  }
+
+  @Test public void shouldReturnCorrectKeysAndValues() {
+    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale);
+    assertThat(updates.size()).isEqualTo(2);
+    assertThat(updates.get(0).getPath()).isEqualTo("global.sdk_mapzen_api_key");
+    assertThat(updates.get(0).getValue()).isEqualTo(apiKey);
+    assertThat(updates.get(1).getPath()).isEqualTo("global.ux_language");
+    assertThat(updates.get(1).getValue()).isEqualTo(locale.getLanguage());
+  }
+}

--- a/core/src/test/java/com/mapzen/android/graphics/TestMapView.java
+++ b/core/src/test/java/com/mapzen/android/graphics/TestMapView.java
@@ -1,11 +1,14 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.MapStyle;
 import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.MapController;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+
+import java.util.Locale;
 
 import static com.mapzen.TestHelper.getMockContext;
 import static org.mockito.Mockito.mock;
@@ -20,13 +23,15 @@ public class TestMapView extends MapView {
   @Override public void getMapAsync(@NonNull OnMapReadyCallback callback) {
     callback.onMapReady(new MapzenMap(mock(MapView.class), mock(MapController.class),
         mock(OverlayManager.class), mock(MapStateManager.class), mock(LabelPickHandler.class),
-        mock(MarkerManager.class)));
+        mock(MarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
+        MapzenManager.class)));
   }
 
   @Override public void getMapAsync(MapStyle mapStyle, @NonNull OnMapReadyCallback callback) {
     callback.onMapReady(new MapzenMap(mock(MapView.class), mock(MapController.class),
         mock(OverlayManager.class), mock(MapStateManager.class), mock(LabelPickHandler.class),
-        mock(MarkerManager.class)));
+        mock(MarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
+        MapzenManager.class)));
   }
 
   @Override public TangramMapView getTangramMapView() {


### PR DESCRIPTION
### Overview
This PR updates `MapzenMap#setStyle` so that it reconfigures global scene updates (such as api key and locale) when a new style is loaded

Closes #363 
