### PR TITLE
Fix Crash

### DIFF
--- a/core/src/main/java/com/mapzen/android/core/MapzenManager.java
+++ b/core/src/main/java/com/mapzen/android/core/MapzenManager.java
@@ -5,7 +5,6 @@ import com.mapzen.BuildConfig;
 import android.content.Context;
 import android.content.res.Resources;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,7 +37,7 @@ public class MapzenManager {
 
   static MapzenManager instance;
 
-  private List<WeakReference<ApiKeyChangeListener>> listeners = new ArrayList<>();
+  private List<ApiKeyChangeListener> listeners = new ArrayList<>();
 
   /**
    * Get singleton instance.
@@ -101,27 +100,23 @@ public class MapzenManager {
   /**
    * Adds listener to list of managed callbacks so that it can be notified when API key changes
    * occur.
-   * @param listenerReference
+   * @param listener
    */
-  public void addApiKeyChangeListener(WeakReference<ApiKeyChangeListener> listenerReference) {
-    Collections.synchronizedList(listeners).add(listenerReference);
+  public void addApiKeyChangeListener(ApiKeyChangeListener listener) {
+    Collections.synchronizedList(listeners).add(listener);
   }
 
   /**
    * Removes listener from list of managed callbacks.
-   * @param listenerReference
+   * @param listener
    */
-  public void removeApiKeyChangeListener(WeakReference<ApiKeyChangeListener> listenerReference) {
-    Collections.synchronizedList(listeners).remove(listenerReference);
+  public void removeApiKeyChangeListener(ApiKeyChangeListener listener) {
+    Collections.synchronizedList(listeners).remove(listener);
   }
 
   private void notifyListeners() {
-    for (WeakReference<ApiKeyChangeListener> weakReference : Collections.synchronizedList(
-        listeners)) {
-      ApiKeyChangeListener listener = weakReference.get();
-      if (listener != null) {
-        listener.onApiKeyChanged(apiKey);
-      }
+    for (ApiKeyChangeListener listener: Collections.synchronizedList(listeners)) {
+      listener.onApiKeyChanged(apiKey);
     }
   }
 }

--- a/core/src/main/java/com/mapzen/android/core/MapzenManager.java
+++ b/core/src/main/java/com/mapzen/android/core/MapzenManager.java
@@ -107,6 +107,14 @@ public class MapzenManager {
     Collections.synchronizedList(listeners).add(listenerReference);
   }
 
+  /**
+   * Removes listener from list of managed callbacks.
+   * @param listenerReference
+   */
+  public void removeApiKeyChangeListener(WeakReference<ApiKeyChangeListener> listenerReference) {
+    Collections.synchronizedList(listeners).remove(listenerReference);
+  }
+
   private void notifyListeners() {
     for (WeakReference<ApiKeyChangeListener> weakReference : Collections.synchronizedList(
         listeners)) {

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -1088,6 +1088,8 @@ public class MapzenMap {
     mapStateManager.setZoom(mapController.getZoom());
     mapStateManager.setRotation(mapController.getRotation());
     mapStateManager.setTilt(mapController.getTilt());
+
+    mapzenManager.removeApiKeyChangeListener(apiKeyChangeListener);
   }
 
   private void postFeaturePickRunnable(final Map<String, String> properties, final float positionX,

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -30,7 +30,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.View;
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -160,14 +159,13 @@ public class MapzenMap {
     }
   };
 
-  WeakReference<ApiKeyChangeListener> apiKeyChangeListener = new WeakReference(
-      new ApiKeyChangeListener() {
-        @Override public void onApiKeyChanged(String apiKey) {
-          List<SceneUpdate> updates = new ArrayList<>();
-          updates.add(sceneUpdateManager.getApiKeyUpdate(apiKey));
-          mapController.updateSceneAsync(updates);
-        }
-      });
+  ApiKeyChangeListener apiKeyChangeListener = new ApiKeyChangeListener() {
+    @Override public void onApiKeyChanged(String apiKey) {
+      List<SceneUpdate> updates = new ArrayList<>();
+      updates.add(sceneUpdateManager.getApiKeyUpdate(apiKey));
+      mapController.updateSceneAsync(updates);
+    }
+  };
 
   OnStyleLoadedListener styleLoadedListener = null;
   int currSceneId = Integer.MIN_VALUE;

--- a/core/src/main/java/com/mapzen/android/search/MapzenSearchHttpHandler.java
+++ b/core/src/main/java/com/mapzen/android/search/MapzenSearchHttpHandler.java
@@ -7,7 +7,6 @@ import com.mapzen.pelias.PeliasRequestHandler;
 
 import android.content.Context;
 
-import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,12 +16,11 @@ import java.util.Map;
 public abstract class MapzenSearchHttpHandler implements GenericHttpHandler {
 
   private SearchRequestHandler searchHandler;
-  WeakReference<ApiKeyChangeListener> apiKeyChangeListener = new WeakReference(
-      new ApiKeyChangeListener() {
-        @Override public void onApiKeyChanged(String apiKey) {
-          searchHandler.setApiKey(apiKey);
-        }
-      });
+  ApiKeyChangeListener apiKeyChangeListener = new ApiKeyChangeListener() {
+    @Override public void onApiKeyChanged(String apiKey) {
+      searchHandler.setApiKey(apiKey);
+    }
+  };
 
   /**
    * Public constructor.

--- a/core/src/test/java/com/mapzen/android/core/MapzenManagerTest.java
+++ b/core/src/test/java/com/mapzen/android/core/MapzenManagerTest.java
@@ -13,8 +13,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 
-import java.lang.ref.WeakReference;
-
 import static com.mapzen.TestHelper.getMockContext;
 import static com.mapzen.android.core.MapzenManager.API_KEY_RES_NAME;
 import static com.mapzen.android.core.MapzenManager.API_KEY_RES_TYPE;
@@ -77,12 +75,21 @@ public class MapzenManagerTest {
     assertThat(MapzenManager.getSdkVersion()).isNotEmpty();
   }
 
-  @Test public void weakAddApiKeyChangeListener_shouldAddListener() throws Exception {
+  @Test public void addApiKeyChangeListener_shouldAddListener() throws Exception {
     MapzenManager manager = MapzenManager.instance(getMockContext());
     TestApiKeyListener listener = new TestApiKeyListener();
-    WeakReference<ApiKeyChangeListener> listenerReference = new WeakReference(listener);
-    manager.addApiKeyChangeListener(listenerReference);
+    manager.addApiKeyChangeListener(listener);
     manager.setApiKey("key");
+    assertThat(listener.key).isEqualTo("key");
+  }
+
+  @Test public void removeApiKeyChangeListener_shouldRemoveListener() throws Exception {
+    MapzenManager manager = MapzenManager.instance(getMockContext());
+    TestApiKeyListener listener = new TestApiKeyListener();
+    manager.addApiKeyChangeListener(listener);
+    manager.setApiKey("key");
+    manager.removeApiKeyChangeListener(listener);
+    manager.setApiKey("test");
     assertThat(listener.key).isEqualTo("key");
   }
 

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -631,6 +631,12 @@ public class MapzenMapTest {
     assertThat(mapStateManager.getTilt()).isEqualTo(1.57f);
   }
 
+  @Test public void onDestroy_shouldUnregisterApiKeyListener() throws Exception {
+    mapzenManager.addApiKeyChangeListener(map.apiKeyChangeListener);
+    map.onDestroy();
+    verify(mapzenManager).removeApiKeyChangeListener(map.apiKeyChangeListener);
+  }
+
   @Test public void restoreMapState_shouldPersistPosition() throws Exception {
     verify(mapController).setPosition(new LngLat(0, 0));
   }

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouterHttpHandler.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouterHttpHandler.java
@@ -32,12 +32,11 @@ public abstract class MapzenRouterHttpHandler implements GenericHttpHandler {
   public static final LogLevel DEFAULT_LOG_LEVEL = MapzenRouterHttpHandler.getDefaultLogLevel();
   private TurnByTurnHttpHandler handler;
   ChainProceder chainProceder = new ChainProceder();
-  WeakReference<ApiKeyChangeListener> apiKeyChangeListener = new WeakReference(
-      new ApiKeyChangeListener() {
-        @Override public void onApiKeyChanged(String apiKey) {
-          handler.setApiKey(apiKey);
-        }
-      });
+  ApiKeyChangeListener apiKeyChangeListener = new ApiKeyChangeListener() {
+    @Override public void onApiKeyChanged(String apiKey) {
+      handler.setApiKey(apiKey);
+    }
+  };
 
   /**
    * Construct handler with default url and log levels.


### PR DESCRIPTION
### Overview
Previously we registered for changes to the api key in `MapzenMap` with a weak reference to a listener and never unregistered this listener. This could produce a crash in scenarios where `MapView` was destroyed and then a call to set the api key was received (because the native pointer is reset when the `MapView` is destroyed but the `MapzenMap` is still in memory and therefore still able to receive calls to the key change). This PR updates the listener behavior so that api calls are balanced with add/remove and updates `MapzenMap` to remove its key listener in the existing `onDestroy` method (called when the `MapView` is destroyed).

### Proposed Changes
- Remove `ApiKeyChangeListener` when `MapView` is destroyed to prevent triggering a scene update
- Add `removeApiKeyChangeListener` method to `MapzenManager`
- Adds test coverage for these changes

Closes #467 