### PR TITLE
Add map overlays

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -87,7 +87,7 @@ public class MapInitializer {
 
   private void loadMap(final MapView mapView, String sceneFile, final OnMapReadyCallback callback) {
     final String apiKey = MapzenManager.instance(context).getApiKey();
-    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale);
+    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale, false);
     getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
       @Override public void onMapReady(MapController mapController) {
         mapController.setHttpHandler(tileHttpHandler);

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -88,7 +88,7 @@ public class MapInitializer {
   private void loadMap(final MapView mapView, String sceneFile, final OnMapReadyCallback callback) {
     final String apiKey = MapzenManager.instance(context).getApiKey();
     final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale, false,
-        false);
+        false, false);
     getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
       @Override public void onMapReady(MapController mapController) {
         mapController.setHttpHandler(tileHttpHandler);

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -87,7 +87,8 @@ public class MapInitializer {
 
   private void loadMap(final MapView mapView, String sceneFile, final OnMapReadyCallback callback) {
     final String apiKey = MapzenManager.instance(context).getApiKey();
-    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale, false);
+    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale, false,
+        false);
     getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
       @Override public void onMapReady(MapController mapController) {
         mapController.setHttpHandler(tileHttpHandler);

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -87,8 +87,9 @@ public class MapInitializer {
 
   private void loadMap(final MapView mapView, String sceneFile, final OnMapReadyCallback callback) {
     final String apiKey = MapzenManager.instance(context).getApiKey();
-    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale, false,
-        false, false);
+    final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
+        mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled(),
+        mapStateManager.isPathOverlayEnabled());
     getTangramView(mapView).getMapAsync(new com.mapzen.tangram.MapView.OnMapReadyCallback() {
       @Override public void onMapReady(MapController mapController) {
         mapController.setHttpHandler(tileHttpHandler);

--- a/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
@@ -20,7 +20,7 @@ class MapStateManager {
   private CameraType cameraType = CameraType.ISOMETRIC;
   private boolean transitOverlayEnabled = false;
   private boolean bikeOverlayEnabled = false;
-  private boolean pathOverlayEnabled = false;
+  private boolean pathOverlayEnabled = true;
 
   public void setPersistMapState(boolean persistMapState) {
     this.persistMapState = persistMapState;

--- a/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
@@ -18,6 +18,7 @@ class MapStateManager {
   private float rotation = 0;
   private float tilt = 0;
   private CameraType cameraType = CameraType.ISOMETRIC;
+  private boolean transitOverlayEnabled = false;
 
   public void setPersistMapState(boolean persistMapState) {
     this.persistMapState = persistMapState;
@@ -73,5 +74,13 @@ class MapStateManager {
 
   public CameraType getCameraType() {
     return this.cameraType;
+  }
+
+  public void setTransitOverlayEnabled(boolean transitOverlayEnabled) {
+    this.transitOverlayEnabled = transitOverlayEnabled;
+  }
+
+  public boolean isTransitOverlayEnabled() {
+    return this.transitOverlayEnabled;
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
@@ -20,6 +20,7 @@ class MapStateManager {
   private CameraType cameraType = CameraType.ISOMETRIC;
   private boolean transitOverlayEnabled = false;
   private boolean bikeOverlayEnabled = false;
+  private boolean pathOverlayEnabled = false;
 
   public void setPersistMapState(boolean persistMapState) {
     this.persistMapState = persistMapState;
@@ -91,5 +92,13 @@ class MapStateManager {
 
   public boolean isBikeOverlayEnabled() {
     return this.bikeOverlayEnabled;
+  }
+
+  public void setPathOverlayEnabled(boolean pathOverlayEnabled) {
+    this.pathOverlayEnabled = pathOverlayEnabled;
+  }
+
+  public boolean isPathOverlayEnabled() {
+    return this.pathOverlayEnabled;
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapStateManager.java
@@ -19,6 +19,7 @@ class MapStateManager {
   private float tilt = 0;
   private CameraType cameraType = CameraType.ISOMETRIC;
   private boolean transitOverlayEnabled = false;
+  private boolean bikeOverlayEnabled = false;
 
   public void setPersistMapState(boolean persistMapState) {
     this.persistMapState = persistMapState;
@@ -82,5 +83,13 @@ class MapStateManager {
 
   public boolean isTransitOverlayEnabled() {
     return this.transitOverlayEnabled;
+  }
+
+  public void setBikeOverlayEnabled(boolean bikeOverlayEnabled) {
+    this.bikeOverlayEnabled = bikeOverlayEnabled;
+  }
+
+  public boolean isBikeOverlayEnabled() {
+    return this.bikeOverlayEnabled;
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -24,6 +24,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -902,6 +903,25 @@ public class MapzenMap {
   }
 
   /**
+   * Method to facilitate enabling/disabling multiple overlays at once.
+   * @param transitOverlayEnabled whether or not the transit overlay should be enabled.
+   * @param bikeOverlayEnabled whether or not the bike overlay should be enabled.
+   * @param pathOverlayEnabled whether or not the path overlay should be enabled.
+   */
+  public void setOverlaysEnabled(boolean transitOverlayEnabled, boolean bikeOverlayEnabled,
+      boolean pathOverlayEnabled) {
+    mapStateManager.setTransitOverlayEnabled(transitOverlayEnabled);
+    mapStateManager.setBikeOverlayEnabled(bikeOverlayEnabled);
+    mapStateManager.setPathOverlayEnabled(pathOverlayEnabled);
+    List<SceneUpdate> updates = new ArrayList<>();
+    updates.add(sceneUpdateManager.getTransitOverlayUpdate(transitOverlayEnabled));
+    updates.add(sceneUpdateManager.getBikeOverlayUpdate(bikeOverlayEnabled));
+    updates.add(sceneUpdateManager.getPathOverlayUpdate(pathOverlayEnabled));
+    mapController.queueSceneUpdate(updates);
+    mapController.applySceneUpdates();
+  }
+
+  /**
    * Restores all aspects of the map EXCEPT the style, this is restored in the
    * {@link MapInitializer}.
    */
@@ -914,9 +934,8 @@ public class MapzenMap {
     setRotation(mapStateManager.getRotation());
     setTilt(mapStateManager.getTilt());
     setCameraType(mapStateManager.getCameraType());
-    setTransitOverlayEnabled(mapStateManager.isTransitOverlayEnabled());
-    setBikeOverlayEnabled(mapStateManager.isBikeOverlayEnabled());
-    setPathOverlayEnabled(mapStateManager.isPathOverlayEnabled());
+    setOverlaysEnabled(mapStateManager.isTransitOverlayEnabled(),
+        mapStateManager.isBikeOverlayEnabled(), mapStateManager.isPathOverlayEnabled());
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -46,6 +46,7 @@ public class MapzenMap {
   private final SceneUpdateManager sceneUpdateManager;
   private final MapzenManager mapzenManager;
   private Locale locale;
+  private boolean transitOverlayEnabled = false;
 
   boolean pickFeatureOnSingleTapConfirmed = false;
   boolean pickLabelOnSingleTapConfirmed = false;
@@ -183,7 +184,8 @@ public class MapzenMap {
   public void setStyle(MapStyle mapStyle) {
     mapStateManager.setMapStyle(mapStyle);
     String apiKey = mapzenManager.getApiKey();
-    List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale);
+    List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
+        transitOverlayEnabled);
     mapController.loadSceneFile(mapStyle.getSceneFile(), globalSceneUpdates);
   }
 
@@ -862,6 +864,17 @@ public class MapzenMap {
    */
   public void setPersistMapState(boolean persistStateOnRecreation) {
     mapStateManager.setPersistMapState(persistStateOnRecreation);
+  }
+
+  /**
+   * All mapzen basemap styles support a transit overlay. This method toggles its visibility.
+   * @param transitOverlayEnabled whether or not the transit overlay should be enabled.
+   */
+  public void setTransitOverlayEnabled(boolean transitOverlayEnabled) {
+    this.transitOverlayEnabled = transitOverlayEnabled;
+    mapController.queueSceneUpdate(sceneUpdateManager.getTransitOverlayUpdate(
+        transitOverlayEnabled));
+    mapController.applySceneUpdates();
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -184,7 +184,8 @@ public class MapzenMap {
     mapStateManager.setMapStyle(mapStyle);
     String apiKey = mapzenManager.getApiKey();
     List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
-        mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled());
+        mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled(),
+        mapStateManager.isPathOverlayEnabled());
     mapController.loadSceneFile(mapStyle.getSceneFile(), globalSceneUpdates);
   }
 
@@ -889,6 +890,18 @@ public class MapzenMap {
   }
 
   /**
+   * The {@link com.mapzen.android.graphics.model.WalkaboutStyle} supports a path overlay. This
+   * method toggles its visibility.
+   * @param pathOverlayEnabled whether or not the path overlay should be enabled.
+   */
+  public void setPathOverlayEnabled(boolean pathOverlayEnabled) {
+    mapStateManager.setPathOverlayEnabled(pathOverlayEnabled);
+    mapController.queueSceneUpdate(sceneUpdateManager.getPathOverlayUpdate(
+        pathOverlayEnabled));
+    mapController.applySceneUpdates();
+  }
+
+  /**
    * Restores all aspects of the map EXCEPT the style, this is restored in the
    * {@link MapInitializer}.
    */
@@ -903,6 +916,7 @@ public class MapzenMap {
     setCameraType(mapStateManager.getCameraType());
     setTransitOverlayEnabled(mapStateManager.isTransitOverlayEnabled());
     setBikeOverlayEnabled(mapStateManager.isBikeOverlayEnabled());
+    setPathOverlayEnabled(mapStateManager.isPathOverlayEnabled());
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -184,7 +184,7 @@ public class MapzenMap {
     mapStateManager.setMapStyle(mapStyle);
     String apiKey = mapzenManager.getApiKey();
     List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
-        mapStateManager.isTransitOverlayEnabled());
+        mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled());
     mapController.loadSceneFile(mapStyle.getSceneFile(), globalSceneUpdates);
   }
 
@@ -866,13 +866,25 @@ public class MapzenMap {
   }
 
   /**
-   * All mapzen basemap styles support a transit overlay. This method toggles its visibility.
+   * All Mapzen basemap styles support a transit overlay. This method toggles its visibility.
    * @param transitOverlayEnabled whether or not the transit overlay should be enabled.
    */
   public void setTransitOverlayEnabled(boolean transitOverlayEnabled) {
     mapStateManager.setTransitOverlayEnabled(transitOverlayEnabled);
     mapController.queueSceneUpdate(sceneUpdateManager.getTransitOverlayUpdate(
         transitOverlayEnabled));
+    mapController.applySceneUpdates();
+  }
+
+  /**
+   * The {@link com.mapzen.android.graphics.model.WalkaboutStyle} supports a bike overlay. This
+   * method toggles its visibility.
+   * @param bikeOverlayEnabled whether or not the bike overlay should be enabled.
+   */
+  public void setBikeOverlayEnabled(boolean bikeOverlayEnabled) {
+    mapStateManager.setBikeOverlayEnabled(bikeOverlayEnabled);
+    mapController.queueSceneUpdate(sceneUpdateManager.getBikeOverlayUpdate(
+        bikeOverlayEnabled));
     mapController.applySceneUpdates();
   }
 
@@ -890,6 +902,7 @@ public class MapzenMap {
     setTilt(mapStateManager.getTilt());
     setCameraType(mapStateManager.getCameraType());
     setTransitOverlayEnabled(mapStateManager.isTransitOverlayEnabled());
+    setBikeOverlayEnabled(mapStateManager.isBikeOverlayEnabled());
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -46,7 +46,6 @@ public class MapzenMap {
   private final SceneUpdateManager sceneUpdateManager;
   private final MapzenManager mapzenManager;
   private Locale locale;
-  private boolean transitOverlayEnabled = false;
 
   boolean pickFeatureOnSingleTapConfirmed = false;
   boolean pickLabelOnSingleTapConfirmed = false;
@@ -185,7 +184,7 @@ public class MapzenMap {
     mapStateManager.setMapStyle(mapStyle);
     String apiKey = mapzenManager.getApiKey();
     List<SceneUpdate> globalSceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
-        transitOverlayEnabled);
+        mapStateManager.isTransitOverlayEnabled());
     mapController.loadSceneFile(mapStyle.getSceneFile(), globalSceneUpdates);
   }
 
@@ -871,7 +870,7 @@ public class MapzenMap {
    * @param transitOverlayEnabled whether or not the transit overlay should be enabled.
    */
   public void setTransitOverlayEnabled(boolean transitOverlayEnabled) {
-    this.transitOverlayEnabled = transitOverlayEnabled;
+    mapStateManager.setTransitOverlayEnabled(transitOverlayEnabled);
     mapController.queueSceneUpdate(sceneUpdateManager.getTransitOverlayUpdate(
         transitOverlayEnabled));
     mapController.applySceneUpdates();
@@ -890,6 +889,7 @@ public class MapzenMap {
     setRotation(mapStateManager.getRotation());
     setTilt(mapStateManager.getTilt());
     setCameraType(mapStateManager.getCameraType());
+    setTransitOverlayEnabled(mapStateManager.isTransitOverlayEnabled());
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
@@ -15,6 +15,7 @@ class SceneUpdateManager {
   static final String STYLE_GLOBAL_VAR_LANGUAGE = "global.ux_language";
   static final String STYLE_GLOBAL_VAR_TRANSIT_OVERLAY = "global.sdk_transit_overlay";
   static final String STYLE_GLOBAL_VAR_BIKE_OVERLAY = "global.sdk_bike_overlay";
+  static final String STYLE_GLOBAL_VAR_PATH_OVERLAY = "global.sdk_path_overlay";
 
   /**
    * Creates {@link SceneUpdate}s given an api key and locale.
@@ -23,12 +24,13 @@ class SceneUpdateManager {
    * @return scene updates for api key and locale.
    */
   List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale, boolean transitOverlayEnabled,
-      boolean bikeOverlayEnabled) {
+      boolean bikeOverlayEnabled, boolean pathOverlayEnabled) {
     final ArrayList<SceneUpdate> sceneUpdates = new ArrayList<>(2);
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, apiKey));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     sceneUpdates.add(getTransitOverlayUpdate(transitOverlayEnabled));
     sceneUpdates.add(getBikeOverlayUpdate(bikeOverlayEnabled));
+    sceneUpdates.add(getPathOverlayUpdate(pathOverlayEnabled));
     return sceneUpdates;
   }
 
@@ -50,5 +52,15 @@ class SceneUpdateManager {
   SceneUpdate getBikeOverlayUpdate(boolean bikeOverlayEnabled) {
     return new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, String.valueOf(
         bikeOverlayEnabled));
+  }
+
+  /**
+   * Creates a {@link SceneUpdate} for enabling/disabling the path overlay.
+   * @param pathOverlayEnabled
+   * @return
+   */
+  SceneUpdate getPathOverlayUpdate(boolean pathOverlayEnabled) {
+    return new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, String.valueOf(
+        pathOverlayEnabled));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
@@ -14,6 +14,7 @@ class SceneUpdateManager {
   static final String STYLE_GLOBAL_VAR_API_KEY = "global.sdk_mapzen_api_key";
   static final String STYLE_GLOBAL_VAR_LANGUAGE = "global.ux_language";
   static final String STYLE_GLOBAL_VAR_TRANSIT_OVERLAY = "global.sdk_transit_overlay";
+  static final String STYLE_GLOBAL_VAR_BIKE_OVERLAY = "global.sdk_bike_overlay";
 
   /**
    * Creates {@link SceneUpdate}s given an api key and locale.
@@ -21,11 +22,13 @@ class SceneUpdateManager {
    * @param locale user's preferred map locale.
    * @return scene updates for api key and locale.
    */
-  List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale, boolean transitOverlayEnabled) {
+  List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale, boolean transitOverlayEnabled,
+      boolean bikeOverlayEnabled) {
     final ArrayList<SceneUpdate> sceneUpdates = new ArrayList<>(2);
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, apiKey));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     sceneUpdates.add(getTransitOverlayUpdate(transitOverlayEnabled));
+    sceneUpdates.add(getBikeOverlayUpdate(bikeOverlayEnabled));
     return sceneUpdates;
   }
 
@@ -37,5 +40,15 @@ class SceneUpdateManager {
   SceneUpdate getTransitOverlayUpdate(boolean transitOverlayEnabled) {
     return new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, String.valueOf(
         transitOverlayEnabled));
+  }
+
+  /**
+   * Creates a {@link SceneUpdate} for enabling/disabling the bike overlay.
+   * @param bikeOverlayEnabled
+   * @return
+   */
+  SceneUpdate getBikeOverlayUpdate(boolean bikeOverlayEnabled) {
+    return new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, String.valueOf(
+        bikeOverlayEnabled));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/SceneUpdateManager.java
@@ -13,6 +13,7 @@ class SceneUpdateManager {
 
   static final String STYLE_GLOBAL_VAR_API_KEY = "global.sdk_mapzen_api_key";
   static final String STYLE_GLOBAL_VAR_LANGUAGE = "global.ux_language";
+  static final String STYLE_GLOBAL_VAR_TRANSIT_OVERLAY = "global.sdk_transit_overlay";
 
   /**
    * Creates {@link SceneUpdate}s given an api key and locale.
@@ -20,10 +21,21 @@ class SceneUpdateManager {
    * @param locale user's preferred map locale.
    * @return scene updates for api key and locale.
    */
-  List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale) {
+  List<SceneUpdate> getUpdatesFor(String apiKey, Locale locale, boolean transitOverlayEnabled) {
     final ArrayList<SceneUpdate> sceneUpdates = new ArrayList<>(2);
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, apiKey));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
+    sceneUpdates.add(getTransitOverlayUpdate(transitOverlayEnabled));
     return sceneUpdates;
+  }
+
+  /**
+   * Creates a {@link SceneUpdate} for enabling/disabling the transit overlay.
+   * @param transitOverlayEnabled
+   * @return
+   */
+  SceneUpdate getTransitOverlayUpdate(boolean transitOverlayEnabled) {
+    return new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, String.valueOf(
+        transitOverlayEnabled));
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -21,6 +21,7 @@ import static com.mapzen.TestHelper.getMockContext;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_BIKE_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_PATH_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -75,6 +76,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
@@ -95,11 +97,12 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.FRENCH.getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
 
-  @Test public void init_shouldDefaultToTransitOverlayDisabled() throws Exception {
+  @Test public void init_shouldDefaultToOverlaysDisabled() throws Exception {
     // Arrange
     MapView mapView = mock(MapView.class);
     TangramMapView tangramMapView = mock(TangramMapView.class);
@@ -115,6 +118,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 import static com.mapzen.TestHelper.getMockContext;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_BIKE_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +73,8 @@ public class MapInitializerTest {
     ArrayList<SceneUpdate> expected = new ArrayList<>();
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
@@ -90,6 +93,8 @@ public class MapInitializerTest {
     ArrayList<SceneUpdate> expected = new ArrayList<>();
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.FRENCH.getLanguage()));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
@@ -109,6 +114,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -76,7 +76,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
@@ -97,12 +97,12 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.FRENCH.getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
 
-  @Test public void init_shouldDefaultToOverlaysDisabled() throws Exception {
+  @Test public void init_shouldDefaultToOverlaysDisabledExceptPath() throws Exception {
     // Arrange
     MapView mapView = mock(MapView.class);
     TangramMapView tangramMapView = mock(TangramMapView.class);
@@ -118,7 +118,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
         anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -8,7 +8,6 @@ import com.mapzen.tangram.SceneUpdate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatcher;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -16,12 +15,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import android.content.Context;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 import static com.mapzen.TestHelper.getMockContext;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -74,7 +73,7 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
-        anyString(), argThat(new SceneUpdateMatcher(expected)));
+        anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
 
   @Test public void init_shouldSetGivenMapLocale() throws Exception {
@@ -92,31 +91,25 @@ public class MapInitializerTest {
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
     expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.FRENCH.getLanguage()));
     verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
-        anyString(), argThat(new SceneUpdateMatcher(expected)));
+        anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
 
-  /**
-   * Custom Mockito matcher for a list of SceneUpdates. Verifies paths and values are all equal.
-   */
-  private class SceneUpdateMatcher extends ArgumentMatcher<List<SceneUpdate>> {
-    List<SceneUpdate> thisObject;
+  @Test public void init_shouldDefaultToTransitOverlayDisabled() throws Exception {
+    // Arrange
+    MapView mapView = mock(MapView.class);
+    TangramMapView tangramMapView = mock(TangramMapView.class);
+    when(mapView.getTangramMapView()).thenReturn(tangramMapView);
+    MapzenManager.instance(getMockContext()).setApiKey("fake-mapzen-api-key");
 
-    public SceneUpdateMatcher(List<SceneUpdate> thisObject) {
-      this.thisObject = thisObject;
-    }
+    // Act
+    mapInitializer.init(mapView, new BubbleWrapStyle(), null);
 
-    @Override public boolean matches(Object argument) {
-      List<SceneUpdate> otherObject = (List<SceneUpdate>) argument;
-      for (int i = 0; i < thisObject.size(); i++) {
-        if (!thisObject.get(i).getPath().equals(otherObject.get(i).getPath())) {
-          return false;
-        }
-        if (!thisObject.get(i).getValue().equals(otherObject.get(i).getValue())) {
-          return false;
-        }
-      }
-
-      return true;
-    }
+    // Assert
+    ArrayList<SceneUpdate> expected = new ArrayList<>();
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "fake-mapzen-api-key"));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, Locale.getDefault().getLanguage()));
+    expected.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    verify(tangramMapView).getMapAsync(any(com.mapzen.tangram.MapView.OnMapReadyCallback.class),
+        anyString(), argThat(new SceneUpdatesMatcher(expected)));
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
@@ -96,8 +96,8 @@ public class MapStateManagerTest {
     assertThat(stateManager.isBikeOverlayEnabled()).isEqualTo(true);
   }
 
-  @Test public void isPathOverlayEnabled_shouldDefaultToFalse() {
-    assertThat(stateManager.isPathOverlayEnabled()).isEqualTo(false);
+  @Test public void isPathOverlayEnabled_shouldDefaultToTrue() {
+    assertThat(stateManager.isPathOverlayEnabled()).isEqualTo(true);
   }
 
   @Test public void setPathOverlayEnabled_shouldUpdatePathOverlayEnabled() {

--- a/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
@@ -77,4 +77,13 @@ public class MapStateManagerTest {
     stateManager.setCameraType(CameraType.PERSPECTIVE);
     assertThat(stateManager.getCameraType()).isEqualTo(CameraType.PERSPECTIVE);
   }
+
+  @Test public void isTransitOverlayEnabled_shouldDefaultToFalse() {
+    assertThat(stateManager.isTransitOverlayEnabled()).isEqualTo(false);
+  }
+
+  @Test public void setTransitOverlayEnabled_shouldUpdateTransitOverlayEnabled() {
+    stateManager.setTransitOverlayEnabled(true);
+    assertThat(stateManager.isTransitOverlayEnabled()).isEqualTo(true);
+  }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
@@ -95,4 +95,13 @@ public class MapStateManagerTest {
     stateManager.setBikeOverlayEnabled(true);
     assertThat(stateManager.isBikeOverlayEnabled()).isEqualTo(true);
   }
+
+  @Test public void isPathOverlayEnabled_shouldDefaultToFalse() {
+    assertThat(stateManager.isPathOverlayEnabled()).isEqualTo(false);
+  }
+
+  @Test public void setPathOverlayEnabled_shouldUpdatePathOverlayEnabled() {
+    stateManager.setPathOverlayEnabled(true);
+    assertThat(stateManager.isPathOverlayEnabled()).isEqualTo(true);
+  }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapStateManagerTest.java
@@ -86,4 +86,13 @@ public class MapStateManagerTest {
     stateManager.setTransitOverlayEnabled(true);
     assertThat(stateManager.isTransitOverlayEnabled()).isEqualTo(true);
   }
+
+  @Test public void isBikeOverlayEnabled_shouldDefaultToFalse() {
+    assertThat(stateManager.isBikeOverlayEnabled()).isEqualTo(false);
+  }
+
+  @Test public void setBikeOverlayEnabled_shouldUpdateBikeOverlayEnabled() {
+    stateManager.setBikeOverlayEnabled(true);
+    assertThat(stateManager.isBikeOverlayEnabled()).isEqualTo(true);
+  }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -624,7 +624,7 @@ public class MapzenMapTest {
     ArrayList<SceneUpdate> updates = new ArrayList<>();
     updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdatesMatcher(updates)));
   }
 
@@ -634,7 +634,7 @@ public class MapzenMapTest {
         anyString(), any(List.class));
   }
 
-  @Test public void overlays_shouldBeDisabledByDefault() throws Exception {
+  @Test public void overlays_shouldBeDisabledByDefaultExceptPath() throws Exception {
     when(mapzenManager.getApiKey()).thenReturn("test-api-key");
     map.setStyle(new BubbleWrapStyle());
     List<SceneUpdate> sceneUpdates = new ArrayList<>();
@@ -642,7 +642,7 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(mapController).loadSceneFile(anyString(), argThat(
         new SceneUpdatesMatcher(sceneUpdates)));
   }
@@ -674,8 +674,7 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
-    verify(mapController, times(2)).queueSceneUpdate(
-        argThat(new SceneUpdatesMatcher(sceneUpdates)));
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdatesMatcher(sceneUpdates)));
     verify(mapController, times(2)).applySceneUpdates();
   }
 

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_BIKE_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -570,7 +571,7 @@ public class MapzenMapTest {
 
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
-    verify(mapController, times(2)).applySceneUpdates();
+    verify(mapController, times(3)).applySceneUpdates();
   }
 
   @Test public void onDestroy_shouldPersistMapPosition() throws Exception {
@@ -623,6 +624,11 @@ public class MapzenMapTest {
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
   }
 
+  @Test public void restoreMapState_shouldPersistBikeOverlayEnabled() throws Exception {
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+  }
+
   @Test public void setStyle_shouldSetStyleAndGlobalVariables() throws Exception {
     map.setStyle(new WalkaboutStyle());
     verify(mapController).loadSceneFile(
@@ -636,6 +642,7 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "test-api-key"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     verify(mapController).loadSceneFile(anyString(), argThat(
         new SceneUpdatesMatcher(sceneUpdates)));
   }
@@ -646,7 +653,28 @@ public class MapzenMapTest {
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(2)).applySceneUpdates();
+    verify(mapController, times(3)).applySceneUpdates();
+  }
+
+  @Test public void setBikeOverlayEnabled_shouldBeDisabledByDefault() throws Exception {
+    when(mapzenManager.getApiKey()).thenReturn("test-api-key");
+    map.setStyle(new BubbleWrapStyle());
+    List<SceneUpdate> sceneUpdates = new ArrayList<>();
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "test-api-key"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    verify(mapController).loadSceneFile(anyString(), argThat(
+        new SceneUpdatesMatcher(sceneUpdates)));
+  }
+
+  @Test public void setBikeOverlayEnabled_shouldCallSceneUpdates() throws Exception {
+    map.setBikeOverlayEnabled(true);
+    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "true");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+    verify(mapController, times(3)).applySceneUpdates();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -674,7 +674,8 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
-    verify(mapController, times(2)).queueSceneUpdate(argThat(new SceneUpdatesMatcher(sceneUpdates)));
+    verify(mapController, times(2)).queueSceneUpdate(
+        argThat(new SceneUpdatesMatcher(sceneUpdates)));
     verify(mapController, times(2)).applySceneUpdates();
   }
 

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -2,6 +2,7 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BitmapMarker;
+import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
 import com.mapzen.android.graphics.model.Marker;
@@ -30,10 +31,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -597,6 +602,24 @@ public class MapzenMapTest {
     map.setStyle(new WalkaboutStyle());
     verify(mapController).loadSceneFile(
         anyString(), any(List.class));
+  }
+
+  @Test public void setTransitOverlayEnabled_shouldBeDisabledByDefault() throws Exception {
+    when(mapzenManager.getApiKey()).thenReturn("test-api-key");
+    map.setStyle(new BubbleWrapStyle());
+    List<SceneUpdate> sceneUpdates = new ArrayList<>();
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "test-api-key"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    verify(mapController).loadSceneFile(anyString(), argThat(
+        new SceneUpdatesMatcher(sceneUpdates)));
+  }
+
+  @Test public void setTransitOverlayEnabled_shouldCallSceneUpdates() throws Exception {
+    map.setTransitOverlayEnabled(true);
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+    verify(mapController).applySceneUpdates();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -572,7 +572,7 @@ public class MapzenMapTest {
 
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
-    verify(mapController, times(4)).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   @Test public void onDestroy_shouldPersistMapPosition() throws Exception {
@@ -620,19 +620,12 @@ public class MapzenMapTest {
     verify(mapController).setCameraType(MapController.CameraType.ISOMETRIC);
   }
 
-  @Test public void restoreMapState_shouldPersistTransitOverlayEnabled() throws Exception {
-    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-  }
-
-  @Test public void restoreMapState_shouldPersistBikeOverlayEnabled() throws Exception {
-    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-  }
-
-  @Test public void restoreMapState_shouldPersistPathOverlayEnabled() throws Exception {
-    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+  @Test public void restoreMapState_shouldPersistOverlaysEnabled() throws Exception {
+    ArrayList<SceneUpdate> updates = new ArrayList<>();
+    updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    updates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdatesMatcher(updates)));
   }
 
   @Test public void setStyle_shouldSetStyleAndGlobalVariables() throws Exception {
@@ -656,29 +649,43 @@ public class MapzenMapTest {
 
   @Test public void setTransitOverlayEnabled_shouldCallSceneUpdates() throws Exception {
     map.setTransitOverlayEnabled(true);
-    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(4)).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   @Test public void setBikeOverlayEnabled_shouldCallSceneUpdates() throws Exception {
     map.setBikeOverlayEnabled(true);
-    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(4)).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   @Test public void setPathOverlayEnabled_shouldCallSceneUpdates() throws Exception {
     map.setPathOverlayEnabled(true);
-    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false");
-    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(4)).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
+  }
+
+  @Test public void setOverlaysEnabled_fff_shouldCallSceneUpdates() throws Exception {
+    map.setOverlaysEnabled(false, false, false);
+    List<SceneUpdate> sceneUpdates = new ArrayList<>();
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
+    verify(mapController, times(2)).queueSceneUpdate(argThat(new SceneUpdatesMatcher(sceneUpdates)));
+    verify(mapController, times(2)).applySceneUpdates();
+  }
+
+  @Test public void setOverlaysEnabled_ttt_shouldCallSceneUpdates() throws Exception {
+    map.setOverlaysEnabled(true, true, true);
+    List<SceneUpdate> sceneUpdates = new ArrayList<>();
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "true"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdatesMatcher(sceneUpdates)));
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_API_KEY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_BIKE_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_LANGUAGE;
+import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_PATH_OVERLAY;
 import static com.mapzen.android.graphics.SceneUpdateManager.STYLE_GLOBAL_VAR_TRANSIT_OVERLAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -571,7 +572,7 @@ public class MapzenMapTest {
 
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
-    verify(mapController, times(3)).applySceneUpdates();
+    verify(mapController, times(4)).applySceneUpdates();
   }
 
   @Test public void onDestroy_shouldPersistMapPosition() throws Exception {
@@ -629,13 +630,18 @@ public class MapzenMapTest {
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
   }
 
+  @Test public void restoreMapState_shouldPersistPathOverlayEnabled() throws Exception {
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+  }
+
   @Test public void setStyle_shouldSetStyleAndGlobalVariables() throws Exception {
     map.setStyle(new WalkaboutStyle());
     verify(mapController).loadSceneFile(
         anyString(), any(List.class));
   }
 
-  @Test public void setTransitOverlayEnabled_shouldBeDisabledByDefault() throws Exception {
+  @Test public void overlays_shouldBeDisabledByDefault() throws Exception {
     when(mapzenManager.getApiKey()).thenReturn("test-api-key");
     map.setStyle(new BubbleWrapStyle());
     List<SceneUpdate> sceneUpdates = new ArrayList<>();
@@ -643,6 +649,7 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
+    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false"));
     verify(mapController).loadSceneFile(anyString(), argThat(
         new SceneUpdatesMatcher(sceneUpdates)));
   }
@@ -653,19 +660,7 @@ public class MapzenMapTest {
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(3)).applySceneUpdates();
-  }
-
-  @Test public void setBikeOverlayEnabled_shouldBeDisabledByDefault() throws Exception {
-    when(mapzenManager.getApiKey()).thenReturn("test-api-key");
-    map.setStyle(new BubbleWrapStyle());
-    List<SceneUpdate> sceneUpdates = new ArrayList<>();
-    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_API_KEY, "test-api-key"));
-    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_LANGUAGE, locale.getLanguage()));
-    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false"));
-    sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "false"));
-    verify(mapController).loadSceneFile(anyString(), argThat(
-        new SceneUpdatesMatcher(sceneUpdates)));
+    verify(mapController, times(4)).applySceneUpdates();
   }
 
   @Test public void setBikeOverlayEnabled_shouldCallSceneUpdates() throws Exception {
@@ -674,7 +669,16 @@ public class MapzenMapTest {
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController, times(3)).applySceneUpdates();
+    verify(mapController, times(4)).applySceneUpdates();
+  }
+
+  @Test public void setPathOverlayEnabled_shouldCallSceneUpdates() throws Exception {
+    map.setPathOverlayEnabled(true);
+    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+    verify(mapController, times(4)).applySceneUpdates();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -570,7 +570,7 @@ public class MapzenMapTest {
 
   @Test public void applySceneUpdates_shouldInvokeMapController() {
     map.applySceneUpdates();
-    verify(mapController).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   @Test public void onDestroy_shouldPersistMapPosition() throws Exception {
@@ -598,6 +598,31 @@ public class MapzenMapTest {
     assertThat(mapStateManager.getTilt()).isEqualTo(1.57f);
   }
 
+  @Test public void restoreMapState_shouldPersistPosition() throws Exception {
+    verify(mapController).setPosition(new LngLat(0, 0));
+  }
+
+  @Test public void restoreMapState_shouldPersistZoom() throws Exception {
+    verify(mapController).setZoom(0);
+  }
+
+  @Test public void restoreMapState_shouldPersistRotation() throws Exception {
+    verify(mapController).setRotation(0);
+  }
+
+  @Test public void restoreMapState_shouldPersistTilt() throws Exception {
+    verify(mapController).setTilt(0);
+  }
+
+  @Test public void restoreMapState_shouldPersistCameraType() throws Exception {
+    verify(mapController).setCameraType(MapController.CameraType.ISOMETRIC);
+  }
+
+  @Test public void restoreMapState_shouldPersistTransitOverlayEnabled() throws Exception {
+    SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
+  }
+
   @Test public void setStyle_shouldSetStyleAndGlobalVariables() throws Exception {
     map.setStyle(new WalkaboutStyle());
     verify(mapController).loadSceneFile(
@@ -617,9 +642,11 @@ public class MapzenMapTest {
 
   @Test public void setTransitOverlayEnabled_shouldCallSceneUpdates() throws Exception {
     map.setTransitOverlayEnabled(true);
+    SceneUpdate falseSceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "false");
+    verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(falseSceneUpdate)));
     SceneUpdate sceneUpdate = new SceneUpdate(STYLE_GLOBAL_VAR_TRANSIT_OVERLAY, "true");
     verify(mapController).queueSceneUpdate(argThat(new SceneUpdateMatcher(sceneUpdate)));
-    verify(mapController).applySceneUpdates();
+    verify(mapController, times(2)).applySceneUpdates();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
@@ -23,19 +23,27 @@ public class SceneUpdateManagerTest {
   }
 
   @Test public void getUpdatesFor_shouldReturnCorrectKeysAndValues() {
-    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale, false);
-    assertThat(updates.size()).isEqualTo(3);
+    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale, false, false);
+    assertThat(updates.size()).isEqualTo(4);
     assertThat(updates.get(0).getPath()).isEqualTo("global.sdk_mapzen_api_key");
     assertThat(updates.get(0).getValue()).isEqualTo(apiKey);
     assertThat(updates.get(1).getPath()).isEqualTo("global.ux_language");
     assertThat(updates.get(1).getValue()).isEqualTo(locale.getLanguage());
     assertThat(updates.get(2).getPath()).isEqualTo("global.sdk_transit_overlay");
     assertThat(updates.get(2).getValue()).isEqualTo("false");
+    assertThat(updates.get(3).getPath()).isEqualTo("global.sdk_bike_overlay");
+    assertThat(updates.get(3).getValue()).isEqualTo("false");
   }
 
-  @Test public void shouldReturnCorrectKeysAndValues() {
+  @Test public void getTransitOverlayUpdate_shouldReturnCorrectKeysAndValues() {
     SceneUpdate update = manager.getTransitOverlayUpdate(true);
     assertThat(update.getPath()).isEqualTo("global.sdk_transit_overlay");
+    assertThat(update.getValue()).isEqualTo("true");
+  }
+
+  @Test public void getBikeOverlayUpdate_shouldReturnCorrectKeysAndValues() {
+    SceneUpdate update = manager.getBikeOverlayUpdate(true);
+    assertThat(update.getPath()).isEqualTo("global.sdk_bike_overlay");
     assertThat(update.getValue()).isEqualTo("true");
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
@@ -23,8 +23,8 @@ public class SceneUpdateManagerTest {
   }
 
   @Test public void getUpdatesFor_shouldReturnCorrectKeysAndValues() {
-    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale, false, false);
-    assertThat(updates.size()).isEqualTo(4);
+    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale, false, false, false);
+    assertThat(updates.size()).isEqualTo(5);
     assertThat(updates.get(0).getPath()).isEqualTo("global.sdk_mapzen_api_key");
     assertThat(updates.get(0).getValue()).isEqualTo(apiKey);
     assertThat(updates.get(1).getPath()).isEqualTo("global.ux_language");
@@ -33,6 +33,8 @@ public class SceneUpdateManagerTest {
     assertThat(updates.get(2).getValue()).isEqualTo("false");
     assertThat(updates.get(3).getPath()).isEqualTo("global.sdk_bike_overlay");
     assertThat(updates.get(3).getValue()).isEqualTo("false");
+    assertThat(updates.get(4).getPath()).isEqualTo("global.sdk_path_overlay");
+    assertThat(updates.get(4).getValue()).isEqualTo("false");
   }
 
   @Test public void getTransitOverlayUpdate_shouldReturnCorrectKeysAndValues() {
@@ -44,6 +46,12 @@ public class SceneUpdateManagerTest {
   @Test public void getBikeOverlayUpdate_shouldReturnCorrectKeysAndValues() {
     SceneUpdate update = manager.getBikeOverlayUpdate(true);
     assertThat(update.getPath()).isEqualTo("global.sdk_bike_overlay");
+    assertThat(update.getValue()).isEqualTo("true");
+  }
+
+  @Test public void getPathOverlayUpdate_shouldReturnCorrectKeysAndValues() {
+    SceneUpdate update = manager.getPathOverlayUpdate(true);
+    assertThat(update.getPath()).isEqualTo("global.sdk_path_overlay");
     assertThat(update.getValue()).isEqualTo("true");
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdateManagerTest.java
@@ -22,12 +22,20 @@ public class SceneUpdateManagerTest {
     locale = new Locale("fr_fr");
   }
 
-  @Test public void shouldReturnCorrectKeysAndValues() {
-    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale);
-    assertThat(updates.size()).isEqualTo(2);
+  @Test public void getUpdatesFor_shouldReturnCorrectKeysAndValues() {
+    List<SceneUpdate> updates = manager.getUpdatesFor(apiKey, locale, false);
+    assertThat(updates.size()).isEqualTo(3);
     assertThat(updates.get(0).getPath()).isEqualTo("global.sdk_mapzen_api_key");
     assertThat(updates.get(0).getValue()).isEqualTo(apiKey);
     assertThat(updates.get(1).getPath()).isEqualTo("global.ux_language");
     assertThat(updates.get(1).getValue()).isEqualTo(locale.getLanguage());
+    assertThat(updates.get(2).getPath()).isEqualTo("global.sdk_transit_overlay");
+    assertThat(updates.get(2).getValue()).isEqualTo("false");
+  }
+
+  @Test public void shouldReturnCorrectKeysAndValues() {
+    SceneUpdate update = manager.getTransitOverlayUpdate(true);
+    assertThat(update.getPath()).isEqualTo("global.sdk_transit_overlay");
+    assertThat(update.getValue()).isEqualTo("true");
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdateMatcher.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdateMatcher.java
@@ -1,0 +1,31 @@
+package com.mapzen.android.graphics;
+
+import com.mapzen.tangram.SceneUpdate;
+
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Custom Mockito matcher for a list of SceneUpdates. Verifies paths and values are all equal.
+ */
+class SceneUpdateMatcher extends ArgumentMatcher<SceneUpdate> {
+  SceneUpdate update;
+
+  public SceneUpdateMatcher(SceneUpdate update) {
+    this.update = update;
+  }
+
+  @Override public boolean matches(Object argument) {
+    SceneUpdate otherObject = (SceneUpdate) argument;
+    return updateEqualToUpdate(update, otherObject);
+  }
+
+  static boolean updateEqualToUpdate(SceneUpdate update, SceneUpdate otherUpdate) {
+    if (!update.getPath().equals(otherUpdate.getPath())) {
+      return false;
+    }
+    if (!update.getValue().equals(otherUpdate.getValue())) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdatesMatcher.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdatesMatcher.java
@@ -18,6 +18,9 @@ class SceneUpdatesMatcher extends ArgumentMatcher<List<SceneUpdate>> {
 
   @Override public boolean matches(Object argument) {
     List<SceneUpdate> otherObject = (List<SceneUpdate>) argument;
+    if (updates.size() != otherObject.size()) {
+      return false;
+    }
     for (int i = 0; i < updates.size(); i++) {
       if (!SceneUpdateMatcher.updateEqualToUpdate(updates.get(i), otherObject.get(i))) {
         return false;

--- a/core/src/test/java/com/mapzen/android/graphics/SceneUpdatesMatcher.java
+++ b/core/src/test/java/com/mapzen/android/graphics/SceneUpdatesMatcher.java
@@ -1,0 +1,28 @@
+package com.mapzen.android.graphics;
+
+import com.mapzen.tangram.SceneUpdate;
+
+import org.mockito.ArgumentMatcher;
+
+import java.util.List;
+
+/**
+ * Custom Mockito matcher for a list of SceneUpdates. Verifies paths and values are all equal.
+ */
+class SceneUpdatesMatcher extends ArgumentMatcher<List<SceneUpdate>> {
+  List<SceneUpdate> updates;
+
+  public SceneUpdatesMatcher(List<SceneUpdate> updates) {
+    this.updates = updates;
+  }
+
+  @Override public boolean matches(Object argument) {
+    List<SceneUpdate> otherObject = (List<SceneUpdate>) argument;
+    for (int i = 0; i < updates.size(); i++) {
+      if (!SceneUpdateMatcher.updateEqualToUpdate(updates.get(i), otherObject.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/samples/mapzen-android-sdk-sample/src/main/AndroidManifest.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
         android:name=".CustomMarkerActivity"
         android:label="@string/custom_marker_demo_label"
         />
+    <activity
+        android:name=".OverlayActivity"
+        android:theme="@style/AppTheme.NoActionBar"/>
   </application>
 
 </manifest>

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -1,12 +1,83 @@
 package com.mapzen.android.sdk.sample;
 
+import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+
 /**
  * Example activity for toggling transit, bike, and path overlays.
  */
 public class OverlayActivity extends SwitchStyleActivity {
 
+  private AdapterView.OnItemSelectedListener itemSelectedListener =
+      new AdapterView.OnItemSelectedListener() {
+    @Override
+    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+      switch (position) {
+        case 0:
+          // do nothing
+          break;
+        case 1:
+          enableTransitOverlay();
+          break;
+        case 2:
+          disableOverlays();
+          break;
+        default:
+          break;
+      }
+    }
+
+    @Override public void onNothingSelected(AdapterView<?> parent) {
+
+    }
+  };
+
+  @Override public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Spinner spinner = (Spinner) findViewById(R.id.overlay_spinner);
+    ArrayAdapter<CharSequence> adapter =
+        ArrayAdapter.createFromResource(this, R.array.overlay_array, R.layout.simple_spinner_item);
+    adapter.setDropDownViewResource(R.layout.simple_spinner_dropdown_item);
+    spinner.setAdapter(adapter);
+    spinner.setOnItemSelectedListener(itemSelectedListener);
+  }
+
   @Override void configureMap() {
     super.configureMap();
+    mapzenMap.setMyLocationEnabled(true);
+  }
+
+  @Override protected void onDestroy() {
+    mapzenMap.setMyLocationEnabled(false);
+    mapzenMap.setTransitOverlayEnabled(false);
+    super.onDestroy();
+  }
+
+  int getLayoutId() {
+    return R.layout.activity_overlay;
+  }
+
+  /**
+   * Enables transit overlay on the map.
+   */
+  void enableTransitOverlay() {
+    if (mapzenMap == null) {
+      return;
+    }
     mapzenMap.setTransitOverlayEnabled(true);
+  }
+
+  /**
+   * Disables transit overlay on the map.
+   */
+  void disableOverlays() {
+    if (mapzenMap == null) {
+      return;
+    }
+    mapzenMap.setTransitOverlayEnabled(false);
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -53,7 +53,6 @@ public class OverlayActivity extends SwitchStyleActivity {
 
   @Override protected void onDestroy() {
     mapzenMap.setMyLocationEnabled(false);
-    mapzenMap.setTransitOverlayEnabled(false);
     super.onDestroy();
   }
 

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -26,8 +26,10 @@ public class OverlayActivity extends SwitchStyleActivity {
           enableBikeOverlay();
           break;
         case 3:
-          disableOverlays();
+          enablePathOverlay();
           break;
+        case 4:
+          disableOverlays();
         default:
           break;
       }
@@ -74,13 +76,23 @@ public class OverlayActivity extends SwitchStyleActivity {
   }
 
   /**
-   * Enables transit overlay on the map.
+   * Enables bike overlay on the map.
    */
   void enableBikeOverlay() {
     if (mapzenMap == null) {
       return;
     }
     mapzenMap.setBikeOverlayEnabled(true);
+  }
+
+  /**
+   * Enables path overlay on the map.
+   */
+  void enablePathOverlay() {
+    if (mapzenMap == null) {
+      return;
+    }
+    mapzenMap.setPathOverlayEnabled(true);
   }
 
   /**
@@ -92,5 +104,6 @@ public class OverlayActivity extends SwitchStyleActivity {
     }
     mapzenMap.setTransitOverlayEnabled(false);
     mapzenMap.setBikeOverlayEnabled(false);
+    mapzenMap.setPathOverlayEnabled(false);
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -1,0 +1,12 @@
+package com.mapzen.android.sdk.sample;
+
+/**
+ * Example activity for toggling transit, bike, and path overlays.
+ */
+public class OverlayActivity extends SwitchStyleActivity {
+
+  @Override void configureMap() {
+    super.configureMap();
+    mapzenMap.setTransitOverlayEnabled(true);
+  }
+}

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -102,8 +102,6 @@ public class OverlayActivity extends SwitchStyleActivity {
     if (mapzenMap == null) {
       return;
     }
-    mapzenMap.setTransitOverlayEnabled(false);
-    mapzenMap.setBikeOverlayEnabled(false);
-    mapzenMap.setPathOverlayEnabled(false);
+    mapzenMap.setOverlaysEnabled(false, false, false);
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -23,6 +23,9 @@ public class OverlayActivity extends SwitchStyleActivity {
           enableTransitOverlay();
           break;
         case 2:
+          enableBikeOverlay();
+          break;
+        case 3:
           disableOverlays();
           break;
         default:
@@ -71,6 +74,16 @@ public class OverlayActivity extends SwitchStyleActivity {
   }
 
   /**
+   * Enables transit overlay on the map.
+   */
+  void enableBikeOverlay() {
+    if (mapzenMap == null) {
+      return;
+    }
+    mapzenMap.setBikeOverlayEnabled(true);
+  }
+
+  /**
    * Disables transit overlay on the map.
    */
   void disableOverlays() {
@@ -78,5 +91,6 @@ public class OverlayActivity extends SwitchStyleActivity {
       return;
     }
     mapzenMap.setTransitOverlayEnabled(false);
+    mapzenMap.setBikeOverlayEnabled(false);
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SampleDetailsList.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SampleDetailsList.java
@@ -59,6 +59,9 @@ public final class SampleDetailsList {
           MapzenSearchViewActivity.class),
       new SampleDetails(R.string.custom_marker_demo_label,
           R.string.custom_marker_demo_description,
-          CustomMarkerActivity.class)
+          CustomMarkerActivity.class),
+      new SampleDetails(R.string.overlay_demo_label,
+          R.string.overlay_demo_description,
+          OverlayActivity.class)
   };
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
@@ -24,7 +24,7 @@ public class SwitchStyleActivity extends BaseDemoActivity
     implements AdapterView.OnItemSelectedListener {
 
   private MapFragment mapFragment;
-  private MapzenMap mapzenMap;
+  MapzenMap mapzenMap;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -49,9 +49,16 @@ public class SwitchStyleActivity extends BaseDemoActivity
         if (state == null) {
           mapzenMap.setStyle(new BubbleWrapStyle());
         }
-        mapzenMap.setPersistMapState(true);
+        configureMap();
       }
     });
+  }
+
+  /**
+   * Configure the map after it has loaded the style. Override in subclass.
+   */
+  void configureMap() {
+    mapzenMap.setPersistMapState(true);
   }
 
   private void changeMapStyle(MapStyle style) {

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
@@ -28,7 +28,7 @@ public class SwitchStyleActivity extends BaseDemoActivity
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_spinner);
+    setContentView(getLayoutId());
 
     Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
     setSupportActionBar(toolbar);
@@ -52,6 +52,10 @@ public class SwitchStyleActivity extends BaseDemoActivity
         configureMap();
       }
     });
+  }
+
+  int getLayoutId() {
+    return R.layout.activity_spinner;
   }
 
   /**

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
@@ -43,12 +43,9 @@ public class SwitchStyleActivity extends BaseDemoActivity
 
     final Bundle state = savedInstanceState;
     mapFragment = (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-    mapFragment.getMapAsync(new BubbleWrapStyle(), new OnMapReadyCallback() {
+    mapFragment.getMapAsync(new OnMapReadyCallback() {
       @Override public void onMapReady(MapzenMap mapzenMap) {
         SwitchStyleActivity.this.mapzenMap = mapzenMap;
-        if (state == null) {
-          mapzenMap.setStyle(new BubbleWrapStyle());
-        }
         configureMap();
       }
     });
@@ -74,18 +71,21 @@ public class SwitchStyleActivity extends BaseDemoActivity
   @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
     switch (position) {
       case 0:
-        changeMapStyle(new BubbleWrapStyle());
+        // do nothing
         break;
       case 1:
-        changeMapStyle(new CinnabarStyle());
+        changeMapStyle(new BubbleWrapStyle());
         break;
       case 2:
-        changeMapStyle(new RefillStyle());
+        changeMapStyle(new CinnabarStyle());
         break;
       case 3:
-        changeMapStyle(new WalkaboutStyle());
+        changeMapStyle(new RefillStyle());
         break;
       case 4:
+        changeMapStyle(new WalkaboutStyle());
+        break;
+      case 5:
         changeMapStyle(new ZincStyle());
         break;
       default:

--- a/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_overlay.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_overlay.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    >
+
+  <android.support.design.widget.AppBarLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:theme="@style/AppTheme.AppBarOverlay"
+      >
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/AppTheme.PopupOverlay"
+        >
+
+      <LinearLayout
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal"
+          android:weightSum="1" >
+
+        <Spinner
+            android:id="@+id/spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".5"
+            />
+
+        <Spinner
+            android:id="@+id/overlay_spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight=".5"
+            />
+
+      </LinearLayout>
+
+    </android.support.v7.widget.Toolbar>
+
+  </android.support.design.widget.AppBarLayout>
+
+  <fragment
+      android:id="@+id/fragment"
+      android:name="com.mapzen.android.graphics.MapFragment"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior"
+      app:overlayMode="classic"
+      />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
@@ -80,4 +80,6 @@
   <string name="label_listener_map_demo_description">Adds a label pick listener to the map</string>
   <string name="custom_marker_demo_label">Custom Marker</string>
   <string name="custom_marker_demo_description">Adds a custom bitmap marker</string>
+  <string name="overlay_demo_label">Overlays</string>
+  <string name="overlay_demo_description">Toggle transit, bike, and path overlays</string>
 </resources>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
   <string-array name="overlay_array">
     <item>(Select Overlay)</item>
     <item>Transit</item>
+    <item>Bike</item>
     <item>None</item>
   </string-array>
   <string name="on_single_tap_up">Single Tap Up</string>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
   <string name="style_refill">Refill</string>
   <string name="style_outdoor">Outdoor</string>
   <string-array name="style_array">
+    <item>(Select Style)</item>
     <item>Bubble Wrap</item>
     <item>Cinnabar</item>
     <item>Refill</item>
@@ -27,7 +28,7 @@
     <item>Zinc</item>
   </string-array>
   <string-array name="overlay_array">
-    <item></item>
+    <item>(Select Overlay)</item>
     <item>Transit</item>
     <item>None</item>
   </string-array>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
@@ -26,6 +26,11 @@
     <item>Walkabout</item>
     <item>Zinc</item>
   </string-array>
+  <string-array name="overlay_array">
+    <item></item>
+    <item>Transit</item>
+    <item>None</item>
+  </string-array>
   <string name="on_single_tap_up">Single Tap Up</string>
   <string name="on_single_tap_confirmed">Single Tap Confirmed</string>
   <string name="on_shove">Shove</string>

--- a/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <item>(Select Overlay)</item>
     <item>Transit</item>
     <item>Bike</item>
+    <item>Path</item>
     <item>None</item>
   </string-array>
   <string name="on_single_tap_up">Single Tap Up</string>


### PR DESCRIPTION
### Overview
Adds support for transit,bike, and path overlays provided via global stylesheet variables.

### Proposed Changes
- Adds methods to `MapzenMap` to update these overlays individually or in bulk
- Transit and bike overlays are disabled by default, path overlay is enabled (to be consistent with house stylesheets)
- Persists overlay state on rotation
- Adds an `OverlayActivity` example to show off this functionality in the sample app
- Small UI and optimizations made to `SwitchStyleActivity` example

Closes #244 