### PR TITLE
Return Place from Feature if no gid present

### DIFF
--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasCallbackHandler.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasCallbackHandler.java
@@ -13,13 +13,13 @@ import retrofit2.Response;
  */
 class PeliasCallbackHandler {
 
-  private PeliasFeatureToPlaceConverter converter;
+  private PeliasFeatureConverter converter;
 
   /**
    * Constructor.
    */
   PeliasCallbackHandler() {
-    converter = new PeliasFeatureToPlaceConverter();
+    converter = new PeliasFeatureConverter();
   }
 
   /**
@@ -41,7 +41,7 @@ class PeliasCallbackHandler {
     for (Feature feature : response.body().getFeatures()) {
       if (feature.properties.name.equals(title)) {
         Place place = converter.getFetchedPlace(feature);
-        String details = getDetails(feature, title);
+        String details = converter.getDetails(feature, title);
         listener.onFetchSuccess(place, details);
       }
     }
@@ -63,9 +63,8 @@ class PeliasCallbackHandler {
     }
 
     Feature feature = response.body().getFeatures().get(0);
-    String title = feature.properties.name;
     Place place = converter.getFetchedPlace(feature);
-    String details = getDetails(feature, title);
+    String details = converter.getDetails(feature);
     listener.onFetchSuccess(place, details);
   }
 
@@ -87,11 +86,5 @@ class PeliasCallbackHandler {
    */
   void handleFailure(OnPlaceDetailsFetchedListener listener) {
     listener.onFetchFailure();
-  }
-
-  private String getDetails(Feature feature, String title) {
-    String label = feature.properties.label;
-    label = label.replace(title + ",", "").trim();
-    return title + "\n" + label;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasFeatureConverter.java
@@ -10,10 +10,10 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * Handles converting Pelias {@link Feature} objects into {@link Place} objects for
- * {@link PeliasCallbackHandler}.
+ * Handles converting Pelias {@link Feature} objects into {@link Place} objects and detail strings
+ * for {@link PeliasCallbackHandler}.
  */
-class PeliasFeatureToPlaceConverter {
+class PeliasFeatureConverter {
 
   private PeliasLayerToPlaceTypeConverter layerConverter;
   private PointToBoundsConverter pointConverter;
@@ -21,7 +21,7 @@ class PeliasFeatureToPlaceConverter {
   /**
    * Constructor.
    */
-  PeliasFeatureToPlaceConverter() {
+  PeliasFeatureConverter() {
     layerConverter = new PeliasLayerToPlaceTypeConverter();
     pointConverter = new PointToBoundsConverter();
   }
@@ -58,5 +58,27 @@ class PeliasFeatureToPlaceConverter {
         .setViewPort(viewport)
         .setWebsiteUri(null)
         .build();
+  }
+
+  /**
+   * Constructs a detail string from a {@link Feature}.
+   * @param feature
+   * @return
+   */
+  String getDetails(Feature feature) {
+    String title = feature.properties.name;
+    return getDetails(feature, title);
+  }
+
+  /**
+   * Constructs a detail string from a {@link Feature} and title.
+   * @param feature
+   * @param title
+   * @return
+   */
+  String getDetails(Feature feature, String title) {
+    String label = feature.properties.label;
+    label = label.replace(title + ",", "").trim();
+    return title + "\n" + label;
   }
 }

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverter.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PeliasLayerToPlaceTypeConverter.java
@@ -31,7 +31,7 @@ import static com.mapzen.places.api.internal.PeliasLayerConsts.PELIAS_LAYER_VENU
 
 /**
  * Converts a "layer" returned from Pelias into a list of {@link com.mapzen.places.api.Place} types
- * for {@link PeliasFeatureToPlaceConverter}.
+ * for {@link PeliasFeatureConverter}.
  */
 class PeliasLayerToPlaceTypeConverter {
 

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlaceAutocompleteActivity.java
@@ -87,9 +87,11 @@ public class PlaceAutocompleteActivity extends AppCompatActivity
     PeliasCallbackHandler callbackHandler = new PeliasCallbackHandler();
     PlaceDetailFetcher detailFetcher = new PeliasPlaceDetailFetcher(mapzenSearch.getPelias(),
         callbackHandler);
+    PeliasFeatureConverter featureConverter = new PeliasFeatureConverter();
     OnPlaceDetailsFetchedListener detailFetchListener = new AutocompleteDetailFetchListener(this);
     FilterMapper filterMapper = new PeliasFilterMapper();
-    presenter = new PlaceAutocompletePresenter(detailFetcher, detailFetchListener, filterMapper);
+    presenter = new PlaceAutocompletePresenter(detailFetcher, featureConverter, detailFetchListener,
+        filterMapper);
     presenter.setBounds((LatLngBounds) safeGetExtra(EXTRA_BOUNDS));
     presenter.setFilter((AutocompleteFilter) safeGetExtra(EXTRA_FILTER));
     LostApiClient client = new LostApiClient.Builder(this).build();

--- a/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerViewController.java
+++ b/mapzen-places-api/src/main/java/com/mapzen/places/api/internal/PlacePickerViewController.java
@@ -9,15 +9,15 @@ import com.mapzen.places.api.Place;
 interface PlacePickerViewController {
   /**
    * Show an alert dialog to represent the place selected by the user.
-   * @param id
-   * @param title
+   * @param id the selected {@link Place}'s id.
+   * @param title the dialog title.
    */
   void showDialog(String id, String title);
 
   /**
    * Update the visible dialog with more details about the selected place.
-   * @param id
-   * @param message
+   * @param id the selected {@link Place}'s id.
+   * @param message the dialog message.
    */
   void updateDialog(String id, String message);
 

--- a/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureConverterTest.java
+++ b/mapzen-places-api/src/test/java/com/mapzen/places/api/internal/PeliasFeatureConverterTest.java
@@ -12,9 +12,9 @@ import static com.mapzen.places.api.Place.TYPE_ESTABLISHMENT;
 import static com.mapzen.places.api.Place.TYPE_POINT_OF_INTEREST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PeliasFeatureToPlaceConverterTest {
+public class PeliasFeatureConverterTest {
 
-  PeliasFeatureToPlaceConverter converter = new PeliasFeatureToPlaceConverter();
+  PeliasFeatureConverter converter = new PeliasFeatureConverter();
 
   @Test
   public void getFetchedPlace_shouldHaveCorrectAddress() throws Exception {


### PR DESCRIPTION
### Overview
To handle optional `gid` values, this code updates the `Places` API to simply return a `Place` object from the current `Feature` instead of trying to fetch details given an empty `gid`

### Proposed Changes
- Refactors code to create a `Place` and details string into the same `PeliasFeatureConverter` object to centralize logic
- Updates documentation
- Adds more test coverage for optional `gid`

Closes #388 
