### PR TITLE
Provide top level methods to set custom http handlers

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -22,4 +22,5 @@
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/MapReadyInitializer.java"/>
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/model/MarkerManager.java"/>
     <suppress checks="ParameterNumberCheck" files="src/main/java/com/mapzen/android/graphics/model/BitmapMarkerManager.java"/>
+    <suppress checks="[a-zA-Z0-9]*" files="src/main/java/com/mapzen/android/routing/MapzenRouterHttpHandler"/>
 </suppressions>

--- a/core/src/main/java/com/mapzen/android/core/GenericHttpHandler.java
+++ b/core/src/main/java/com/mapzen/android/core/GenericHttpHandler.java
@@ -13,6 +13,65 @@ public interface GenericHttpHandler {
   String USER_AGENT = "android-sdk;" + MapzenManager.getSdkVersion() + ";" + Build.VERSION.RELEASE;
 
   /**
+   * Log levels for http requests.
+   */
+  enum LogLevel {
+    /** No logs. */
+    NONE,
+    /**
+     * Logs request and response lines.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * --> POST /greeting http/1.1 (3-byte body)
+     *
+     * <-- 200 OK (22ms, 6-byte body)
+     * }</pre>
+     */
+    BASIC,
+    /**
+     * Logs request and response lines and their respective headers.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * --> POST /greeting http/1.1
+     * Host: example.com
+     * Content-Type: plain/text
+     * Content-Length: 3
+     * --> END POST
+     *
+     * <-- 200 OK (22ms)
+     * Content-Type: plain/text
+     * Content-Length: 6
+     * <-- END HTTP
+     * }</pre>
+     */
+    HEADERS,
+    /**
+     * Logs request and response lines and their respective headers and bodies (if present).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * --> POST /greeting http/1.1
+     * Host: example.com
+     * Content-Type: plain/text
+     * Content-Length: 3
+     *
+     * Hi?
+     * --> END POST
+     *
+     * <-- 200 OK (22ms)
+     * Content-Type: plain/text
+     * Content-Length: 6
+     *
+     * Hello!
+     * <-- END HTTP
+     * }</pre>
+     */
+    BODY
+  }
+
+  /**
    * Return query parameters to be appended to every request.
    * @return
    */

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -932,6 +932,14 @@ public class MapzenMap {
   }
 
   /**
+   * Sets the object used to add query parameters and headers to each request.
+   * @param handler
+   */
+  public void setHttpHandler(MapzenMapHttpHandler handler) {
+    mapController.setHttpHandler(handler.httpHandler());
+  }
+
+  /**
    * Restores all aspects of the map EXCEPT the style, this is restored in the
    * {@link MapInitializer}.
    */

--- a/core/src/main/java/com/mapzen/android/search/MapzenSearch.java
+++ b/core/src/main/java/com/mapzen/android/search/MapzenSearch.java
@@ -130,6 +130,15 @@ public class MapzenSearch {
   }
 
   /**
+   * Sets the router's http handler for adding custom headers and parameters to
+   * requests.
+   * @param handler
+   */
+  public void setHttpHandler(MapzenSearchHttpHandler handler) {
+    internalSearch.setRequestHandler(handler.searchHandler());
+  }
+
+  /**
    * Return the underlying {@link Pelias} object.
    * @return
    */

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -10,6 +10,7 @@ import com.mapzen.android.graphics.model.Marker;
 import com.mapzen.android.graphics.model.Polygon;
 import com.mapzen.android.graphics.model.Polyline;
 import com.mapzen.android.graphics.model.WalkaboutStyle;
+import com.mapzen.tangram.HttpHandler;
 import com.mapzen.tangram.LabelPickResult;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
@@ -707,6 +708,14 @@ public class MapzenMapTest {
   @Test public void onSceneReady_restoresMarkers() throws Exception {
     map.internalSceneLoadListener.onSceneReady(1, null);
     verify(bitmapMarkerManager).restoreMarkers();
+  }
+
+  @Test public void setHttpHandler_shouldCallMapController() throws Exception {
+    MapzenMapHttpHandler mapzenMapHandler = mock(MapzenMapHttpHandler.class);
+    HttpHandler handler = mock(HttpHandler.class);
+    when(mapzenMapHandler.httpHandler()).thenReturn(handler);
+    map.setHttpHandler(mapzenMapHandler);
+    verify(mapController).setHttpHandler(handler);
   }
 
   public class TestRotateResponder implements TouchInput.RotateResponder {

--- a/core/src/test/java/com/mapzen/android/search/MapzenSearchTest.java
+++ b/core/src/test/java/com/mapzen/android/search/MapzenSearchTest.java
@@ -16,6 +16,7 @@ import static com.mapzen.TestHelper.getMockContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -83,6 +84,15 @@ public class MapzenSearchTest {
     TestPeliasLocationProvider provider = new TestPeliasLocationProvider();
     search.setLocationProvider(provider);
     verify(search.getPelias()).setLocationProvider(provider);
+  }
+
+  @Test public void setHttpHandler_shouldCallInternalSearch() throws Exception {
+    MapzenSearchHttpHandler mapzenSearchHandler = mock(MapzenSearchHttpHandler.class);
+    MapzenSearchHttpHandler.SearchRequestHandler handler = mock(
+        MapzenSearchHttpHandler.SearchRequestHandler.class);
+    when(mapzenSearchHandler.searchHandler()).thenReturn(handler);
+    search.setHttpHandler(mapzenSearchHandler);
+    verify(search.getPelias()).setRequestHandler(handler);
   }
 
   private class TestCallback implements Callback<Result> {

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
@@ -150,6 +150,15 @@ public class MapzenRouter {
     return this;
   }
 
+  /**
+   * Sets the router's http handler for adding custom headers and parameters to
+   * requests.
+   * @param handler
+   */
+  public void setHttpHandler(MapzenRouterHttpHandler handler) {
+    internalRouter.setHttpHandler(handler.turnByTurnHandler());
+  }
+
   public Router getRouter() {
     return internalRouter;
   }

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouterHttpHandler.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouterHttpHandler.java
@@ -7,6 +7,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.mapzen.android.core.GenericHttpHandler.LogLevel.BASIC;
+import static com.mapzen.android.core.GenericHttpHandler.LogLevel.BODY;
+import static com.mapzen.android.core.GenericHttpHandler.LogLevel.HEADERS;
+import static com.mapzen.android.core.GenericHttpHandler.LogLevel.NONE;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -18,6 +22,8 @@ import okhttp3.logging.HttpLoggingInterceptor;
  */
 public abstract class MapzenRouterHttpHandler implements GenericHttpHandler {
 
+  public static final String DEFAULT_URL = "https://valhalla.mapzen.com/";
+  public static final LogLevel DEFAULT_LOG_LEVEL = MapzenRouterHttpHandler.getDefaultLogLevel();
   private TurnByTurnHttpHandler handler;
   ChainProceder chainProceder = new ChainProceder();
 
@@ -25,7 +31,14 @@ public abstract class MapzenRouterHttpHandler implements GenericHttpHandler {
    * Construct handler with default url and log levels.
    */
   public MapzenRouterHttpHandler() {
-    handler = new TurnByTurnHttpHandler(HttpLoggingInterceptor.Level.BODY);
+    handler = new TurnByTurnHttpHandler(DEFAULT_URL, DEFAULT_LOG_LEVEL);
+  }
+
+  /**
+   * Construct handler with custom url and log levels.
+   */
+  public MapzenRouterHttpHandler(String url, LogLevel logLevel) {
+    handler = new TurnByTurnHttpHandler(url, logLevel);
   }
 
   /**
@@ -34,6 +47,10 @@ public abstract class MapzenRouterHttpHandler implements GenericHttpHandler {
    */
   TurnByTurnHttpHandler turnByTurnHandler() {
     return handler;
+  }
+
+  private static LogLevel getDefaultLogLevel() {
+    return BASIC;
   }
 
   /**
@@ -45,32 +62,20 @@ public abstract class MapzenRouterHttpHandler implements GenericHttpHandler {
 
     private String apiKey;
 
-    /**
-     * Construct handler with default url and log levels.
-     */
-    public TurnByTurnHttpHandler() {
-      configure(DEFAULT_URL, DEFAULT_LOG_LEVEL);
-    }
-
-    /**
-     * Construct handler with url and default log levels.
-     */
-    public TurnByTurnHttpHandler(String endpoint) {
-      configure(endpoint, DEFAULT_LOG_LEVEL);
-    }
-
-    /**
-     * Construct handler with log levels and default url.
-     */
-    public TurnByTurnHttpHandler(HttpLoggingInterceptor.Level logLevel) {
-      configure(DEFAULT_URL, logLevel);
-    }
+    private final Map<LogLevel, HttpLoggingInterceptor.Level> TO_INTERNAL_LEVEL = new HashMap() {
+      {
+        put(NONE, HttpLoggingInterceptor.Level.NONE);
+        put(BASIC, HttpLoggingInterceptor.Level.BASIC);
+        put(HEADERS, HttpLoggingInterceptor.Level.HEADERS);
+        put(BODY, HttpLoggingInterceptor.Level.BODY);
+      }
+    };
 
     /**
      * Construct handler with url and log levels.
      */
-    public TurnByTurnHttpHandler(String endpoint, HttpLoggingInterceptor.Level logLevel) {
-      configure(endpoint, logLevel);
+    public TurnByTurnHttpHandler(String endpoint, LogLevel logLevel) {
+      configure(endpoint, TO_INTERNAL_LEVEL.get(logLevel));
     }
 
     /**

--- a/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterHttpHandlerTest.java
+++ b/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterHttpHandlerTest.java
@@ -1,5 +1,8 @@
 package com.mapzen.android.routing;
 
+import com.mapzen.android.core.GenericHttpHandler;
+import com.mapzen.valhalla.TestHttpHandlerHelper;
+
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -9,6 +12,8 @@ import static com.mapzen.android.core.GenericHttpHandler.HEADER_USER_AGENT;
 import static com.mapzen.android.core.GenericHttpHandler.USER_AGENT;
 import static com.mapzen.android.routing.MapzenRouterHttpHandler.TurnByTurnHttpHandler.NAME_API_KEY;
 import okhttp3.Interceptor;
+import okhttp3.logging.HttpLoggingInterceptor;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -63,5 +68,23 @@ public class MapzenRouterHttpHandlerTest {
     headers.putAll(testHeaders);
 
     verify(proceder).proceed(chain, params, headers);
+  }
+
+  @Test public void initWithCustomUrlAndLogLevelShouldCallConstructor() throws Exception {
+    MapzenRouterHttpHandler handler = new MapzenRouterHttpHandler("http://test.com",
+        GenericHttpHandler.LogLevel.BODY) {
+      @Override public Map<String, String> queryParamsForRequest() {
+        return null;
+      }
+
+      @Override public Map<String, String> headersForRequest() {
+        return null;
+      }
+    };
+    String endpoint = TestHttpHandlerHelper.getEndpoint(handler.turnByTurnHandler());
+    assertThat(endpoint).isEqualTo("http://test.com");
+    HttpLoggingInterceptor.Level level = TestHttpHandlerHelper.getLogLevel(
+        handler.turnByTurnHandler());
+    assertThat(level).isEqualTo(HttpLoggingInterceptor.Level.BODY);
   }
 }

--- a/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterTest.java
+++ b/mapzen-android-sdk/src/test/java/com/mapzen/android/routing/MapzenRouterTest.java
@@ -16,6 +16,7 @@ import static com.mapzen.android.TestHelper.getMockContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MapzenRouterTest {
 
@@ -94,6 +95,15 @@ public class MapzenRouterTest {
 
   @Test public void distanceUnitsToString_shouldReturnKilometers() throws Exception {
     assertThat(MapzenRouter.DistanceUnits.KILOMETERS.toString()).isEqualTo("kilometers");
+  }
+
+  @Test public void setHttpHandler_shouldCallInternalRouter() throws Exception {
+    MapzenRouterHttpHandler mapzenRouterHandler = mock(MapzenRouterHttpHandler.class);
+    MapzenRouterHttpHandler.TurnByTurnHttpHandler handler = mock(
+        MapzenRouterHttpHandler.TurnByTurnHttpHandler.class);
+    when(mapzenRouterHandler.turnByTurnHandler()).thenReturn(handler);
+    router.setHttpHandler(mapzenRouterHandler);
+    verify(router.getRouter()).setHttpHandler(handler);
   }
 
   class TestRouteCallback implements RouteCallback {

--- a/mapzen-android-sdk/src/test/java/com/mapzen/valhalla/TestHttpHandlerHelper.java
+++ b/mapzen-android-sdk/src/test/java/com/mapzen/valhalla/TestHttpHandlerHelper.java
@@ -1,0 +1,19 @@
+package com.mapzen.valhalla;
+
+
+import okhttp3.logging.HttpLoggingInterceptor;
+
+/**
+ * Used to get access to internal variables for
+ * {@link com.mapzen.android.routing.MapzenRouterHttpHandlerTest}.
+ */
+public class TestHttpHandlerHelper {
+
+  public static String getEndpoint(HttpHandler httpHandler) {
+    return httpHandler.endpoint;
+  }
+
+  public static HttpLoggingInterceptor.Level getLogLevel(HttpHandler httpHandler) {
+    return httpHandler.logLevel;
+  }
+}


### PR DESCRIPTION
### Overview
This is the first of two PRs needed to bring first class support for providing custom http headers and parameters to search, routing, and tile requests. This work adds `MapzenSearch#setHttpHandler(MapzenSearchHttpHandler )`, `MapzenRouter#setHttpHandler(MapzenRouterHttpHandler )`, and `MapzenMap#setHttpHandler(MapzenMapHttpHandler )` methods.

### Proposed Changes
- Adds top level APIs to set custom http parameters and headers
- Adds relevant test coverage
- Adds SDK `LogLevel` enum for mapping to internal implementation log level (future PR will provide ability to set log level on search and map handlers as well https://github.com/mapzen/android/issues/445)
- Updates `MapzenRouterHttpHandler` to allow setting base url and log level

A follow up PR will provide support for pulling the API key from `MapzenManager` automatically (https://github.com/mapzen/android/issues/444)

Closes #443 