### PR TITLE
Update placeholder text, few links, typos

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,15 +14,15 @@ A map can be added to a layout using either `MapView` or `MapFragment`.
 
 ## 2. Sign up for a Mapzen API key
 
-Sign up for an API key from the [Mapzen developer portal](https://mapzen.com/developers).
+Sign up for an API key from the [Mapzen developer portal](https://mapzen.com/documentation/overview/).
 
 ### Set API key using a string resource
 
-You can set your Mapzen API key via an XML string resource. Add a file `app/src/main/res/values/mapzen.xml` and copy the following code but replace `[YOUR_MAPZEN_API_KEY]` with your real Mapzen API key from the developer portal.
+You can set your Mapzen API key via an XML string resource. Add a file `app/src/main/res/values/mapzen.xml` and copy the following code.
 
 ```xml
 <resources>
-    <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
+    <string name="mapzen_api_key">your-mapzen-api-key</string>
 </resources>
 ```
 
@@ -30,10 +30,8 @@ You can set your Mapzen API key via an XML string resource. Add a file `app/src/
 
 Alternatively you can set your Mapzen API key via the `MapzenManager` class. Just make sure you call the following method prior to calling `MapView#getMapAsyc(...)` or creating an instance of `MapzenSearch` or `MapzenRouter`.
 
-Of course you'll want to replace `[YOUR_MAPZEN_API_KEY]` with your real key just like above.
-
 ```java
-MapzenManager.instance(context).setApiKey("[YOUR_MAPZEN_API_KEY]");
+MapzenManager.instance(context).setApiKey("your-mapzen-api-key");
 ```
 
 ## 3. Initialize the map
@@ -51,6 +49,6 @@ mapFragment.getMapAsync(new OnMapReadyCallback() {
 
 Your map is now ready to use. `MapzenMap` is your main entry point to interact with the map.
 
-Most common map operertions can be completed using `MapzenMap` including [setting the position, rotation, zoom, and tilt](https://mapzen.com/documentation/android/basic-functions/). You can also [load new styles](https://mapzen.com/documentation/android/styles/) or draw [point](https://mapzen.com/documentation/android/add-features/), [line](https://mapzen.com/documentation/android/add-features/), and [polygon](https://mapzen.com/documentation/android/add-features/) overlays.
+Most common map operations can be completed using `MapzenMap` including [setting the position, rotation, zoom, and tilt](https://mapzen.com/documentation/android/basic-functions/). You can also [load new styles](https://mapzen.com/documentation/android/styles/) or draw [point](https://mapzen.com/documentation/android/add-features/), [line](https://mapzen.com/documentation/android/add-features/), and [polygon](https://mapzen.com/documentation/android/add-features/) overlays.
 
 For advanced use cases you have access the underlying Tangram `MapController` instance by calling `MapzenMap#getMapController()`. See the [Tangram ES Android documentation](https://mapzen.com/documentation/tangram/Android-API/) for more information.

--- a/docs/search.md
+++ b/docs/search.md
@@ -2,14 +2,14 @@
 
 ## Getting Started
 
-To start using Mapzen Search in your apps, you need a Mapzen developer API key. After you [sign up for an API key](https://mapzen.com/developers/sign_in) you will need to include it in your application through the Java API or in a `mapzen.xml` properties file in your app resources folder.
+To start using Mapzen Search in your apps, you need a Mapzen API key. After you [sign up for an API key](https://mapzen.com/documentation/overview/) you will need to include it in your application through the Java API or in a `mapzen.xml` properties file in your app resources folder.
 
 **MySearchActivity.java**
 
 ```java
 public class MySearchActivity extends Activity {
   @Override protected void onCreate(Bundle icicle) {
-    MapzenSearch mapzenSearch = new MapzenSearch(this, “YOUR_MAPZEN_API_KEY”);
+    MapzenSearch mapzenSearch = new MapzenSearch(this, “your-mapzen-api-key”);
     ...
   }
 ```
@@ -18,7 +18,7 @@ public class MySearchActivity extends Activity {
 
 ```xml
 <resources>
-  <string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
+  <string name="mapzen_api_key">your-mapzen-api-key</string>
 </resources>
 ```
 
@@ -86,7 +86,7 @@ AutoCompleteAdapter adapter = new AutoCompleteAdapter(this,
 listView.setAdapter(autocompleteAdapter);
 
 // Configure search service
-MapzenSearch mapzenSearch = new MapzenSearch(this, “YOUR_MAPZEN_API_KEY”);
+MapzenSearch mapzenSearch = new MapzenSearch(this, “your-mapzen-api-key”);
 
 // Tying it all together
 peliasSearchView.setAutoCompleteListView(listView);

--- a/docs/turn-by-turn.md
+++ b/docs/turn-by-turn.md
@@ -2,18 +2,18 @@
 
 ## Getting Started
 
-To start using Mapzen Turn-by-turn in your apps, you need a Mapzen developer API key. After you [sign up for an API key](https://mapzen.com/developers/sign_in) you will need to include it in your application through the Java API or in a `mapzen.xml` properties file in your app resources folder.
+To start using Mapzen Turn-by-turn in your apps, you need a Mapzen API key. After you [sign up for an API key](https://mapzen.com/documentation/overview/) you will need to include it in your application through the Java API or in a `mapzen.xml` properties file in your app resources folder.
 
 **Java API**
 ```java
-MapzenRouter router = new MapzenRouter(this, [YOUR_MAPZEN_API_KEY]);
+MapzenRouter router = new MapzenRouter(this, your-mapzen-api-key);
 ```
 
 -or-
 
 **mapzen.xml**
 ```xml
-<string name="mapzen_api_key">[YOUR_MAPZEN_API_KEY]</string>
+<string name="mapzen_api_key">your-mapzen-api-key</string>
 ```
 
 ```java
@@ -119,7 +119,7 @@ After the listener is set, the engine is ready to receive a route:
 engine.setRoute(route);
 ```
 
-The next thing you need to do is retrieve the device’s current location. We won’t detail out how to do this here but we recommend using a library like [Lost](https://github.com/mapzen/LOST) to facilitate this task. As you receive location updates, you need to notify the `RouteEngine` of the new current location. You can do this by converting your `Location` objects into `ValhallaLocation` objects and simply calling:
+The next thing you need to do is retrieve the device’s current location. Without detailing how to do this here, but it is recommended using a library like [Lost](https://github.com/mapzen/LOST) to facilitate this task. As you receive location updates, you need to notify the `RouteEngine` of the new current location. You can do this by converting your `Location` objects into `ValhallaLocation` objects and simply calling:
 
 ```java
 ValhallaLocation valhallaLocation = new ValhallaLocation();
@@ -131,4 +131,3 @@ engine.onLocationChanged(valhallaLocation);
 ```
 
 Every time this method is called, `RouteEngine` will do the heavy lifting to determine whether the user has started the route, reached a milestone or instruction, gotten lost, or ended the route. Your `RouteListener` will be called on each of these events, allowing you to appropriately request a new route if the user is lost or speak instructions upon the approach of a milestone or instruction.
-


### PR DESCRIPTION
These changes are part of https://github.com/mapzen/documentation/issues/310

This updates the placeholder text to use your-mapzen-api-key (please make sure I didn't accidentally remove required quotation marks or anything like that) so it can be automatically replaced when signed in.

I also deleted some text that describes how to use the placeholder text (like replace it with your real key) because the key is already replaced when signed in, and the pop-up over the text will be the call to action for users who are not signed in.

There were also a few minor style (change "we" to you or third-party) and typo issues that I happened to see.