### PR TITLE
Restore Markers

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -20,4 +20,5 @@
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapzenMap.java"/>
     <suppress checks="[a-zA-Z0-9]*" files="src/main/java/com/mapzen/android/graphics/TmpHttpHandler.java"/>
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java"/>
+    <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/model/MarkerManager.java"/>
 </suppressions>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -19,4 +19,5 @@
     <suppress checks="ConstantName" files="R.java" />
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapzenMap.java"/>
     <suppress checks="[a-zA-Z0-9]*" files="src/main/java/com/mapzen/android/graphics/TmpHttpHandler.java"/>
+    <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java"/>
 </suppressions>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -21,4 +21,5 @@
     <suppress checks="[a-zA-Z0-9]*" files="src/main/java/com/mapzen/android/graphics/TmpHttpHandler.java"/>
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java"/>
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/model/MarkerManager.java"/>
+    <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java"/>
 </suppressions>

--- a/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
+++ b/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
@@ -2,6 +2,7 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarkerFactory;
+import com.mapzen.android.graphics.model.MarkerManager;
 
 import javax.inject.Singleton;
 
@@ -52,5 +53,14 @@ import dagger.Provides;
    */
   @Provides @Singleton public StyleStringGenerator providesStyleStringGenerator() {
     return new StyleStringGenerator();
+  }
+
+  /**
+   * Returns the object used to manager markers.
+   * {@link com.mapzen.tangram.Marker}.
+   */
+  @Provides @Singleton public MarkerManager providesMarkerManager(
+      BitmapMarkerFactory bitmapMarkerFactory, StyleStringGenerator styleStringGenerator) {
+    return new MarkerManager(bitmapMarkerFactory, styleStringGenerator);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
+++ b/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
@@ -1,5 +1,8 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
+
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -33,5 +36,21 @@ import dagger.Provides;
    */
   @Provides @Singleton public SceneUpdateManager providesSceneUpdateManager() {
     return new SceneUpdateManager();
+  }
+
+  /**
+   * Returns the object used create {@link com.mapzen.android.graphics.model.BitmapMarker}s.
+   * @return
+   */
+  @Provides @Singleton public BitmapMarkerFactory providesBitmapMarkerFactory() {
+    return new BitmapMarkerFactory();
+  }
+
+  /**
+   * Returns the object used to generate a style string for a Tangram
+   * {@link com.mapzen.tangram.Marker}.
+   */
+  @Provides @Singleton public StyleStringGenerator providesStyleStringGenerator() {
+    return new StyleStringGenerator();
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
+++ b/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
@@ -2,7 +2,7 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarkerFactory;
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 
 import javax.inject.Singleton;
 
@@ -59,8 +59,8 @@ import dagger.Provides;
    * Returns the object used to manager markers.
    * {@link com.mapzen.tangram.Marker}.
    */
-  @Provides @Singleton public MarkerManager providesMarkerManager(
+  @Provides @Singleton public BitmapMarkerManager providesBitmapMarkerManager(
       BitmapMarkerFactory bitmapMarkerFactory, StyleStringGenerator styleStringGenerator) {
-    return new MarkerManager(bitmapMarkerFactory, styleStringGenerator);
+    return new BitmapMarkerManager(bitmapMarkerFactory, styleStringGenerator);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.MapStyle;
 import com.mapzen.tangram.MapController;
@@ -33,18 +35,25 @@ public class MapInitializer {
 
   MapReadyInitializer mapReadyInitializer;
 
+  private BitmapMarkerFactory bitmapMarkerFactory;
+
+  private StyleStringGenerator styleStringGenerator;
+
   /**
    * Creates a new instance.
    */
   @Inject MapInitializer(Context context, MapzenMapHttpHandler mapzenMapHttpHandler,
       MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager) {
+      SceneUpdateManager sceneUpdateManager, BitmapMarkerFactory bitmapMarkerFactory,
+      StyleStringGenerator styleStringGenerator) {
     this.context = context;
     this.mapzenMapHttpHandler = mapzenMapHttpHandler;
     this.mapDataManager = mapDataManager;
     this.mapStateManager = mapStateManager;
     this.sceneUpdateManager = sceneUpdateManager;
     mapReadyInitializer = new MapReadyInitializer();
+    this.bitmapMarkerFactory = bitmapMarkerFactory;
+    this.styleStringGenerator = styleStringGenerator;
   }
 
   /**
@@ -93,7 +102,7 @@ public class MapInitializer {
         new MapController.SceneLoadListener() {
       @Override public void onSceneReady(int sceneId, SceneError sceneError) {
         mapReadyInitializer.onMapReady(mapView, mapzenMapHttpHandler, callback, mapDataManager,
-            mapStateManager, sceneUpdateManager, locale);
+            mapStateManager, sceneUpdateManager, locale, bitmapMarkerFactory, styleStringGenerator);
       }
     });
     controller.loadSceneFileAsync(sceneFile, sceneUpdates);

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -3,7 +3,7 @@ package com.mapzen.android.graphics;
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.MapStyle;
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneError;
 import com.mapzen.tangram.SceneUpdate;
@@ -34,21 +34,21 @@ public class MapInitializer {
 
   MapReadyInitializer mapReadyInitializer;
 
-  private MarkerManager markerManager;
+  private BitmapMarkerManager bitmapMarkerManager;
 
   /**
    * Creates a new instance.
    */
   @Inject MapInitializer(Context context, MapzenMapHttpHandler mapzenMapHttpHandler,
       MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, MarkerManager markerManager) {
+      SceneUpdateManager sceneUpdateManager, BitmapMarkerManager bitmapMarkerManager) {
     this.context = context;
     this.mapzenMapHttpHandler = mapzenMapHttpHandler;
     this.mapDataManager = mapDataManager;
     this.mapStateManager = mapStateManager;
     this.sceneUpdateManager = sceneUpdateManager;
     mapReadyInitializer = new MapReadyInitializer();
-    this.markerManager = markerManager;
+    this.bitmapMarkerManager = bitmapMarkerManager;
   }
 
   /**
@@ -97,7 +97,7 @@ public class MapInitializer {
         new MapController.SceneLoadListener() {
       @Override public void onSceneReady(int sceneId, SceneError sceneError) {
         mapReadyInitializer.onMapReady(mapView, mapzenMapHttpHandler, callback, mapDataManager,
-            mapStateManager, sceneUpdateManager, locale, markerManager);
+            mapStateManager, sceneUpdateManager, locale, bitmapMarkerManager);
       }
     });
     controller.loadSceneFileAsync(sceneFile, sceneUpdates);

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -1,10 +1,9 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
-import com.mapzen.android.graphics.internal.StyleStringGenerator;
-import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.MapStyle;
+import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneError;
 import com.mapzen.tangram.SceneUpdate;
@@ -35,25 +34,21 @@ public class MapInitializer {
 
   MapReadyInitializer mapReadyInitializer;
 
-  private BitmapMarkerFactory bitmapMarkerFactory;
-
-  private StyleStringGenerator styleStringGenerator;
+  private MarkerManager markerManager;
 
   /**
    * Creates a new instance.
    */
   @Inject MapInitializer(Context context, MapzenMapHttpHandler mapzenMapHttpHandler,
       MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, BitmapMarkerFactory bitmapMarkerFactory,
-      StyleStringGenerator styleStringGenerator) {
+      SceneUpdateManager sceneUpdateManager, MarkerManager markerManager) {
     this.context = context;
     this.mapzenMapHttpHandler = mapzenMapHttpHandler;
     this.mapDataManager = mapDataManager;
     this.mapStateManager = mapStateManager;
     this.sceneUpdateManager = sceneUpdateManager;
     mapReadyInitializer = new MapReadyInitializer();
-    this.bitmapMarkerFactory = bitmapMarkerFactory;
-    this.styleStringGenerator = styleStringGenerator;
+    this.markerManager = markerManager;
   }
 
   /**
@@ -102,7 +97,7 @@ public class MapInitializer {
         new MapController.SceneLoadListener() {
       @Override public void onSceneReady(int sceneId, SceneError sceneError) {
         mapReadyInitializer.onMapReady(mapView, mapzenMapHttpHandler, callback, mapDataManager,
-            mapStateManager, sceneUpdateManager, locale, bitmapMarkerFactory, styleStringGenerator);
+            mapStateManager, sceneUpdateManager, locale, markerManager);
       }
     });
     controller.loadSceneFileAsync(sceneFile, sceneUpdates);

--- a/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
@@ -1,6 +1,8 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.MapController;
 
@@ -24,7 +26,8 @@ class MapReadyInitializer {
    */
   void onMapReady(MapView mapView, MapzenMapHttpHandler mapzenMapHttpHandler,
       OnMapReadyCallback callback, MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, Locale locale) {
+      SceneUpdateManager sceneUpdateManager, Locale locale, BitmapMarkerFactory bitmapMarkerFactory,
+      StyleStringGenerator styleStringGenerator) {
     MapController mapController = mapView.getTangramMapView().getMap(null);
     mapController.setSceneLoadListener(null);
     mapController.setHttpHandler(mapzenMapHttpHandler.httpHandler());
@@ -32,6 +35,7 @@ class MapReadyInitializer {
     callback.onMapReady(
         new MapzenMap(mapView, mapController, new OverlayManager(mapView, mapController,
             mapDataManager, mapStateManager), mapStateManager, new LabelPickHandler(mapView),
-            new MarkerManager(mapController), sceneUpdateManager, locale, mapzenManager));
+            new MarkerManager(mapController, bitmapMarkerFactory, styleStringGenerator),
+            sceneUpdateManager, locale, mapzenManager));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
@@ -1,7 +1,7 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.tangram.MapController;
 
 import java.util.Locale;
@@ -24,15 +24,15 @@ class MapReadyInitializer {
    */
   void onMapReady(MapView mapView, MapzenMapHttpHandler mapzenMapHttpHandler,
       OnMapReadyCallback callback, MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, Locale locale, MarkerManager markerManager) {
+      SceneUpdateManager sceneUpdateManager, Locale locale, BitmapMarkerManager bitmapMarkerManager) {
     MapController mapController = mapView.getTangramMapView().getMap(null);
     mapController.setSceneLoadListener(null);
     mapController.setHttpHandler(mapzenMapHttpHandler.httpHandler());
     MapzenManager mapzenManager = MapzenManager.instance(mapView.getContext());
-    markerManager.setMapController(mapController);
+    bitmapMarkerManager.setMapController(mapController);
     callback.onMapReady(
         new MapzenMap(mapView, mapController, new OverlayManager(mapView, mapController,
             mapDataManager, mapStateManager), mapStateManager, new LabelPickHandler(mapView),
-            markerManager, sceneUpdateManager, locale, mapzenManager));
+            bitmapMarkerManager, sceneUpdateManager, locale, mapzenManager));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
@@ -1,8 +1,6 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
-import com.mapzen.android.graphics.internal.StyleStringGenerator;
-import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.MapController;
 
@@ -26,16 +24,15 @@ class MapReadyInitializer {
    */
   void onMapReady(MapView mapView, MapzenMapHttpHandler mapzenMapHttpHandler,
       OnMapReadyCallback callback, MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, Locale locale, BitmapMarkerFactory bitmapMarkerFactory,
-      StyleStringGenerator styleStringGenerator) {
+      SceneUpdateManager sceneUpdateManager, Locale locale, MarkerManager markerManager) {
     MapController mapController = mapView.getTangramMapView().getMap(null);
     mapController.setSceneLoadListener(null);
     mapController.setHttpHandler(mapzenMapHttpHandler.httpHandler());
     MapzenManager mapzenManager = MapzenManager.instance(mapView.getContext());
+    markerManager.setMapController(mapController);
     callback.onMapReady(
         new MapzenMap(mapView, mapController, new OverlayManager(mapView, mapController,
             mapDataManager, mapStateManager), mapStateManager, new LabelPickHandler(mapView),
-            new MarkerManager(mapController, bitmapMarkerFactory, styleStringGenerator),
-            sceneUpdateManager, locale, mapzenManager));
+            markerManager, sceneUpdateManager, locale, mapzenManager));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java
@@ -24,7 +24,8 @@ class MapReadyInitializer {
    */
   void onMapReady(MapView mapView, MapzenMapHttpHandler mapzenMapHttpHandler,
       OnMapReadyCallback callback, MapDataManager mapDataManager, MapStateManager mapStateManager,
-      SceneUpdateManager sceneUpdateManager, Locale locale, BitmapMarkerManager bitmapMarkerManager) {
+      SceneUpdateManager sceneUpdateManager, Locale locale,
+      BitmapMarkerManager bitmapMarkerManager) {
     MapController mapController = mapView.getTangramMapView().getMap(null);
     mapController.setSceneLoadListener(null);
     mapController.setHttpHandler(mapzenMapHttpHandler.httpHandler());

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -3,11 +3,11 @@ package com.mapzen.android.graphics;
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarker;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
 import com.mapzen.android.graphics.model.MapStyle;
 import com.mapzen.android.graphics.model.Marker;
-import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.android.graphics.model.MarkerOptions;
 import com.mapzen.android.graphics.model.Polygon;
 import com.mapzen.android.graphics.model.Polyline;
@@ -49,7 +49,7 @@ public class MapzenMap {
   private final OverlayManager overlayManager;
   private final MapStateManager mapStateManager;
   private final LabelPickHandler labelPickHandler;
-  private final MarkerManager markerManager;
+  private final BitmapMarkerManager bitmapMarkerManager;
   private final SceneUpdateManager sceneUpdateManager;
   private final MapzenManager mapzenManager;
   private Locale locale;
@@ -142,7 +142,7 @@ public class MapzenMap {
   MapController.SceneLoadListener internalSceneLoadListener
       = new MapController.SceneLoadListener() {
     @Override public void onSceneReady(int sceneId, SceneError sceneError) {
-      markerManager.restoreMarkers();
+      bitmapMarkerManager.restoreMarkers();
     }
   };
 
@@ -151,7 +151,7 @@ public class MapzenMap {
    */
   MapzenMap(MapView mapView, MapController mapController, OverlayManager overlayManager,
       MapStateManager mapStateManager, LabelPickHandler labelPickHandler,
-      MarkerManager markerManager, SceneUpdateManager sceneUpdateManager, Locale locale,
+      BitmapMarkerManager bitmapMarkerManager, SceneUpdateManager sceneUpdateManager, Locale locale,
       MapzenManager mapzenManager) {
     this.mapView = mapView;
     this.mapController = mapController;
@@ -159,7 +159,7 @@ public class MapzenMap {
     this.overlayManager = overlayManager;
     this.mapStateManager = mapStateManager;
     this.labelPickHandler = labelPickHandler;
-    this.markerManager = markerManager;
+    this.bitmapMarkerManager = bitmapMarkerManager;
     this.sceneUpdateManager = sceneUpdateManager;
     this.locale = locale;
     this.mapzenManager = mapzenManager;
@@ -655,7 +655,7 @@ public class MapzenMap {
         mapView.post(new Runnable() {
           @Override public void run() {
             if (markerPickResult != null) {
-              listener.onMarkerPick(new BitmapMarker(markerManager, markerPickResult.getMarker(),
+              listener.onMarkerPick(new BitmapMarker(bitmapMarkerManager, markerPickResult.getMarker(),
                   new StyleStringGenerator()));
             }
           }
@@ -964,6 +964,6 @@ public class MapzenMap {
    * @return a new bitmap marker instance.
    */
   public BitmapMarker addBitmapMarker(MarkerOptions markerOptions) {
-    return markerManager.addMarker(markerOptions);
+    return bitmapMarkerManager.addMarker(markerOptions);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -15,6 +15,7 @@ import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.MarkerPickResult;
+import com.mapzen.tangram.SceneError;
 import com.mapzen.tangram.SceneUpdate;
 import com.mapzen.tangram.TouchInput;
 
@@ -138,6 +139,13 @@ public class MapzenMap {
     }
   };
 
+  MapController.SceneLoadListener internalSceneLoadListener
+      = new MapController.SceneLoadListener() {
+    @Override public void onSceneReady(int sceneId, SceneError sceneError) {
+      markerManager.restoreMarkers();
+    }
+  };
+
   /**
    * Creates a new map based on the given {@link MapView} and {@link MapController}.
    */
@@ -147,6 +155,7 @@ public class MapzenMap {
       MapzenManager mapzenManager) {
     this.mapView = mapView;
     this.mapController = mapController;
+    this.mapController.setSceneLoadListener(internalSceneLoadListener);
     this.overlayManager = overlayManager;
     this.mapStateManager = mapStateManager;
     this.labelPickHandler = labelPickHandler;

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -4,6 +4,7 @@ import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarker;
 import com.mapzen.android.graphics.model.BitmapMarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerOptions;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
 import com.mapzen.android.graphics.model.MapStyle;
@@ -963,7 +964,18 @@ public class MapzenMap {
    * @param markerOptions options used to define marker appearance.
    * @return a new bitmap marker instance.
    */
+  @Deprecated
   public BitmapMarker addBitmapMarker(MarkerOptions markerOptions) {
+    return bitmapMarkerManager.addMarker(markerOptions);
+  }
+
+  /**
+   * Adds a custom bitmap marker to the map.
+   *
+   * @param markerOptions options used to define marker appearance.
+   * @return a new bitmap marker instance.
+   */
+  public BitmapMarker addBitmapMarker(BitmapMarkerOptions markerOptions) {
     return bitmapMarkerManager.addMarker(markerOptions);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -656,8 +656,8 @@ public class MapzenMap {
         mapView.post(new Runnable() {
           @Override public void run() {
             if (markerPickResult != null) {
-              listener.onMarkerPick(new BitmapMarker(bitmapMarkerManager, markerPickResult.getMarker(),
-                  new StyleStringGenerator()));
+              listener.onMarkerPick(new BitmapMarker(bitmapMarkerManager,
+                  markerPickResult.getMarker(), new StyleStringGenerator()));
             }
           }
         });

--- a/core/src/main/java/com/mapzen/android/graphics/internal/StyleStringGenerator.java
+++ b/core/src/main/java/com/mapzen/android/graphics/internal/StyleStringGenerator.java
@@ -7,42 +7,11 @@ package com.mapzen.android.graphics.internal;
  */
 public class StyleStringGenerator {
 
-  private int width = 50;
-  private int height = 50;
-  private boolean interactive = true;
-  private String colorHex = "#FFFFFF";
-
-  /**
-   * Set the width and height in pixels.
-   * @param width
-   * @param height
-   */
-  public void setSize(int width, int height) {
-    this.width = width;
-    this.height = height;
-  }
-
-  /**
-   * Set whether or not the marker can be selected.
-   * @param interactive
-   */
-  public void setInteractive(boolean interactive) {
-    this.interactive = interactive;
-  }
-
-  /**
-   * Sets the hex value for color to be used.
-   * @param hex
-   */
-  public void setColor(String hex) {
-    this.colorHex = hex;
-  }
-
   /**
    * Return the style string given the current property configurations.
    * @return
    */
-  public String getStyleString() {
+  public String getStyleString(int width, int height, boolean interactive, String colorHex) {
     return new StringBuilder()
         .append("{ style: 'points', color: '")
         .append(colorHex)

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
@@ -13,7 +13,7 @@ import android.graphics.drawable.Drawable;
 public class BitmapMarker {
 
   private final MarkerManager markerManager;
-  private final Marker tangramMarker;
+  private Marker tangramMarker;
   private final StyleStringGenerator styleStringGenerator;
   private LngLat position;
   private int resourceId;
@@ -121,7 +121,6 @@ public class BitmapMarker {
   public void setSize(int width, int height) {
     this.width = width;
     this.height = height;
-    styleStringGenerator.setSize(width, height);
     updateStyleString();
   }
 
@@ -198,9 +197,7 @@ public class BitmapMarker {
    */
   public void setColor(int colorInt) {
     this.colorInt = colorInt;
-    this.colorHex = null;
-    String hex = "#" + Integer.toHexString(colorInt);
-    styleStringGenerator.setColor(hex);
+    this.colorHex = "#" + Integer.toHexString(colorInt);
     updateStyleString();
   }
 
@@ -220,7 +217,6 @@ public class BitmapMarker {
   public void setColor(String hex) {
     this.colorHex = hex;
     this.colorInt = Integer.MIN_VALUE;
-    styleStringGenerator.setColor(hex);
     updateStyleString();
   }
 
@@ -238,7 +234,6 @@ public class BitmapMarker {
    */
   public void setInteractive(boolean interactive) {
     this.isInteractive = interactive;
-    styleStringGenerator.setInteractive(interactive);
     updateStyleString();
   }
 
@@ -251,6 +246,14 @@ public class BitmapMarker {
   }
 
   /**
+   * Allows setting the tangram marker, useful when restoring markers.
+   * @param tangramMarker
+   */
+  void setTangramMarker(Marker tangramMarker) {
+    this.tangramMarker = tangramMarker;
+  }
+
+  /**
    * Returns the underlying Tangram {@link Marker}.
    * @return
    */
@@ -258,8 +261,17 @@ public class BitmapMarker {
     return tangramMarker;
   }
 
+  /**
+   * Returns the object used to generate style string.
+   * @return
+   */
+  StyleStringGenerator getStyleStringGenerator() {
+    return styleStringGenerator;
+  }
+
   private void updateStyleString() {
-    tangramMarker.setStylingFromString(styleStringGenerator.getStyleString());
+    tangramMarker.setStylingFromString(styleStringGenerator.getStyleString(width, height,
+        isInteractive, colorHex));
   }
 
 }

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
@@ -15,6 +15,16 @@ public class BitmapMarker {
   private final MarkerManager markerManager;
   private final Marker tangramMarker;
   private final StyleStringGenerator styleStringGenerator;
+  private LngLat position;
+  private int resourceId;
+  private Drawable drawable;
+  private int width;
+  private int height;
+  private boolean isVisible;
+  private int drawOrder;
+  private int colorInt;
+  private String colorHex;
+  private boolean isInteractive;
 
   /**
    * Constructor that wraps a Tangram marker.
@@ -33,7 +43,7 @@ public class BitmapMarker {
    * methods is undefined.
    */
   public void remove() {
-    markerManager.removeMarker(tangramMarker);
+    markerManager.removeMarker(this);
   }
 
   /**
@@ -41,6 +51,7 @@ public class BitmapMarker {
    * @param position
    */
   public void setPosition(LngLat position) {
+    this.position = position;
     this.tangramMarker.setPoint(position);
   }
 
@@ -51,24 +62,55 @@ public class BitmapMarker {
    * @param easeType
    */
   public void setPosition(LngLat position, int duration, EaseType easeType) {
+    this.position = position;
     this.tangramMarker.setPointEased(position, duration,
         EaseTypeConverter.EASE_TYPE_TO_MAP_CONTROLLER_EASE_TYPE.get(easeType));
   }
 
   /**
-   * Sets the drawable resource id displayed as the marker's icon.
+   * Returns the marker's coordinate position.
+   * @return
+   */
+  public LngLat getPosition() {
+    return this.position;
+  }
+
+  /**
+   * Sets the drawable resource id displayed as the marker's icon. Setting this value will override
+   * existing icon drawable values set via {@link BitmapMarker#setIcon(Drawable)}.
    * @param resourceId
    */
   public void setIcon(int resourceId) {
+    this.resourceId = resourceId;
+    this.drawable = null;
     this.tangramMarker.setDrawable(resourceId);
   }
 
   /**
-   * Sets the drawable displayed as the marker's icon.
+   * Returns the marker's icon resource id.
+   * @return
+   */
+  public int getIcon() {
+    return this.resourceId;
+  }
+
+  /**
+   * Sets the drawable displayed as the marker's icon. Setting this value will override existing
+   * icon resource id values set via {@link BitmapMarker#setIcon(int)}.
    * @param drawable
    */
   public void setIcon(Drawable drawable) {
+    this.resourceId = Integer.MIN_VALUE;
+    this.drawable = drawable;
     this.tangramMarker.setDrawable(drawable);
+  }
+
+  /**
+   * Returns the marker's icon drawable.
+   * @return
+   */
+  public Drawable getIconDrawable() {
+    return this.drawable;
   }
 
   /**
@@ -77,8 +119,26 @@ public class BitmapMarker {
    * @param height
    */
   public void setSize(int width, int height) {
+    this.width = width;
+    this.height = height;
     styleStringGenerator.setSize(width, height);
     updateStyleString();
+  }
+
+  /**
+   * Returns the marker's width in pixels.
+   * @return
+   */
+  public int getWidth() {
+    return this.width;
+  }
+
+  /**
+   * Returns the marker's height in pixels.
+   * @return
+   */
+  public int getHeight() {
+    return this.height;
   }
 
   /**
@@ -86,7 +146,16 @@ public class BitmapMarker {
    * @param visible
    */
   public void setVisible(boolean visible) {
+    this.isVisible = visible;
     tangramMarker.setVisible(visible);
+  }
+
+  /**
+   * Returns whether the marker is visible.
+   * @return
+   */
+  public boolean isVisible() {
+    return isVisible;
   }
 
   /**
@@ -94,7 +163,16 @@ public class BitmapMarker {
    * @param drawOrder
    */
   public void setDrawOrder(int drawOrder) {
+    this.drawOrder = drawOrder;
     this.tangramMarker.setDrawOrder(drawOrder);
+  }
+
+  /**
+   * Returns the marker's z-axis draw order.
+   * @return
+   */
+  public int getDrawOrder() {
+    return this.drawOrder;
   }
 
   /**
@@ -114,22 +192,44 @@ public class BitmapMarker {
   }
 
   /**
-   * Sets color of marker given a color int ie {@code android.graphics.Color.BLUE}.
+   * Sets color of marker given a color int ie {@code android.graphics.Color.BLUE}. Setting this
+   * value will override existing color hex values set via {@link BitmapMarker#setColor(String)}.
    * @param colorInt
    */
   public void setColor(int colorInt) {
+    this.colorInt = colorInt;
+    this.colorHex = null;
     String hex = "#" + Integer.toHexString(colorInt);
     styleStringGenerator.setColor(hex);
     updateStyleString();
   }
 
   /**
-   * Sets color of marker given a color hex string.
+   * Returns the marker's color int.
+   * @return
+   */
+  public int getColor() {
+    return this.colorInt;
+  }
+
+  /**
+   * Sets color of marker given a color hex string. Setting this value will override existing
+   * color int values set via {@link BitmapMarker#setColor(int)}.
    * @param hex
    */
   public void setColor(String hex) {
+    this.colorHex = hex;
+    this.colorInt = Integer.MIN_VALUE;
     styleStringGenerator.setColor(hex);
     updateStyleString();
+  }
+
+  /**
+   * Returns the marker's color hex.
+   * @return
+   */
+  public String getColorHex() {
+    return this.colorHex;
   }
 
   /**
@@ -137,8 +237,25 @@ public class BitmapMarker {
    * @param interactive
    */
   public void setInteractive(boolean interactive) {
+    this.isInteractive = interactive;
     styleStringGenerator.setInteractive(interactive);
     updateStyleString();
+  }
+
+  /**
+   * Returns whether or not the marker responds to touches.
+   * @return
+   */
+  public boolean isInteractive() {
+    return this.isInteractive;
+  }
+
+  /**
+   * Returns the underlying Tangram {@link Marker}.
+   * @return
+   */
+  Marker getTangramMarker() {
+    return tangramMarker;
   }
 
   private void updateStyleString() {

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarker.java
@@ -12,7 +12,7 @@ import android.graphics.drawable.Drawable;
  */
 public class BitmapMarker {
 
-  private final MarkerManager markerManager;
+  private final BitmapMarkerManager bitmapMarkerManager;
   private Marker tangramMarker;
   private final StyleStringGenerator styleStringGenerator;
   private LngLat position;
@@ -31,9 +31,9 @@ public class BitmapMarker {
    *
    * @param tangramMarker the underlying Tangram marker object.
    */
-  public BitmapMarker(MarkerManager markerManager, Marker tangramMarker,
+  public BitmapMarker(BitmapMarkerManager bitmapMarkerManager, Marker tangramMarker,
       StyleStringGenerator styleStringGenerator) {
-    this.markerManager = markerManager;
+    this.bitmapMarkerManager = bitmapMarkerManager;
     this.tangramMarker = tangramMarker;
     this.styleStringGenerator = styleStringGenerator;
   }
@@ -43,7 +43,7 @@ public class BitmapMarker {
    * methods is undefined.
    */
   public void remove() {
-    markerManager.removeMarker(this);
+    bitmapMarkerManager.removeMarker(this);
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerFactory.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerFactory.java
@@ -1,0 +1,21 @@
+package com.mapzen.android.graphics.model;
+
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+
+/**
+ * Creates {@link BitmapMarker} objects.
+ */
+public class BitmapMarkerFactory {
+
+  /**
+   * Creates new {@link BitmapMarker} with the given parameters.
+   * @param manager
+   * @param marker
+   * @param styleStringGenerator
+   * @return
+   */
+  BitmapMarker createMarker(MarkerManager manager, com.mapzen.tangram.Marker marker,
+      StyleStringGenerator styleStringGenerator) {
+    return new BitmapMarker(manager, marker, styleStringGenerator);
+  }
+}

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerFactory.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerFactory.java
@@ -14,7 +14,7 @@ public class BitmapMarkerFactory {
    * @param styleStringGenerator
    * @return
    */
-  BitmapMarker createMarker(MarkerManager manager, com.mapzen.tangram.Marker marker,
+  BitmapMarker createMarker(BitmapMarkerManager manager, com.mapzen.tangram.Marker marker,
       StyleStringGenerator styleStringGenerator) {
     return new BitmapMarker(manager, marker, styleStringGenerator);
   }

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Manages {@link BitmapMarker} instances on the map.
  */
-public class MarkerManager {
+public class BitmapMarkerManager {
   private MapController mapController;
   private final BitmapMarkerFactory bitmapMarkerFactory;
   private final StyleStringGenerator styleStringGenerator;
@@ -23,7 +23,7 @@ public class MarkerManager {
   /**
    * Constructor.
    */
-  public MarkerManager(BitmapMarkerFactory bitmapMarkerFactory,
+  public BitmapMarkerManager(BitmapMarkerFactory bitmapMarkerFactory,
       StyleStringGenerator styleStringGenerator) {
     this.bitmapMarkerFactory = bitmapMarkerFactory;
     this.styleStringGenerator = styleStringGenerator;

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java
@@ -41,10 +41,28 @@ public class BitmapMarkerManager {
   /**
    * Adds a new marker to the map.
    *
+   * Deprecated in favor of {@link BitmapMarkerManager#addMarker(BitmapMarkerOptions)}.
+   *
    * @param markerOptions options that define the appearance of the marker.
    * @return a new bitmap marker wrapper for the Tangram marker object.
    */
+  @Deprecated
   public BitmapMarker addMarker(MarkerOptions markerOptions) {
+    final Marker marker = mapController.addMarker();
+    BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
+        styleStringGenerator);
+    configureMarker(bitmapMarker, markerOptions);
+    Collections.synchronizedList(restorableMarkers).add(bitmapMarker);
+    return bitmapMarker;
+  }
+
+  /**
+   * Adds a new marker to the map.
+   *
+   * @param markerOptions options that define the appearance of the marker.
+   * @return a new bitmap marker wrapper for the Tangram marker object.
+   */
+  public BitmapMarker addMarker(BitmapMarkerOptions markerOptions) {
     final Marker marker = mapController.addMarker();
     BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
         styleStringGenerator);
@@ -83,6 +101,15 @@ public class BitmapMarkerManager {
         bitmapMarker.getDrawOrder(), bitmapMarker.getUserData());
   }
 
+  private void configureMarker(BitmapMarker bitmapMarker, BitmapMarkerOptions markerOptions) {
+    configureMarker(bitmapMarker, markerOptions.getPosition(), markerOptions.getIconDrawable(),
+        markerOptions.getIcon(), markerOptions.getWidth(),
+        markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
+        markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
+        markerOptions.getUserData());
+  }
+
+  @Deprecated
   private void configureMarker(BitmapMarker bitmapMarker, MarkerOptions markerOptions) {
     configureMarker(bitmapMarker, markerOptions.getPosition(), markerOptions.getIconDrawable(),
         markerOptions.getIcon(), markerOptions.getWidth(),

--- a/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerOptions.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/BitmapMarkerOptions.java
@@ -5,16 +5,10 @@ import com.mapzen.tangram.LngLat;
 
 import android.graphics.drawable.Drawable;
 
-
 /**
  * Defines options for a {@link BitmapMarker}.
- *
- * This class has been deprecated in favor of
- * {@link com.mapzen.android.graphics.model.BitmapMarkerOptions} which replaces this class'
- * behavior exactly.
  */
-@Deprecated
-public class MarkerOptions {
+public class BitmapMarkerOptions {
   private static final LngLat DEFAULT_POSITION = new LngLat(-73.985428, 40.748817);
   private static final int DEFAULT_DRAWABLE = R.drawable.mapzen;
   private static final int DEFAULT_WIDTH = 50;
@@ -41,19 +35,19 @@ public class MarkerOptions {
    * @param position coordinate to display the marker.
    * @return this marker options instance.
    */
-  public MarkerOptions position(LngLat position) {
+  public BitmapMarkerOptions position(LngLat position) {
     this.position = position;
     return this;
   }
 
   /**
    * Set the marker icon resource ID. Setting this property will override previously set resource
-   * ids set in the call to {@link MarkerOptions#icon(Drawable)}.
+   * ids set in the call to {@link BitmapMarkerOptions#icon(Drawable)}.
    *
    * @param resId drawable resource ID for the marker to display.
    * @return this marker options instance.
    */
-  public MarkerOptions icon(int resId) {
+  public BitmapMarkerOptions icon(int resId) {
     this.resId = resId;
     this.res = null;
     return this;
@@ -61,12 +55,12 @@ public class MarkerOptions {
 
   /**
    * Set the marker icon resource. Setting this property will override previously set resource ids
-   * set in the call to {@link MarkerOptions#icon(int)}.
+   * set in the call to {@link BitmapMarkerOptions#icon(int)}.
    *
    * @param res drawable resource for the marker to display.
    * @return this marker options instance.
    */
-  public MarkerOptions icon(Drawable res) {
+  public BitmapMarkerOptions icon(Drawable res) {
     this.res = res;
     this.resId = RES_NONE;
     return this;
@@ -79,7 +73,7 @@ public class MarkerOptions {
    * @param height in pixels
    * @return this marker options instance.
    */
-  public MarkerOptions size(int width, int height) {
+  public BitmapMarkerOptions size(int width, int height) {
     this.width = width;
     this.height = height;
     return this;
@@ -90,7 +84,7 @@ public class MarkerOptions {
    * @param isVisible
    * @return
    */
-  public MarkerOptions visible(boolean isVisible) {
+  public BitmapMarkerOptions visible(boolean isVisible) {
     this.isVisible = isVisible;
     return this;
   }
@@ -98,7 +92,7 @@ public class MarkerOptions {
   /**
    * Sets marker z-axis draw order.
    */
-  public MarkerOptions drawOrder(int drawOrder) {
+  public BitmapMarkerOptions drawOrder(int drawOrder) {
     this.drawOrder = drawOrder;
     return this;
   }
@@ -108,18 +102,18 @@ public class MarkerOptions {
    * @param userData
    * @return
    */
-  public MarkerOptions userData(Object userData) {
+  public BitmapMarkerOptions userData(Object userData) {
     this.userData = userData;
     return this;
   }
 
   /**
    * Sets color resource int. Setting the color in overrides previous set color hex values set via
-   * {@link MarkerOptions#colorHex(String)}.
+   * {@link BitmapMarkerOptions#colorHex(String)}.
    * @param colorInt
    * @return
    */
-  public MarkerOptions colorInt(int colorInt) {
+  public BitmapMarkerOptions colorInt(int colorInt) {
     this.colorInt = colorInt;
     this.colorHex = null;
     return this;
@@ -127,11 +121,11 @@ public class MarkerOptions {
 
   /**
    * Sets color hex value. Setting the color in overrides previous set color int values set via
-   * {@link MarkerOptions#colorInt(int)}.
+   * {@link BitmapMarkerOptions#colorInt(int)}.
    * @param colorHex
    * @return
    */
-  public MarkerOptions colorHex(String colorHex) {
+  public BitmapMarkerOptions colorHex(String colorHex) {
     this.colorHex = colorHex;
     this.colorInt = Integer.MIN_VALUE;
     return this;
@@ -142,7 +136,7 @@ public class MarkerOptions {
    * @param isInteractive
    * @return
    */
-  public MarkerOptions interactive(boolean isInteractive) {
+  public BitmapMarkerOptions interactive(boolean isInteractive) {
     this.isInteractive = isInteractive;
     return this;
   }

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
@@ -40,13 +40,13 @@ public class MarkerManager {
    */
   public BitmapMarker addMarker(MarkerOptions markerOptions) {
     final Marker marker = mapController.addMarker();
-    configureTangramMarker(marker, styleStringGenerator, markerOptions.getPosition(),
-        markerOptions.getIconDrawable(), markerOptions.getIcon(), markerOptions.getWidth(),
+    BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
+        styleStringGenerator);
+    configureMarker(bitmapMarker, markerOptions.getPosition(), markerOptions.getIconDrawable(),
+        markerOptions.getIcon(), markerOptions.getWidth(),
         markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
         markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
         markerOptions.getUserData());
-    BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
-        styleStringGenerator);
     restorableMarkers.add(bitmapMarker);
     return bitmapMarker;
   }
@@ -67,36 +67,34 @@ public class MarkerManager {
   public void restoreMarkers() {
     for (BitmapMarker restorableMarker : restorableMarkers) {
       Marker tangramMarker = mapController.addMarker();
-      configureTangramMarker(tangramMarker, restorableMarker.getStyleStringGenerator(),
-          restorableMarker.getPosition(), restorableMarker.getIconDrawable(),
-          restorableMarker.getIcon(), restorableMarker.getWidth(), restorableMarker.getHeight(),
+      restorableMarker.setTangramMarker(tangramMarker);
+      configureMarker(restorableMarker, restorableMarker.getPosition(),
+          restorableMarker.getIconDrawable(), restorableMarker.getIcon(),
+          restorableMarker.getWidth(), restorableMarker.getHeight(),
           restorableMarker.isInteractive(), restorableMarker.getColorHex(),
           restorableMarker.getColor(), restorableMarker.isVisible(),
           restorableMarker.getDrawOrder(), restorableMarker.getUserData());
-      restorableMarker.setTangramMarker(tangramMarker);
     }
   }
 
-  private void configureTangramMarker(Marker marker, StyleStringGenerator styleStringGenerator,
-      LngLat position, Drawable drawable, int drawableId, int width, int height,
-      boolean interactive, String colorHex, int colorInt, boolean visible, int drawOrder,
-      Object userData) {
-    marker.setPoint(position);
+  private void configureMarker(BitmapMarker marker, LngLat position, Drawable drawable,
+      int drawableId, int width, int height, boolean interactive, String colorHex, int colorInt,
+      boolean visible, int drawOrder, Object userData) {
+    marker.setPosition(position);
     if (drawable != null) {
-      marker.setDrawable(drawable);
+      marker.setIcon(drawable);
     } else {
-      marker.setDrawable(drawableId);
+      marker.setIcon(drawableId);
     }
     marker.setVisible(visible);
     marker.setDrawOrder(drawOrder);
     marker.setUserData(userData);
-    String color;
     if (colorHex != null) {
-      color = colorHex;
+      marker.setColor(colorHex);
     } else {
-      color = "#" + Integer.toHexString(colorInt);
+      marker.setColor(colorInt);
     }
-    marker.setStylingFromString(styleStringGenerator.getStyleString(width, height, interactive,
-        color));
+    marker.setSize(width, height);
+    marker.setInteractive(interactive);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
@@ -48,11 +48,7 @@ public class MarkerManager {
     final Marker marker = mapController.addMarker();
     BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
         styleStringGenerator);
-    configureMarker(bitmapMarker, markerOptions.getPosition(), markerOptions.getIconDrawable(),
-        markerOptions.getIcon(), markerOptions.getWidth(),
-        markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
-        markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
-        markerOptions.getUserData());
+    configureMarker(bitmapMarker, markerOptions);
     Collections.synchronizedList(restorableMarkers).add(bitmapMarker);
     return bitmapMarker;
   }
@@ -74,13 +70,25 @@ public class MarkerManager {
     for (BitmapMarker restorableMarker : Collections.synchronizedList(restorableMarkers)) {
       Marker tangramMarker = mapController.addMarker();
       restorableMarker.setTangramMarker(tangramMarker);
-      configureMarker(restorableMarker, restorableMarker.getPosition(),
-          restorableMarker.getIconDrawable(), restorableMarker.getIcon(),
-          restorableMarker.getWidth(), restorableMarker.getHeight(),
-          restorableMarker.isInteractive(), restorableMarker.getColorHex(),
-          restorableMarker.getColor(), restorableMarker.isVisible(),
-          restorableMarker.getDrawOrder(), restorableMarker.getUserData());
+      configureMarker(restorableMarker);
     }
+  }
+
+  private void configureMarker(BitmapMarker bitmapMarker) {
+    configureMarker(bitmapMarker, bitmapMarker.getPosition(),
+        bitmapMarker.getIconDrawable(), bitmapMarker.getIcon(),
+        bitmapMarker.getWidth(), bitmapMarker.getHeight(),
+        bitmapMarker.isInteractive(), bitmapMarker.getColorHex(),
+        bitmapMarker.getColor(), bitmapMarker.isVisible(),
+        bitmapMarker.getDrawOrder(), bitmapMarker.getUserData());
+  }
+
+  private void configureMarker(BitmapMarker bitmapMarker, MarkerOptions markerOptions) {
+    configureMarker(bitmapMarker, markerOptions.getPosition(), markerOptions.getIconDrawable(),
+        markerOptions.getIcon(), markerOptions.getWidth(),
+        markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
+        markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
+        markerOptions.getUserData());
   }
 
   private void configureMarker(BitmapMarker marker, LngLat position, Drawable drawable,

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
@@ -14,22 +14,27 @@ import java.util.List;
  * Manages {@link BitmapMarker} instances on the map.
  */
 public class MarkerManager {
-  private final MapController mapController;
+  private MapController mapController;
   private final BitmapMarkerFactory bitmapMarkerFactory;
   private final StyleStringGenerator styleStringGenerator;
   private List<BitmapMarker> restorableMarkers;
 
   /**
    * Constructor.
-   *
-   * @param mapController Tangram map controller used to generate markers.
    */
-  public MarkerManager(MapController mapController, BitmapMarkerFactory bitmapMarkerFactory,
+  public MarkerManager(BitmapMarkerFactory bitmapMarkerFactory,
       StyleStringGenerator styleStringGenerator) {
-    this.mapController = mapController;
     this.bitmapMarkerFactory = bitmapMarkerFactory;
     this.styleStringGenerator = styleStringGenerator;
     this.restorableMarkers = new ArrayList<>();
+  }
+
+  /**
+   * Sets the manager's tangram map. Reset upon orientation changes.
+   * @param mapController
+   */
+  public void setMapController(MapController mapController) {
+    this.mapController = mapController;
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
@@ -8,6 +8,7 @@ import com.mapzen.tangram.Marker;
 import android.graphics.drawable.Drawable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -52,7 +53,7 @@ public class MarkerManager {
         markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
         markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
         markerOptions.getUserData());
-    restorableMarkers.add(bitmapMarker);
+    Collections.synchronizedList(restorableMarkers).add(bitmapMarker);
     return bitmapMarker;
   }
 
@@ -62,7 +63,7 @@ public class MarkerManager {
    * @param marker Tangram marker to be removed.
    */
   public void removeMarker(BitmapMarker marker) {
-    restorableMarkers.remove(marker);
+    Collections.synchronizedList(restorableMarkers).remove(marker);
     mapController.removeMarker(marker.getTangramMarker());
   }
 
@@ -70,7 +71,7 @@ public class MarkerManager {
    * Restores underlying Tangram marker for all {@link BitmapMarker}s when scene updates occur.
    */
   public void restoreMarkers() {
-    for (BitmapMarker restorableMarker : restorableMarkers) {
+    for (BitmapMarker restorableMarker : Collections.synchronizedList(restorableMarkers)) {
       Marker tangramMarker = mapController.addMarker();
       restorableMarker.setTangramMarker(tangramMarker);
       configureMarker(restorableMarker, restorableMarker.getPosition(),

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerManager.java
@@ -42,7 +42,9 @@ public class MarkerManager {
     final Marker marker = mapController.addMarker();
     configureTangramMarker(marker, styleStringGenerator, markerOptions.getPosition(),
         markerOptions.getIconDrawable(), markerOptions.getIcon(), markerOptions.getWidth(),
-        markerOptions.getHeight());
+        markerOptions.getHeight(), markerOptions.isInteractive(), markerOptions.getColorHex(),
+        markerOptions.getColorInt(), markerOptions.isVisible(), markerOptions.getDrawOrder(),
+        markerOptions.getUserData());
     BitmapMarker bitmapMarker = bitmapMarkerFactory.createMarker(this, marker,
         styleStringGenerator);
     restorableMarkers.add(bitmapMarker);
@@ -67,20 +69,34 @@ public class MarkerManager {
       Marker tangramMarker = mapController.addMarker();
       configureTangramMarker(tangramMarker, restorableMarker.getStyleStringGenerator(),
           restorableMarker.getPosition(), restorableMarker.getIconDrawable(),
-          restorableMarker.getIcon(), restorableMarker.getWidth(), restorableMarker.getHeight());
+          restorableMarker.getIcon(), restorableMarker.getWidth(), restorableMarker.getHeight(),
+          restorableMarker.isInteractive(), restorableMarker.getColorHex(),
+          restorableMarker.getColor(), restorableMarker.isVisible(),
+          restorableMarker.getDrawOrder(), restorableMarker.getUserData());
       restorableMarker.setTangramMarker(tangramMarker);
     }
   }
 
   private void configureTangramMarker(Marker marker, StyleStringGenerator styleStringGenerator,
-      LngLat position, Drawable drawable, int drawableId, int width, int height) {
+      LngLat position, Drawable drawable, int drawableId, int width, int height,
+      boolean interactive, String colorHex, int colorInt, boolean visible, int drawOrder,
+      Object userData) {
     marker.setPoint(position);
     if (drawable != null) {
       marker.setDrawable(drawable);
     } else {
       marker.setDrawable(drawableId);
     }
-    //TODO add missing properties to MarkerOptions
-    marker.setStylingFromString(styleStringGenerator.getStyleString(width, height, true, "#fff"));
+    marker.setVisible(visible);
+    marker.setDrawOrder(drawOrder);
+    marker.setUserData(userData);
+    String color;
+    if (colorHex != null) {
+      color = colorHex;
+    } else {
+      color = "#" + Integer.toHexString(colorInt);
+    }
+    marker.setStylingFromString(styleStringGenerator.getStyleString(width, height, interactive,
+        color));
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerOptions.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerOptions.java
@@ -5,6 +5,7 @@ import com.mapzen.tangram.LngLat;
 
 import android.graphics.drawable.Drawable;
 
+
 /**
  * Defines options for a {@link BitmapMarker}.
  */
@@ -20,6 +21,12 @@ public class MarkerOptions {
   private Drawable res = null;
   private int width = DEFAULT_WIDTH;
   private int height = DEFAULT_HEIGHT;
+  private boolean isVisible = true;
+  private int drawOrder = 1;
+  private Object userData;
+  private int colorInt = Integer.MIN_VALUE;
+  private String colorHex = "#fff";
+  private boolean isInteractive = true;
 
   // Setters
 
@@ -73,6 +80,68 @@ public class MarkerOptions {
     return this;
   }
 
+  /**
+   * Sets the marker visibility.
+   * @param isVisible
+   * @return
+   */
+  public MarkerOptions visible(boolean isVisible) {
+    this.isVisible = isVisible;
+    return this;
+  }
+
+  /**
+   * Sets marker z-axis draw order.
+   */
+  public MarkerOptions drawOrder(int drawOrder) {
+    this.drawOrder = drawOrder;
+    return this;
+  }
+
+  /**
+   * Sets extra data to be associated with the marker.
+   * @param userData
+   * @return
+   */
+  public MarkerOptions userData(Object userData) {
+    this.userData = userData;
+    return this;
+  }
+
+  /**
+   * Sets color resource int. Setting the color in overrides previous set color hex values set via
+   * {@link MarkerOptions#colorHex(String)}.
+   * @param colorInt
+   * @return
+   */
+  public MarkerOptions colorInt(int colorInt) {
+    this.colorInt = colorInt;
+    this.colorHex = null;
+    return this;
+  }
+
+  /**
+   * Sets color hex value. Setting the color in overrides previous set color int values set via
+   * {@link MarkerOptions#colorInt(int)}.
+   * @param colorHex
+   * @return
+   */
+  public MarkerOptions colorHex(String colorHex) {
+    this.colorHex = colorHex;
+    this.colorInt = Integer.MIN_VALUE;
+    return this;
+  }
+
+  /**
+   * Sets whether or not the marker is interactive.
+   * @param isInteractive
+   * @return
+   */
+  public MarkerOptions isInteractive(boolean isInteractive) {
+    this.isInteractive = isInteractive;
+    return this;
+  }
+
   // Getters
 
   public LngLat getPosition() {
@@ -93,5 +162,29 @@ public class MarkerOptions {
 
   public int getHeight() {
     return height;
+  }
+
+  public boolean isVisible() {
+    return isVisible;
+  }
+
+  public int getDrawOrder() {
+    return drawOrder;
+  }
+
+  public Object getUserData() {
+    return userData;
+  }
+
+  public int getColorInt() {
+    return colorInt;
+  }
+
+  public String getColorHex() {
+    return colorHex;
+  }
+
+  public boolean isInteractive() {
+    return isInteractive;
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/model/MarkerOptions.java
+++ b/core/src/main/java/com/mapzen/android/graphics/model/MarkerOptions.java
@@ -137,7 +137,7 @@ public class MarkerOptions {
    * @param isInteractive
    * @return
    */
-  public MarkerOptions isInteractive(boolean isInteractive) {
+  public MarkerOptions interactive(boolean isInteractive) {
     this.isInteractive = isInteractive;
     return this;
   }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -2,9 +2,8 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.CoreDI;
 import com.mapzen.android.core.MapzenManager;
-import com.mapzen.android.graphics.internal.StyleStringGenerator;
-import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
+import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneUpdate;
 
@@ -45,7 +44,7 @@ public class MapInitializerTest {
     CoreDI.init(getMockContext());
     mapInitializer = new MapInitializer(mock(Context.class), mock(MapzenMapHttpHandler.class),
         new MapDataManager(), new MapStateManager(), new SceneUpdateManager(),
-        new BitmapMarkerFactory(), new StyleStringGenerator());
+        new MarkerManager(null, null));
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -3,7 +3,7 @@ package com.mapzen.android.graphics;
 import com.mapzen.android.core.CoreDI;
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneUpdate;
 
@@ -44,7 +44,7 @@ public class MapInitializerTest {
     CoreDI.init(getMockContext());
     mapInitializer = new MapInitializer(mock(Context.class), mock(MapzenMapHttpHandler.class),
         new MapDataManager(), new MapStateManager(), new SceneUpdateManager(),
-        new MarkerManager(null, null));
+        new BitmapMarkerManager(null, null));
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -2,6 +2,8 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.CoreDI;
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneUpdate;
@@ -42,7 +44,8 @@ public class MapInitializerTest {
   @Before public void setUp() throws Exception {
     CoreDI.init(getMockContext());
     mapInitializer = new MapInitializer(mock(Context.class), mock(MapzenMapHttpHandler.class),
-        new MapDataManager(), new MapStateManager(), new SceneUpdateManager());
+        new MapDataManager(), new MapStateManager(), new SceneUpdateManager(),
+        new BitmapMarkerFactory(), new StyleStringGenerator());
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
@@ -1,5 +1,7 @@
 package com.mapzen.android.graphics;
 
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.MapController;
 
@@ -37,7 +39,8 @@ public class MapReadyInitializerTest {
         mapController);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
+        mock(StyleStringGenerator.class));
     verify(mapController).setSceneLoadListener(null);
   }
 
@@ -56,7 +59,8 @@ public class MapReadyInitializerTest {
     when(mapzenHttpHandler.httpHandler()).thenReturn(httpHandler);
     initializer.onMapReady(mapView, mapzenHttpHandler,
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
+        mock(StyleStringGenerator.class));
     verify(mapController).setHttpHandler(httpHandler);
   }
 
@@ -73,7 +77,8 @@ public class MapReadyInitializerTest {
     OnMapReadyCallback callback = mock(OnMapReadyCallback.class);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         callback, mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
+        mock(StyleStringGenerator.class));
     verify(callback).onMapReady(any(MapzenMap.class));
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
@@ -1,7 +1,6 @@
 package com.mapzen.android.graphics;
 
-import com.mapzen.android.graphics.internal.StyleStringGenerator;
-import com.mapzen.android.graphics.model.BitmapMarkerFactory;
+import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.MapController;
 
@@ -39,8 +38,7 @@ public class MapReadyInitializerTest {
         mapController);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
-        mock(StyleStringGenerator.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
     verify(mapController).setSceneLoadListener(null);
   }
 
@@ -59,8 +57,7 @@ public class MapReadyInitializerTest {
     when(mapzenHttpHandler.httpHandler()).thenReturn(httpHandler);
     initializer.onMapReady(mapView, mapzenHttpHandler,
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
-        mock(StyleStringGenerator.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
     verify(mapController).setHttpHandler(httpHandler);
   }
 
@@ -77,8 +74,7 @@ public class MapReadyInitializerTest {
     OnMapReadyCallback callback = mock(OnMapReadyCallback.class);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         callback, mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerFactory.class),
-        mock(StyleStringGenerator.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
     verify(callback).onMapReady(any(MapzenMap.class));
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapReadyInitializerTest.java
@@ -1,6 +1,6 @@
 package com.mapzen.android.graphics;
 
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.MapController;
 
@@ -38,7 +38,7 @@ public class MapReadyInitializerTest {
         mapController);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerManager.class));
     verify(mapController).setSceneLoadListener(null);
   }
 
@@ -57,7 +57,7 @@ public class MapReadyInitializerTest {
     when(mapzenHttpHandler.httpHandler()).thenReturn(httpHandler);
     initializer.onMapReady(mapView, mapzenHttpHandler,
         mock(OnMapReadyCallback.class), mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerManager.class));
     verify(mapController).setHttpHandler(httpHandler);
   }
 
@@ -74,7 +74,7 @@ public class MapReadyInitializerTest {
     OnMapReadyCallback callback = mock(OnMapReadyCallback.class);
     initializer.onMapReady(mapView, mock(MapzenMapHttpHandler.class),
         callback, mock(MapDataManager.class), mock(MapStateManager.class),
-        mock(SceneUpdateManager.class), new Locale("en_us"), mock(MarkerManager.class));
+        mock(SceneUpdateManager.class), new Locale("en_us"), mock(BitmapMarkerManager.class));
     verify(callback).onMapReady(any(MapzenMap.class));
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -2,11 +2,11 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.BitmapMarker;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
 import com.mapzen.android.graphics.model.Marker;
-import com.mapzen.android.graphics.model.MarkerManager;
 import com.mapzen.android.graphics.model.Polygon;
 import com.mapzen.android.graphics.model.Polyline;
 import com.mapzen.android.graphics.model.WalkaboutStyle;
@@ -60,7 +60,7 @@ public class MapzenMapTest {
   private OverlayManager overlayManager;
   private LabelPickHandler labelPickHandler;
   private MapStateManager mapStateManager;
-  private MarkerManager markerManager;
+  private BitmapMarkerManager bitmapMarkerManager;
   private SceneUpdateManager sceneUpdateManager;
   private Locale locale;
   private MapzenManager mapzenManager;
@@ -85,12 +85,12 @@ public class MapzenMapTest {
     overlayManager = mock(OverlayManager.class);
     mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
-    markerManager = mock(MarkerManager.class);
+    bitmapMarkerManager = mock(BitmapMarkerManager.class);
     sceneUpdateManager = new SceneUpdateManager();
     locale = new Locale("en_us");
     mapzenManager = mock(MapzenManager.class);
     map = new MapzenMap(mapView, mapController, overlayManager, mapStateManager, labelPickHandler,
-        markerManager, sceneUpdateManager, locale, mapzenManager);
+        bitmapMarkerManager, sceneUpdateManager, locale, mapzenManager);
   }
 
   @Test public void shouldNotBeNull() throws Exception {
@@ -706,7 +706,7 @@ public class MapzenMapTest {
 
   @Test public void onSceneReady_restoresMarkers() throws Exception {
     map.internalSceneLoadListener.onSceneReady(1, null);
-    verify(markerManager).restoreMarkers();
+    verify(bitmapMarkerManager).restoreMarkers();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -1,7 +1,9 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarker;
+import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
@@ -85,7 +87,8 @@ public class MapzenMapTest {
     overlayManager = mock(OverlayManager.class);
     mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
-    markerManager = new MarkerManager(mapController);
+    markerManager = new MarkerManager(mapController, new BitmapMarkerFactory(),
+        new StyleStringGenerator());
     sceneUpdateManager = new SceneUpdateManager();
     locale = new Locale("en_us");
     mapzenManager = mock(MapzenManager.class);

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -1,9 +1,7 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
-import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.android.graphics.model.BitmapMarker;
-import com.mapzen.android.graphics.model.BitmapMarkerFactory;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.CameraType;
 import com.mapzen.android.graphics.model.EaseType;
@@ -87,8 +85,7 @@ public class MapzenMapTest {
     overlayManager = mock(OverlayManager.class);
     mapStateManager = new MapStateManager();
     labelPickHandler = new LabelPickHandler(mapView);
-    markerManager = new MarkerManager(mapController, new BitmapMarkerFactory(),
-        new StyleStringGenerator());
+    markerManager = mock(MarkerManager.class);
     sceneUpdateManager = new SceneUpdateManager();
     locale = new Locale("en_us");
     mapzenManager = mock(MapzenManager.class);
@@ -705,6 +702,11 @@ public class MapzenMapTest {
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_BIKE_OVERLAY, "true"));
     sceneUpdates.add(new SceneUpdate(STYLE_GLOBAL_VAR_PATH_OVERLAY, "true"));
     verify(mapController).updateSceneAsync(argThat(new SceneUpdatesMatcher(sceneUpdates)));
+  }
+
+  @Test public void onSceneReady_restoresMarkers() throws Exception {
+    map.internalSceneLoadListener.onSceneReady(1, null);
+    verify(markerManager).restoreMarkers();
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/graphics/TestMapView.java
+++ b/core/src/test/java/com/mapzen/android/graphics/TestMapView.java
@@ -2,7 +2,7 @@ package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
 import com.mapzen.android.graphics.model.MapStyle;
-import com.mapzen.android.graphics.model.MarkerManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.tangram.MapController;
 
 import android.content.Context;
@@ -28,14 +28,14 @@ public class TestMapView extends MapView {
   @Override public void getMapAsync(@NonNull OnMapReadyCallback callback) {
     callback.onMapReady(new MapzenMap(mock(MapView.class), mock(MapController.class),
         mock(OverlayManager.class), mock(MapStateManager.class), mock(LabelPickHandler.class),
-        mock(MarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
+        mock(BitmapMarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
         MapzenManager.class)));
   }
 
   @Override public void getMapAsync(MapStyle mapStyle, @NonNull OnMapReadyCallback callback) {
     callback.onMapReady(new MapzenMap(mock(MapView.class), mock(MapController.class),
         mock(OverlayManager.class), mock(MapStateManager.class), mock(LabelPickHandler.class),
-        mock(MarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
+        mock(BitmapMarkerManager.class), mock(SceneUpdateManager.class), new Locale("en_us"), mock(
         MapzenManager.class)));
   }
 

--- a/core/src/test/java/com/mapzen/android/graphics/internal/StyleStringGeneratorTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/internal/StyleStringGeneratorTest.java
@@ -9,25 +9,8 @@ public class StyleStringGeneratorTest {
   private StyleStringGenerator generator = new StyleStringGenerator();
 
   @Test public void defaultStyleString() throws Exception {
-    assertThat(generator.getStyleString()).isEqualTo("{ style: 'points', color: '#FFFFFF', "
-        + "size: [50px, 50px], collide: false, interactive: true }");
+    assertThat(generator.getStyleString(50, 50, true, "#FFFFFF")).isEqualTo("{ style: 'points', "
+        + "color: '#FFFFFF', size: [50px, 50px], collide: false, interactive: true }");
   }
 
-  @Test public void setSize_updatesStyleString() throws Exception {
-    generator.setSize(10, 10);
-    assertThat(generator.getStyleString()).isEqualTo("{ style: 'points', color: '#FFFFFF', "
-        + "size: [10px, 10px], collide: false, interactive: true }");
-  }
-
-  @Test public void setInteractive_updatesStyleString() throws Exception {
-    generator.setInteractive(false);
-    assertThat(generator.getStyleString()).isEqualTo("{ style: 'points', color: '#FFFFFF', "
-        + "size: [50px, 50px], collide: false, interactive: false }");
-  }
-
-  @Test public void setBackgroundColor_updatesStyleString() throws Exception {
-    generator.setColor("#0000FF");
-    assertThat(generator.getStyleString()).isEqualTo("{ style: 'points', color: '#0000FF', "
-        + "size: [50px, 50px], collide: false, interactive: true }");
-  }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerManagerTest.java
@@ -37,8 +37,9 @@ public class BitmapMarkerManagerTest {
   @Before public void setUp() throws Exception {
     bitmapMarkerManager.setMapController(mapController);
     when(mapController.addMarker()).thenReturn(tangramMarker);
-    when(markerFactory.createMarker(any(BitmapMarkerManager.class), any(com.mapzen.tangram.Marker.class),
-        any(StyleStringGenerator.class))).thenReturn(mock(BitmapMarker.class));
+    when(markerFactory.createMarker(any(BitmapMarkerManager.class),
+        any(com.mapzen.tangram.Marker.class), any(StyleStringGenerator.class))).thenReturn(
+            mock(BitmapMarker.class));
   }
 
   @Test public void shouldNotBeNull() throws Exception {
@@ -174,8 +175,8 @@ public class BitmapMarkerManagerTest {
         .interactive(isInteractive);
 
     BitmapMarker marker = mock(BitmapMarker.class);
-    when(markerFactory.createMarker(any(BitmapMarkerManager.class), any(com.mapzen.tangram.Marker.class),
-        any(StyleStringGenerator.class))).thenReturn(marker);
+    when(markerFactory.createMarker(any(BitmapMarkerManager.class),
+        any(com.mapzen.tangram.Marker.class), any(StyleStringGenerator.class))).thenReturn(marker);
     when(marker.getPosition()).thenReturn(point);
     when(marker.getIconDrawable()).thenReturn(drawable);
     when(marker.getWidth()).thenReturn(width);

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerManagerTest.java
@@ -27,40 +27,40 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor("com.mapzen.tangram.MapController")
-public class MarkerManagerTest {
+public class BitmapMarkerManagerTest {
   private MapController mapController = mock(MapController.class);
   private com.mapzen.tangram.Marker tangramMarker = mock(com.mapzen.tangram.Marker.class);
   private BitmapMarkerFactory markerFactory = mock(BitmapMarkerFactory.class);
-  private MarkerManager markerManager = new MarkerManager(markerFactory,
+  private BitmapMarkerManager bitmapMarkerManager = new BitmapMarkerManager(markerFactory,
       new StyleStringGenerator());
 
   @Before public void setUp() throws Exception {
-    markerManager.setMapController(mapController);
+    bitmapMarkerManager.setMapController(mapController);
     when(mapController.addMarker()).thenReturn(tangramMarker);
-    when(markerFactory.createMarker(any(MarkerManager.class), any(com.mapzen.tangram.Marker.class),
+    when(markerFactory.createMarker(any(BitmapMarkerManager.class), any(com.mapzen.tangram.Marker.class),
         any(StyleStringGenerator.class))).thenReturn(mock(BitmapMarker.class));
   }
 
   @Test public void shouldNotBeNull() throws Exception {
-    assertThat(markerManager).isNotNull();
+    assertThat(bitmapMarkerManager).isNotNull();
   }
 
   @Test public void addMarker_shouldAddMarkerToMapController() throws Exception {
-    markerManager.addMarker(new MarkerOptions());
+    bitmapMarkerManager.addMarker(new MarkerOptions());
     verify(mapController).addMarker();
   }
 
   @Test public void addMarker_shouldSetPosition() throws Exception {
     LngLat lngLat = new LngLat();
     MarkerOptions markerOptions = new MarkerOptions().position(lngLat);
-    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setPosition(lngLat);
   }
 
   @Test public void addMarker_resId_shouldSetDrawable() throws Exception {
     int resId = 123;
     MarkerOptions markerOptions = new MarkerOptions().icon(resId);
-    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setIcon(resId);
     verify(marker, never()).setIcon(any(Drawable.class));
   }
@@ -68,55 +68,55 @@ public class MarkerManagerTest {
   @Test public void addMarker_res_shouldSetDrawable() throws Exception {
     Drawable res = mock(Drawable.class);
     MarkerOptions markerOptions = new MarkerOptions().icon(res);
-    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setIcon(res);
     verify(marker, never()).setIcon(anyInt());
   }
 
   @Test public void addMarker_shouldSetSize() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().size(100, 100);
-    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setSize(100, 100);
   }
 
   @Test public void addMarker_shouldReturnBitmapMarker() throws Exception {
-    assertThat(markerManager.addMarker(new MarkerOptions())).isNotNull();
+    assertThat(bitmapMarkerManager.addMarker(new MarkerOptions())).isNotNull();
   }
 
   @Test public void addMarker_shouldSetVisibile() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().visible(false);
-    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setVisible(false);
   }
 
   @Test public void addMarker_shouldSetUserData() throws Exception {
     Object data = mock(Object.class);
     MarkerOptions markerOptions = new MarkerOptions().userData(data);
-        BitmapMarker marker = markerManager.addMarker(markerOptions);
+        BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setUserData(data);
   }
 
   @Test public void addMarker_shouldSetDrawOrder() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().drawOrder(8);
-        BitmapMarker marker = markerManager.addMarker(markerOptions);
+        BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setDrawOrder(8);
   }
 
   @Test public void addMarker_shouldSetColorHex() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().colorHex("#fff");
-        BitmapMarker marker = markerManager.addMarker(markerOptions);
+        BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setColor("#fff");
   }
 
   @Test public void addMarker_shouldSetColorInt() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().colorInt(Color.RED);
-        BitmapMarker marker = markerManager.addMarker(markerOptions);
+        BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setColor(Color.RED);
   }
 
   @Test public void addMarker_shouldSetInteractive() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().interactive(false);
-        BitmapMarker marker = markerManager.addMarker(markerOptions);
+        BitmapMarker marker = bitmapMarkerManager.addMarker(markerOptions);
     verify(marker).setInteractive(false);
   }
 
@@ -139,8 +139,8 @@ public class MarkerManagerTest {
         .visible(isVisible)
         .userData(userData)
         .interactive(isInteractive);
-    BitmapMarker marker = markerManager.addMarker(options);
-    markerManager.restoreMarkers();
+    BitmapMarker marker = bitmapMarkerManager.addMarker(options);
+    bitmapMarkerManager.restoreMarkers();
 
     verify(marker).setTangramMarker(tangramMarker);
     verify(marker).setPosition(point);
@@ -174,7 +174,7 @@ public class MarkerManagerTest {
         .interactive(isInteractive);
 
     BitmapMarker marker = mock(BitmapMarker.class);
-    when(markerFactory.createMarker(any(MarkerManager.class), any(com.mapzen.tangram.Marker.class),
+    when(markerFactory.createMarker(any(BitmapMarkerManager.class), any(com.mapzen.tangram.Marker.class),
         any(StyleStringGenerator.class))).thenReturn(marker);
     when(marker.getPosition()).thenReturn(point);
     when(marker.getIconDrawable()).thenReturn(drawable);
@@ -186,9 +186,9 @@ public class MarkerManagerTest {
     when(marker.getDrawOrder()).thenReturn(drawOrder);
     when(marker.getUserData()).thenReturn(userData);
 
-    markerManager.addMarker(options);
-    markerManager.addMarker(options);
-    markerManager.restoreMarkers();
+    bitmapMarkerManager.addMarker(options);
+    bitmapMarkerManager.addMarker(options);
+    bitmapMarkerManager.restoreMarkers();
 
     //times(2) 2 markers and 1x 1x when restoring
     verify(marker, times(2)).setTangramMarker(tangramMarker);

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerOptionsTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerOptionsTest.java
@@ -1,0 +1,67 @@
+package com.mapzen.android.graphics.model;
+
+import com.mapzen.tangram.LngLat;
+
+import org.junit.Test;
+
+import android.graphics.drawable.Drawable;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+public class BitmapMarkerOptionsTest {
+
+  private BitmapMarkerOptions markerOptions = new BitmapMarkerOptions();
+
+  @Test public void shouldNotBeNull() throws Exception {
+    assertThat(markerOptions).isNotNull();
+  }
+
+  @Test public void shouldSetPosition() throws Exception {
+    assertThat(markerOptions.position(new LngLat()).getPosition()).isEqualTo(new LngLat());
+  }
+
+  @Test public void shouldSetIconAndNullDrawable() throws Exception {
+    assertThat(markerOptions.icon(123).getIcon()).isEqualTo(123);
+    assertThat(markerOptions.getIconDrawable()).isNull();
+  }
+
+  @Test public void shouldSetIconDrawableAndNullIcon() throws Exception {
+    Drawable drawable = mock(Drawable.class);
+    assertThat(markerOptions.icon(drawable).getIconDrawable()).isEqualTo(drawable);
+    assertThat(markerOptions.getIcon()).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test public void shouldSetDrawOrder() throws Exception {
+    assertThat(markerOptions.drawOrder(1).getDrawOrder()).isEqualTo(1);
+  }
+
+  @Test public void shouldSetUserData() throws Exception {
+    Map userData = mock(Map.class);
+    assertThat(markerOptions.userData(userData).getUserData()).isEqualTo(userData);
+  }
+
+  @Test public void shouldSetColorInt() throws Exception {
+    assertThat(markerOptions.colorInt(8).getColorInt()).isEqualTo(8);
+  }
+
+  @Test public void shouldSetColorIntResetColorHex() throws Exception {
+    markerOptions.colorHex("test");
+    markerOptions.colorInt(8);
+    assertThat(markerOptions.getColorHex()).isNull();
+  }
+
+  @Test public void shouldSetColorHex() throws Exception {
+    assertThat(markerOptions.colorHex("asdf").getColorHex()).isEqualTo("asdf");
+  }
+
+  @Test public void shouldSetColorHexResetColorInt() throws Exception {
+    markerOptions.colorInt(10);
+    markerOptions.colorHex("asdf");
+    assertThat(markerOptions.getColorInt()).isEqualTo(Integer.MIN_VALUE);
+  }
+}
+

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
@@ -26,14 +26,14 @@ import static org.mockito.Mockito.verify;
 public class BitmapMarkerTest {
   private Marker tangramMarker = mock(Marker.class);
   private MapController mapController = mock(MapController.class);
-  private MarkerManager markerManager = new MarkerManager(new BitmapMarkerFactory(),
+  private BitmapMarkerManager bitmapMarkerManager = new BitmapMarkerManager(new BitmapMarkerFactory(),
       new StyleStringGenerator());
   private StyleStringGenerator styleStringGenerator  = mock(StyleStringGenerator.class);
-  private BitmapMarker bitmapMarker = new BitmapMarker(markerManager, tangramMarker,
+  private BitmapMarker bitmapMarker = new BitmapMarker(bitmapMarkerManager, tangramMarker,
       styleStringGenerator);
 
   @Before public void setup() throws Exception {
-    markerManager.setMapController(mapController);
+    bitmapMarkerManager.setMapController(mapController);
   }
 
   @Test public void shouldNotBeNull() throws Exception {

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verify;
 public class BitmapMarkerTest {
   private Marker tangramMarker = mock(Marker.class);
   private MapController mapController = mock(MapController.class);
-  private BitmapMarkerManager bitmapMarkerManager = new BitmapMarkerManager(new BitmapMarkerFactory(),
-      new StyleStringGenerator());
+  private BitmapMarkerManager bitmapMarkerManager = new BitmapMarkerManager(
+      new BitmapMarkerFactory(), new StyleStringGenerator());
   private StyleStringGenerator styleStringGenerator  = mock(StyleStringGenerator.class);
   private BitmapMarker bitmapMarker = new BitmapMarker(bitmapMarkerManager, tangramMarker,
       styleStringGenerator);

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
@@ -5,6 +5,7 @@ import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.Marker;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
@@ -25,11 +26,15 @@ import static org.mockito.Mockito.verify;
 public class BitmapMarkerTest {
   private Marker tangramMarker = mock(Marker.class);
   private MapController mapController = mock(MapController.class);
-  private MarkerManager markerManager = new MarkerManager(mapController, new BitmapMarkerFactory(),
+  private MarkerManager markerManager = new MarkerManager(new BitmapMarkerFactory(),
       new StyleStringGenerator());
   private StyleStringGenerator styleStringGenerator  = mock(StyleStringGenerator.class);
   private BitmapMarker bitmapMarker = new BitmapMarker(markerManager, tangramMarker,
       styleStringGenerator);
+
+  @Before public void setup() throws Exception {
+    markerManager.setMapController(mapController);
+  }
 
   @Test public void shouldNotBeNull() throws Exception {
     assertThat(bitmapMarker).isNotNull();

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
@@ -44,10 +44,22 @@ public class BitmapMarkerTest {
     verify(tangramMarker).setPoint(pos);
   }
 
+  @Test public void setPosition_shouldSetPosition() throws Exception {
+    LngLat pos = new LngLat(40, 70);
+    bitmapMarker.setPosition(pos);
+    assertThat(bitmapMarker.getPosition()).isEqualTo(pos);
+  }
+
   @Test public void setPosition_animated_shouldCallTangramMarker() throws Exception {
     LngLat pos = new LngLat(40, 70);
     bitmapMarker.setPosition(pos, 1, EaseType.CUBIC);
     verify(tangramMarker).setPointEased(pos, 1, MapController.EaseType.CUBIC);
+  }
+
+  @Test public void setPosition_animated_shouldSetPosition() throws Exception {
+    LngLat pos = new LngLat(40, 70);
+    bitmapMarker.setPosition(pos, 1, EaseType.CUBIC);
+    assertThat(bitmapMarker.getPosition()).isEqualTo(pos);
   }
 
   @Test public void setIcon_shouldCallTangramMarker() throws Exception {
@@ -56,10 +68,36 @@ public class BitmapMarkerTest {
     verify(tangramMarker).setDrawable(resId);
   }
 
+  @Test public void setIcon_shouldSetIcon() throws Exception {
+    int resId = 1;
+    bitmapMarker.setIcon(resId);
+    assertThat(bitmapMarker.getIcon()).isEqualTo(resId);
+  }
+
+  @Test public void setIcon_shouldNullIconDrawable() throws Exception {
+    int resId = 1;
+    bitmapMarker.setIcon(mock(Drawable.class));
+    bitmapMarker.setIcon(resId);
+    assertThat(bitmapMarker.getIconDrawable()).isNull();
+  }
+
   @Test public void setIcon_drawable_shouldCallTangramMarker() throws Exception {
     Drawable drawable = mock(Drawable.class);
     bitmapMarker.setIcon(drawable);
     verify(tangramMarker).setDrawable(drawable);
+  }
+
+  @Test public void setIcon_drawable_shouldSetIcon() throws Exception {
+    Drawable drawable = mock(Drawable.class);
+    bitmapMarker.setIcon(drawable);
+    assertThat(bitmapMarker.getIconDrawable()).isEqualTo(drawable);
+  }
+
+  @Test public void setIcon_drawable_shouldResetIconResId() throws Exception {
+    Drawable drawable = mock(Drawable.class);
+    bitmapMarker.setIcon(1);
+    bitmapMarker.setIcon(drawable);
+    assertThat(bitmapMarker.getIcon()).isEqualTo(Integer.MIN_VALUE);
   }
 
   @Test public void setSize_shouldCallTangramMarkerAndStyleStringGenerator() throws Exception {
@@ -70,14 +108,40 @@ public class BitmapMarkerTest {
     verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
   }
 
+  @Test public void setSize_shouldSetWidth() throws Exception {
+    int width = 10;
+    int height = 5;
+    bitmapMarker.setSize(width, height);
+    assertThat(bitmapMarker.getWidth()).isEqualTo(width);
+  }
+
+  @Test public void setSize_shouldSetHeight() throws Exception {
+    int width = 10;
+    int height = 5;
+    bitmapMarker.setSize(width, height);
+    assertThat(bitmapMarker.getHeight()).isEqualTo(height);
+  }
+
   @Test public void setVisible_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setVisible(true);
     verify(tangramMarker).setVisible(true);
   }
 
+  @Test public void setVisible_shouldSetVisibility() throws Exception {
+    bitmapMarker.setVisible(true);
+    assertThat(bitmapMarker.isVisible()).isTrue();
+    bitmapMarker.setVisible(false);
+    assertThat(bitmapMarker.isVisible()).isFalse();
+  }
+
   @Test public void setDrawOrder_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setDrawOrder(1);
     verify(tangramMarker).setDrawOrder(1);
+  }
+
+  @Test public void setDrawOrder_shouldSetDrawOrder() throws Exception {
+    bitmapMarker.setDrawOrder(1);
+    assertThat(bitmapMarker.getDrawOrder()).isEqualTo(1);
   }
 
   @Test public void setUserData_shouldCallTangramMarker() throws Exception {
@@ -97,15 +161,44 @@ public class BitmapMarkerTest {
     verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
   }
 
-  @Test public void setBackgroundColor_colorInt_shouldCallTangramMarker() throws Exception {
+  @Test public void setInteractive_shouldSetInteractive() throws Exception {
+    bitmapMarker.setInteractive(true);
+    assertThat(bitmapMarker.isInteractive()).isTrue();
+    bitmapMarker.setInteractive(false);
+    assertThat(bitmapMarker.isInteractive()).isFalse();
+  }
+
+  @Test public void setColor_colorInt_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setColor(Color.BLUE);
     verify(styleStringGenerator).setColor("#ff0000ff");
     verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
   }
 
-  @Test public void setBackgroundColor_hex_shouldCallTangramMarker() throws Exception {
+  @Test public void setColor_shouldSetColor() throws Exception {
+    bitmapMarker.setColor(Color.BLUE);
+    assertThat(bitmapMarker.getColor()).isEqualTo(Color.BLUE);
+  }
+
+  @Test public void setIcon_shouldNullColorHex() throws Exception {
+    bitmapMarker.setColor("test");
+    bitmapMarker.setColor(Color.BLUE);
+    assertThat(bitmapMarker.getColorHex()).isNull();
+  }
+
+  @Test public void setColor_hex_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setColor("#222222");
     verify(styleStringGenerator).setColor("#222222");
     verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
+  }
+
+  @Test public void setColor_hex_shouldSetColor() throws Exception {
+    bitmapMarker.setColor("hex");
+    assertThat(bitmapMarker.getColorHex()).isEqualTo("hex");
+  }
+
+  @Test public void setIcon_hex_shouldResetColorInt() throws Exception {
+    bitmapMarker.setColor(Color.BLUE);
+    bitmapMarker.setColor("test");
+    assertThat(bitmapMarker.getColor()).isEqualTo(Integer.MIN_VALUE);
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/BitmapMarkerTest.java
@@ -16,6 +16,7 @@ import android.graphics.drawable.Drawable;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -24,7 +25,8 @@ import static org.mockito.Mockito.verify;
 public class BitmapMarkerTest {
   private Marker tangramMarker = mock(Marker.class);
   private MapController mapController = mock(MapController.class);
-  private MarkerManager markerManager = new MarkerManager(mapController);
+  private MarkerManager markerManager = new MarkerManager(mapController, new BitmapMarkerFactory(),
+      new StyleStringGenerator());
   private StyleStringGenerator styleStringGenerator  = mock(StyleStringGenerator.class);
   private BitmapMarker bitmapMarker = new BitmapMarker(markerManager, tangramMarker,
       styleStringGenerator);
@@ -100,12 +102,11 @@ public class BitmapMarkerTest {
     assertThat(bitmapMarker.getIcon()).isEqualTo(Integer.MIN_VALUE);
   }
 
-  @Test public void setSize_shouldCallTangramMarkerAndStyleStringGenerator() throws Exception {
+  @Test public void setSize_shouldCallTangramMarker() throws Exception {
     int width = 10;
     int height = 5;
     bitmapMarker.setSize(width, height);
-    verify(styleStringGenerator).setSize(width, height);
-    verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
+    verify(tangramMarker).setStylingFromString(anyString());
   }
 
   @Test public void setSize_shouldSetWidth() throws Exception {
@@ -157,8 +158,7 @@ public class BitmapMarkerTest {
 
   @Test public void setInteractive_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setInteractive(true);
-    verify(styleStringGenerator).setInteractive(true);
-    verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
+    verify(tangramMarker).setStylingFromString(anyString());
   }
 
   @Test public void setInteractive_shouldSetInteractive() throws Exception {
@@ -170,8 +170,7 @@ public class BitmapMarkerTest {
 
   @Test public void setColor_colorInt_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setColor(Color.BLUE);
-    verify(styleStringGenerator).setColor("#ff0000ff");
-    verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
+    verify(tangramMarker).setStylingFromString(anyString());
   }
 
   @Test public void setColor_shouldSetColor() throws Exception {
@@ -179,16 +178,15 @@ public class BitmapMarkerTest {
     assertThat(bitmapMarker.getColor()).isEqualTo(Color.BLUE);
   }
 
-  @Test public void setIcon_shouldNullColorHex() throws Exception {
+  @Test public void setColor_shouldUpdateColorHex() throws Exception {
     bitmapMarker.setColor("test");
     bitmapMarker.setColor(Color.BLUE);
-    assertThat(bitmapMarker.getColorHex()).isNull();
+    assertThat(bitmapMarker.getColorHex()).isEqualTo("#ff0000ff");
   }
 
   @Test public void setColor_hex_shouldCallTangramMarker() throws Exception {
     bitmapMarker.setColor("#222222");
-    verify(styleStringGenerator).setColor("#222222");
-    verify(tangramMarker).setStylingFromString(styleStringGenerator.getStyleString());
+    verify(tangramMarker).setStylingFromString(anyString());
   }
 
   @Test public void setColor_hex_shouldSetColor() throws Exception {
@@ -200,5 +198,11 @@ public class BitmapMarkerTest {
     bitmapMarker.setColor(Color.BLUE);
     bitmapMarker.setColor("test");
     assertThat(bitmapMarker.getColor()).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test public void getTangramMarker_shouldReturnMarker() throws Exception {
+    Marker marker = mock(Marker.class);
+    bitmapMarker.setTangramMarker(marker);
+    assertThat(bitmapMarker.getTangramMarker()).isEqualTo(marker);
   }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -1,7 +1,9 @@
 package com.mapzen.android.graphics.model;
 
+import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
+import com.mapzen.tangram.Marker;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,12 +13,16 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import android.graphics.drawable.Drawable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -25,10 +31,14 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class MarkerManagerTest {
   private MapController mapController = mock(MapController.class);
   private com.mapzen.tangram.Marker tangramMarker = mock(com.mapzen.tangram.Marker.class);
-  private MarkerManager markerManager = new MarkerManager(mapController);
+  private BitmapMarkerFactory markerFactory = mock(BitmapMarkerFactory.class);
+  private MarkerManager markerManager = new MarkerManager(mapController, markerFactory,
+      new StyleStringGenerator());
 
   @Before public void setUp() throws Exception {
     when(mapController.addMarker()).thenReturn(tangramMarker);
+    when(markerFactory.createMarker(any(MarkerManager.class), any(com.mapzen.tangram.Marker.class),
+        any(StyleStringGenerator.class))).thenReturn(mock(BitmapMarker.class));
   }
 
   @Test public void shouldNotBeNull() throws Exception {
@@ -72,11 +82,82 @@ public class MarkerManagerTest {
   @Test public void addMarker_shouldSetSize() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().size(100, 100);
     markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#FFFFFF', "
+    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#fff', "
         + "size: [100px, 100px], collide: false, interactive: true }");
   }
 
   @Test public void addMarker_shouldReturnBitmapMarker() throws Exception {
     assertThat(markerManager.addMarker(new MarkerOptions())).isNotNull();
   }
+
+  @Test public void restoreMarkers_shouldProperlyRestoreManagedMarkers() throws Exception {
+    Drawable drawable = mock(Drawable.class);
+    LngLat point = new LngLat(40, 70);
+    int width = 10;
+    int height = 20;
+    //TODO: add these props to MarkerOptions
+    boolean isVisible = true;
+    int drawOrder = 20;
+    Map userData = mock(HashMap.class);
+    int colorInt = Integer.MIN_VALUE;
+    String colorHex = "#fff";
+    boolean isInteractive = true;
+    //end TODO
+    MarkerOptions options = new MarkerOptions()
+        .icon(drawable)
+        .position(point)
+        .size(width, height);
+
+    BitmapMarker marker = markerManager.addMarker(options);
+    when(marker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
+
+    markerManager.restoreMarkers();
+
+    verify(tangramMarker).setPoint(point);
+    verify(tangramMarker).setDrawable(drawable);
+    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#fff', "
+        + "size: [10px, 20px], collide: false, interactive: true }");
+    verify(marker).setTangramMarker(any(Marker.class));
+    //TODO: add other props for verification, make test fail
+    //verify(tangramMarker).setVisible(true);
+    //verify(tangramMarker).setDrawOrder(drawOrder);
+    //verify(tangramMarker).setUserData(userData);
+  }
+
+  @Test public void restoreMarkers_shouldProperlyRestoreAllManagedMarkers() throws Exception {
+    Drawable drawable = mock(Drawable.class);
+    LngLat point = new LngLat(40, 70);
+    int width = 10;
+    int height = 20;
+    //TODO: add these props to MarkerOptions
+    boolean isVisible = true;
+    int drawOrder = 20;
+    Map userData = mock(HashMap.class);
+    int colorInt = Integer.MIN_VALUE;
+    String colorHex = "#fff";
+    boolean isInteractive = true;
+    MarkerOptions options = new MarkerOptions()
+        .icon(drawable)
+        .position(point)
+        .size(width, height);
+
+    BitmapMarker marker = markerManager.addMarker(options);
+    BitmapMarker anotherMarker = markerManager.addMarker(options);
+    when(marker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
+    when(anotherMarker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
+
+    markerManager.restoreMarkers();
+
+    //times(4) instead of times(2) because 1x for adding each marker, 1x when restoring
+    verify(tangramMarker, times(4)).setPoint(any(LngLat.class));
+    verify(tangramMarker, times(4)).setDrawable(any(Drawable.class));
+    verify(tangramMarker, times(4)).setStylingFromString(anyString());
+    verify(marker).setTangramMarker(any(Marker.class));
+    verify(anotherMarker).setTangramMarker(any(Marker.class));
+    //TODO: add other props for verification, make test fail
+    //verify(tangramMarker).setVisible(true);
+    //verify(tangramMarker).setDrawOrder(drawOrder);
+    //verify(tangramMarker).setUserData(userData);
+  }
+
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -54,41 +54,71 @@ public class MarkerManagerTest {
   @Test public void addMarker_shouldSetPosition() throws Exception {
     LngLat lngLat = new LngLat();
     MarkerOptions markerOptions = new MarkerOptions().position(lngLat);
-    markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setPoint(lngLat);
+    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setPosition(lngLat);
   }
 
   @Test public void addMarker_resId_shouldSetDrawable() throws Exception {
     int resId = 123;
     MarkerOptions markerOptions = new MarkerOptions().icon(resId);
-    markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setDrawable(resId);
-    verify(tangramMarker, never()).setDrawable(any(Drawable.class));
+    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setIcon(resId);
+    verify(marker, never()).setIcon(any(Drawable.class));
   }
 
   @Test public void addMarker_res_shouldSetDrawable() throws Exception {
     Drawable res = mock(Drawable.class);
     MarkerOptions markerOptions = new MarkerOptions().icon(res);
-    markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setDrawable(res);
-    verify(tangramMarker, never()).setDrawable(anyInt());
-  }
-
-  @Test public void addMarker_shouldSetStyling() throws Exception {
-    MarkerOptions markerOptions = new MarkerOptions();
-    markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setStylingFromString(anyString());
+    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setIcon(res);
+    verify(marker, never()).setIcon(anyInt());
   }
 
   @Test public void addMarker_shouldSetSize() throws Exception {
     MarkerOptions markerOptions = new MarkerOptions().size(100, 100);
-    markerManager.addMarker(markerOptions);
-    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#fff', "
-        + "size: [100px, 100px], collide: false, interactive: true }");
+    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setSize(100, 100);
   }
 
   @Test public void addMarker_shouldReturnBitmapMarker() throws Exception {
     assertThat(markerManager.addMarker(new MarkerOptions())).isNotNull();
+  }
+
+  @Test public void addMarker_shouldSetVisibile() throws Exception {
+    MarkerOptions markerOptions = new MarkerOptions().visible(false);
+    BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setVisible(false);
+  }
+
+  @Test public void addMarker_shouldSetUserData() throws Exception {
+    Object data = mock(Object.class);
+    MarkerOptions markerOptions = new MarkerOptions().userData(data);
+        BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setUserData(data);
+  }
+
+  @Test public void addMarker_shouldSetDrawOrder() throws Exception {
+    MarkerOptions markerOptions = new MarkerOptions().drawOrder(8);
+        BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setDrawOrder(8);
+  }
+
+  @Test public void addMarker_shouldSetColorHex() throws Exception {
+    MarkerOptions markerOptions = new MarkerOptions().colorHex("#fff");
+        BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setColor("#fff");
+  }
+
+  @Test public void addMarker_shouldSetColorInt() throws Exception {
+    MarkerOptions markerOptions = new MarkerOptions().colorInt(Color.RED);
+        BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setColor(Color.RED);
+  }
+
+  @Test public void addMarker_shouldSetInteractive() throws Exception {
+    MarkerOptions markerOptions = new MarkerOptions().interactive(false);
+        BitmapMarker marker = markerManager.addMarker(markerOptions);
+    verify(marker).setInteractive(false);
   }
 
   @Test public void restoreMarkers_shouldProperlyRestoreManagedMarkers() throws Exception {
@@ -110,20 +140,18 @@ public class MarkerManagerTest {
         .visible(isVisible)
         .userData(userData)
         .interactive(isInteractive);
-
     BitmapMarker marker = markerManager.addMarker(options);
-    when(marker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
-
     markerManager.restoreMarkers();
 
-    verify(tangramMarker).setPoint(point);
-    verify(tangramMarker).setDrawable(drawable);
-    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#ff00ff', "
-        + "size: [10px, 20px], collide: false, interactive: true }");
-    verify(marker).setTangramMarker(any(Marker.class));
-    verify(tangramMarker).setVisible(isVisible);
-    verify(tangramMarker).setDrawOrder(drawOrder);
-    verify(tangramMarker).setUserData(userData);
+    verify(marker).setTangramMarker(tangramMarker);
+    verify(marker).setPosition(point);
+    verify(marker).setIcon(drawable);
+    verify(marker).setSize(width, height);
+    verify(marker).setColor(colorHex);
+    verify(marker).setInteractive(isInteractive);
+    verify(marker).setVisible(isVisible);
+    verify(marker).setDrawOrder(drawOrder);
+    verify(marker).setUserData(userData);
   }
 
   @Test public void restoreMarkers_shouldProperlyRestoreAllManagedMarkers() throws Exception {
@@ -146,42 +174,34 @@ public class MarkerManagerTest {
         .colorInt(colorInt)
         .interactive(isInteractive);
 
-    BitmapMarker marker = markerManager.addMarker(options);
-    BitmapMarker anotherMarker = markerManager.addMarker(options);
-    StyleStringGenerator styleStringGenerator = new StyleStringGenerator();
-    when(marker.getStyleStringGenerator()).thenReturn(styleStringGenerator);
-    when(anotherMarker.getStyleStringGenerator()).thenReturn(styleStringGenerator);
+    BitmapMarker marker = mock(BitmapMarker.class);
+    when(markerFactory.createMarker(any(MarkerManager.class), any(com.mapzen.tangram.Marker.class),
+        any(StyleStringGenerator.class))).thenReturn(marker);
     when(marker.getPosition()).thenReturn(point);
-    when(anotherMarker.getPosition()).thenReturn(point);
     when(marker.getIconDrawable()).thenReturn(drawable);
-    when(anotherMarker.getIconDrawable()).thenReturn(drawable);
     when(marker.getWidth()).thenReturn(width);
-    when(anotherMarker.getWidth()).thenReturn(width);
     when(marker.getHeight()).thenReturn(height);
-    when(anotherMarker.getHeight()).thenReturn(height);
     when(marker.isInteractive()).thenReturn(isInteractive);
-    when(anotherMarker.isInteractive()).thenReturn(isInteractive);
     when(marker.getColor()).thenReturn(colorInt);
-    when(anotherMarker.getColor()).thenReturn(colorInt);
     when(marker.isVisible()).thenReturn(isVisible);
-    when(anotherMarker.isVisible()).thenReturn(isVisible);
     when(marker.getDrawOrder()).thenReturn(drawOrder);
-    when(anotherMarker.getDrawOrder()).thenReturn(drawOrder);
     when(marker.getUserData()).thenReturn(userData);
-    when(anotherMarker.getUserData()).thenReturn(userData);
 
+    markerManager.addMarker(options);
+    markerManager.addMarker(options);
     markerManager.restoreMarkers();
 
-    //times(4) instead of times(2) because 1x for adding each marker, 1x when restoring
-    verify(tangramMarker, times(4)).setPoint(point);
-    verify(tangramMarker, times(4)).setDrawable(drawable);
-    verify(tangramMarker, times(4)).setStylingFromString(styleStringGenerator.getStyleString(
-        width, height, isInteractive, "#ff0000ff"));
+    //times(2) 2 markers and 1x 1x when restoring
     verify(marker, times(2)).setTangramMarker(tangramMarker);
-    verify(anotherMarker, times(2)).setTangramMarker(tangramMarker);
-    verify(tangramMarker, times(4)).setVisible(isVisible);
-    verify(tangramMarker, times(4)).setDrawOrder(drawOrder);
-    verify(tangramMarker, times(4)).setUserData(userData);
+    //times(4) 2 markers and 1x for when adding each marker, 1x when restoring
+    verify(marker, times(4)).setPosition(point);
+    verify(marker, times(4)).setIcon(drawable);
+    verify(marker, times(4)).setSize(width, height);
+    verify(marker, times(4)).setColor(Color.BLUE);
+    verify(marker, times(4)).setInteractive(isInteractive);
+    verify(marker, times(4)).setVisible(isVisible);
+    verify(marker, times(4)).setDrawOrder(drawOrder);
+    verify(marker, times(4)).setUserData(userData);
   }
 
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 
 import java.util.HashMap;
@@ -95,18 +96,20 @@ public class MarkerManagerTest {
     LngLat point = new LngLat(40, 70);
     int width = 10;
     int height = 20;
-    //TODO: add these props to MarkerOptions
     boolean isVisible = true;
     int drawOrder = 20;
     Map userData = mock(HashMap.class);
-    int colorInt = Integer.MIN_VALUE;
-    String colorHex = "#fff";
+    String colorHex = "#ff00ff";
     boolean isInteractive = true;
-    //end TODO
     MarkerOptions options = new MarkerOptions()
         .icon(drawable)
         .position(point)
-        .size(width, height);
+        .size(width, height)
+        .colorHex(colorHex)
+        .drawOrder(drawOrder)
+        .visible(isVisible)
+        .userData(userData)
+        .interactive(isInteractive);
 
     BitmapMarker marker = markerManager.addMarker(options);
     when(marker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
@@ -115,11 +118,10 @@ public class MarkerManagerTest {
 
     verify(tangramMarker).setPoint(point);
     verify(tangramMarker).setDrawable(drawable);
-    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#fff', "
+    verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#ff00ff', "
         + "size: [10px, 20px], collide: false, interactive: true }");
     verify(marker).setTangramMarker(any(Marker.class));
-    //TODO: make tests pass
-    verify(tangramMarker).setVisible(true);
+    verify(tangramMarker).setVisible(isVisible);
     verify(tangramMarker).setDrawOrder(drawOrder);
     verify(tangramMarker).setUserData(userData);
   }
@@ -129,35 +131,57 @@ public class MarkerManagerTest {
     LngLat point = new LngLat(40, 70);
     int width = 10;
     int height = 20;
-    //TODO: add these props to MarkerOptions
     boolean isVisible = true;
     int drawOrder = 20;
     Map userData = mock(HashMap.class);
-    int colorInt = Integer.MIN_VALUE;
-    String colorHex = "#fff";
+    int colorInt = Color.BLUE;
     boolean isInteractive = true;
     MarkerOptions options = new MarkerOptions()
         .icon(drawable)
         .position(point)
-        .size(width, height);
+        .size(width, height)
+        .visible(isVisible)
+        .drawOrder(drawOrder)
+        .userData(userData)
+        .colorInt(colorInt)
+        .interactive(isInteractive);
 
     BitmapMarker marker = markerManager.addMarker(options);
     BitmapMarker anotherMarker = markerManager.addMarker(options);
-    when(marker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
-    when(anotherMarker.getStyleStringGenerator()).thenReturn(new StyleStringGenerator());
+    StyleStringGenerator styleStringGenerator = new StyleStringGenerator();
+    when(marker.getStyleStringGenerator()).thenReturn(styleStringGenerator);
+    when(anotherMarker.getStyleStringGenerator()).thenReturn(styleStringGenerator);
+    when(marker.getPosition()).thenReturn(point);
+    when(anotherMarker.getPosition()).thenReturn(point);
+    when(marker.getIconDrawable()).thenReturn(drawable);
+    when(anotherMarker.getIconDrawable()).thenReturn(drawable);
+    when(marker.getWidth()).thenReturn(width);
+    when(anotherMarker.getWidth()).thenReturn(width);
+    when(marker.getHeight()).thenReturn(height);
+    when(anotherMarker.getHeight()).thenReturn(height);
+    when(marker.isInteractive()).thenReturn(isInteractive);
+    when(anotherMarker.isInteractive()).thenReturn(isInteractive);
+    when(marker.getColor()).thenReturn(colorInt);
+    when(anotherMarker.getColor()).thenReturn(colorInt);
+    when(marker.isVisible()).thenReturn(isVisible);
+    when(anotherMarker.isVisible()).thenReturn(isVisible);
+    when(marker.getDrawOrder()).thenReturn(drawOrder);
+    when(anotherMarker.getDrawOrder()).thenReturn(drawOrder);
+    when(marker.getUserData()).thenReturn(userData);
+    when(anotherMarker.getUserData()).thenReturn(userData);
 
     markerManager.restoreMarkers();
 
     //times(4) instead of times(2) because 1x for adding each marker, 1x when restoring
-    verify(tangramMarker, times(4)).setPoint(any(LngLat.class));
-    verify(tangramMarker, times(4)).setDrawable(any(Drawable.class));
-    verify(tangramMarker, times(4)).setStylingFromString(anyString());
-    verify(marker).setTangramMarker(any(Marker.class));
-    verify(anotherMarker).setTangramMarker(any(Marker.class));
-    //TODO: make tests pass
-    verify(tangramMarker).setVisible(true);
-    verify(tangramMarker).setDrawOrder(drawOrder);
-    verify(tangramMarker).setUserData(userData);
+    verify(tangramMarker, times(4)).setPoint(point);
+    verify(tangramMarker, times(4)).setDrawable(drawable);
+    verify(tangramMarker, times(4)).setStylingFromString(styleStringGenerator.getStyleString(
+        width, height, isInteractive, "#ff0000ff"));
+    verify(marker, times(2)).setTangramMarker(tangramMarker);
+    verify(anotherMarker, times(2)).setTangramMarker(tangramMarker);
+    verify(tangramMarker, times(4)).setVisible(isVisible);
+    verify(tangramMarker, times(4)).setDrawOrder(drawOrder);
+    verify(tangramMarker, times(4)).setUserData(userData);
   }
 
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -31,10 +31,11 @@ public class MarkerManagerTest {
   private MapController mapController = mock(MapController.class);
   private com.mapzen.tangram.Marker tangramMarker = mock(com.mapzen.tangram.Marker.class);
   private BitmapMarkerFactory markerFactory = mock(BitmapMarkerFactory.class);
-  private MarkerManager markerManager = new MarkerManager(mapController, markerFactory,
+  private MarkerManager markerManager = new MarkerManager(markerFactory,
       new StyleStringGenerator());
 
   @Before public void setUp() throws Exception {
+    markerManager.setMapController(mapController);
     when(mapController.addMarker()).thenReturn(tangramMarker);
     when(markerFactory.createMarker(any(MarkerManager.class), any(com.mapzen.tangram.Marker.class),
         any(StyleStringGenerator.class))).thenReturn(mock(BitmapMarker.class));

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -118,10 +118,10 @@ public class MarkerManagerTest {
     verify(tangramMarker).setStylingFromString("{ style: 'points', color: '#fff', "
         + "size: [10px, 20px], collide: false, interactive: true }");
     verify(marker).setTangramMarker(any(Marker.class));
-    //TODO: add other props for verification, make test fail
-    //verify(tangramMarker).setVisible(true);
-    //verify(tangramMarker).setDrawOrder(drawOrder);
-    //verify(tangramMarker).setUserData(userData);
+    //TODO: make tests pass
+    verify(tangramMarker).setVisible(true);
+    verify(tangramMarker).setDrawOrder(drawOrder);
+    verify(tangramMarker).setUserData(userData);
   }
 
   @Test public void restoreMarkers_shouldProperlyRestoreAllManagedMarkers() throws Exception {
@@ -154,10 +154,10 @@ public class MarkerManagerTest {
     verify(tangramMarker, times(4)).setStylingFromString(anyString());
     verify(marker).setTangramMarker(any(Marker.class));
     verify(anotherMarker).setTangramMarker(any(Marker.class));
-    //TODO: add other props for verification, make test fail
-    //verify(tangramMarker).setVisible(true);
-    //verify(tangramMarker).setDrawOrder(drawOrder);
-    //verify(tangramMarker).setUserData(userData);
+    //TODO: make tests pass
+    verify(tangramMarker).setVisible(true);
+    verify(tangramMarker).setDrawOrder(drawOrder);
+    verify(tangramMarker).setUserData(userData);
   }
 
 }

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerManagerTest.java
@@ -3,7 +3,6 @@ package com.mapzen.android.graphics.model;
 import com.mapzen.android.graphics.internal.StyleStringGenerator;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
-import com.mapzen.tangram.Marker;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +19,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/core/src/test/java/com/mapzen/android/graphics/model/MarkerOptionsTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/model/MarkerOptionsTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import android.graphics.drawable.Drawable;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -29,5 +31,34 @@ public class MarkerOptionsTest {
     Drawable drawable = mock(Drawable.class);
     assertThat(markerOptions.icon(drawable).getIconDrawable()).isEqualTo(drawable);
     assertThat(markerOptions.getIcon()).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test public void shouldSetDrawOrder() throws Exception {
+    assertThat(markerOptions.drawOrder(1).getDrawOrder()).isEqualTo(1);
+  }
+
+  @Test public void shouldSetUserData() throws Exception {
+    Map userData = mock(Map.class);
+    assertThat(markerOptions.userData(userData).getUserData()).isEqualTo(userData);
+  }
+
+  @Test public void shouldSetColorInt() throws Exception {
+    assertThat(markerOptions.colorInt(8).getColorInt()).isEqualTo(8);
+  }
+
+  @Test public void shouldSetColorIntResetColorHex() throws Exception {
+    markerOptions.colorHex("test");
+    markerOptions.colorInt(8);
+    assertThat(markerOptions.getColorHex()).isNull();
+  }
+
+  @Test public void shouldSetColorHex() throws Exception {
+    assertThat(markerOptions.colorHex("asdf").getColorHex()).isEqualTo("asdf");
+  }
+
+  @Test public void shouldSetColorHexResetColorInt() throws Exception {
+    markerOptions.colorInt(10);
+    markerOptions.colorHex("asdf");
+    assertThat(markerOptions.getColorInt()).isEqualTo(Integer.MIN_VALUE);
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/AndroidManifest.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/AndroidManifest.xml
@@ -42,8 +42,7 @@
     <activity android:name=".MapzenSearchViewActivity"/>
     <activity
         android:name=".CustomMarkerActivity"
-        android:label="@string/custom_marker_demo_label"
-        />
+        android:theme="@style/AppTheme.NoActionBar"/>
     <activity
         android:name=".OverlayActivity"
         android:theme="@style/AppTheme.NoActionBar"/>

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
@@ -1,51 +1,40 @@
 package com.mapzen.android.sdk.sample;
 
-import com.mapzen.android.graphics.MapFragment;
-import com.mapzen.android.graphics.MapzenMap;
 import com.mapzen.android.graphics.MarkerPickListener;
-import com.mapzen.android.graphics.OnMapReadyCallback;
 import com.mapzen.android.graphics.model.BitmapMarker;
 import com.mapzen.android.graphics.model.MarkerOptions;
 import com.mapzen.tangram.LngLat;
 
-import android.os.Bundle;
 import android.view.View;
 import android.widget.Toast;
 
 /**
  * Custom marker demo.
  */
-public class CustomMarkerActivity extends BaseDemoActivity implements MarkerPickListener {
+public class CustomMarkerActivity extends SwitchStyleActivity implements MarkerPickListener {
 
-  private MapzenMap map;
   private BitmapMarker bitmapMarker;
 
-  @Override protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_custom_marker);
-    final MapFragment mapFragment =
-        (MapFragment) getSupportFragmentManager().findFragmentById(R.id.fragment);
-    mapFragment.getMapAsync(new OnMapReadyCallback() {
-      @Override public void onMapReady(MapzenMap map) {
-        CustomMarkerActivity.this.map = map;
-        configureMap();
-      }
-    });
+  int getLayoutId() {
+    return R.layout.activity_custom_marker;
   }
 
-  private void configureMap() {
-    map.setCompassButtonEnabled(true);
-    map.setPersistMapState(true);
-    map.setPosition(new LngLat(-73.985428, 40.748817));
-    map.setZoom(16);
-    map.setMarkerPickListener(this);
+  /**
+   * Configure map position and zoom. Also setup buttons to add/rm custom marker.
+   */
+  void configureMap() {
+    mapzenMap.setCompassButtonEnabled(true);
+    mapzenMap.setPersistMapState(true);
+    mapzenMap.setPosition(new LngLat(-73.985428, 40.748817));
+    mapzenMap.setZoom(16);
+    mapzenMap.setMarkerPickListener(this);
 
     findViewById(R.id.add_marker_btn).setOnClickListener(new View.OnClickListener() {
       @Override public void onClick(View v) {
         final MarkerOptions markerOptions = new MarkerOptions()
             .position(new LngLat(-73.985428, 40.748817))
             .icon(R.drawable.mapzen);
-        bitmapMarker = map.addBitmapMarker(markerOptions);
+        bitmapMarker = mapzenMap.addBitmapMarker(markerOptions);
       }
     });
 

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
@@ -13,7 +13,7 @@ import android.widget.Toast;
  */
 public class CustomMarkerActivity extends SwitchStyleActivity implements MarkerPickListener {
 
-  private BitmapMarker bitmapMarker;
+  private static BitmapMarker bitmapMarker;
 
   int getLayoutId() {
     return R.layout.activity_custom_marker;

--- a/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_custom_marker.xml
+++ b/samples/mapzen-android-sdk-sample/src/main/res/layout/activity_custom_marker.xml
@@ -1,9 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     >
+
+  <android.support.design.widget.AppBarLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:theme="@style/AppTheme.AppBarOverlay"
+      >
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/AppTheme.PopupOverlay"
+        >
+
+      <Spinner
+          android:id="@+id/spinner"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          />
+
+    </android.support.v7.widget.Toolbar>
+
+  </android.support.design.widget.AppBarLayout>
 
   <fragment
       android:id="@+id/fragment"
@@ -11,28 +36,31 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       app:overlayMode="classic"
-      />
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-  <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      >
 
-    <Button
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/add_marker"
-        android:id="@+id/add_marker_btn"
-        />
+        android:orientation="vertical"
+        >
 
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/remove_marker"
-        android:id="@+id/remove_marker_btn"
-        />
+      <Button
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/add_marker"
+          android:id="@+id/add_marker_btn"
+          />
 
-  </LinearLayout>
+      <Button
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/remove_marker"
+          android:id="@+id/remove_marker_btn"
+          />
 
-</FrameLayout>
+    </LinearLayout>
+
+  </fragment>
+
+</android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
### Overview
This PR uses `SceneLoadListener` to restore markers on scene updates, including scene updates which occur because of orientation changes. This code doesn't check `sceneId` in the listener callback because we always want to restore markers when the scene is ready after any update. It also doesn't check `sceneError` because the sdk doesn't have first class support for loading custom scenes and ensures that all house styles work with the apis we provide.

### Proposed Changes
- Adds `SceneLoadListener` to `MapzenMap`
- Adds restoration handling to `MarkerManager`
- Updates `MarkerOptions` to include all `BitmapMarker` properties
- Updates `BitmapMarker` to provide property getters
- Migrates `StyleStringGenerator` and `MarkerManager` to be singletons
- Updates and adds test coverage
- Updates custom marker example in sample app to show marker restoration on scene load changes

Closes #348 