### PR TITLE
Dont show empty toast in feature pick example

### DIFF
--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/FeaturePickListenerActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/FeaturePickListenerActivity.java
@@ -35,7 +35,9 @@ public class FeaturePickListenerActivity extends BaseDemoActivity {
       } else {
         title = properties.get(PROP_NAME);
       }
-      Toast.makeText(FeaturePickListenerActivity.this, title, Toast.LENGTH_SHORT).show();
+      if (title != null && !title.isEmpty()) {
+        Toast.makeText(FeaturePickListenerActivity.this, title, Toast.LENGTH_SHORT).show();
+      }
     }
   };
 


### PR DESCRIPTION
### Overview
Updates the `FeaturePickActivity` to not show an empty `Toast`. Currently, no `Toasts` are shown because the properties returned by the listener are always empty. This bug will be resolved ~in a future version of Tangram~ when the stylesheets are updated https://github.com/mapzen/android/issues/384 and the example is changed to use non-point style MapData https://github.com/mapzen/android/issues/385

Closes #314 
