### PR TITLE
NPE

### DIFF
--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/BasicMapzenActivity.java
@@ -89,7 +89,9 @@ public class BasicMapzenActivity extends BaseDemoActivity
 
   @Override protected void onDestroy() {
     super.onDestroy();
-    map.setFindMeOnClickListener(null);
+    if (map != null) {
+      map.setFindMeOnClickListener(null);
+    }
   }
 
   @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MapzenSearchViewActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MapzenSearchViewActivity.java
@@ -1,4 +1,4 @@
-package com.mapzen.android.sdk.sample;
+ package com.mapzen.android.sdk.sample;
 
 import com.mapzen.android.graphics.MapView;
 import com.mapzen.android.graphics.MapzenMap;
@@ -99,6 +99,8 @@ public class MapzenSearchViewActivity extends BaseDemoActivity {
 
   @Override protected void onDestroy() {
     super.onDestroy();
-    mapzenMap.setPersistMapData(false);
+    if (mapzenMap != null) {
+        mapzenMap.setPersistMapData(false);
+    }
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MarkerMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/MarkerMapzenActivity.java
@@ -40,7 +40,9 @@ public class MarkerMapzenActivity extends BaseDemoActivity {
   }
 
   @Override protected void onDestroy() {
-    map.removeMarker();
+    if (map != null) {
+        map.removeMarker();
+    }
     super.onDestroy();
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -57,7 +57,9 @@ public class OverlayActivity extends SwitchStyleActivity {
   }
 
   @Override protected void onDestroy() {
-    mapzenMap.setMyLocationEnabled(false);
+    if (mapzenMap != null) {
+        mapzenMap.setMyLocationEnabled(false);
+    }
     super.onDestroy();
   }
 

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/PolygonMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/PolygonMapzenActivity.java
@@ -43,7 +43,9 @@ public class PolygonMapzenActivity extends BaseDemoActivity {
   }
 
   @Override protected void onDestroy() {
-    map.removePolygon();
+    if (map != null) {
+        map.removePolygon();
+    }
     super.onDestroy();
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/PolylineMapzenActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/PolylineMapzenActivity.java
@@ -42,7 +42,9 @@ public class PolylineMapzenActivity extends BaseDemoActivity {
   }
 
   @Override protected void onDestroy() {
-    map.removePolyline();
+    if (map != null) {
+        map.removePolyline();
+    }
     super.onDestroy();
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/RoutePinsActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/RoutePinsActivity.java
@@ -61,7 +61,9 @@ public class RoutePinsActivity extends BaseDemoActivity {
   }
 
   @Override protected void onDestroy() {
-    map.clearRoutePins();
+    if (map != null) {
+        map.clearRoutePins();
+    }
     super.onDestroy();
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/RouterActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/RouterActivity.java
@@ -118,7 +118,9 @@ public class RouterActivity extends BaseDemoActivity {
   }
 
   @Override protected void onDestroy() {
-    map.setMyLocationEnabled(false);
+    if (map != null) {
+        map.setMyLocationEnabled(false);
+    }
     super.onDestroy();
   }
 }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SwitchStyleActivity.java
@@ -86,7 +86,9 @@ public class SwitchStyleActivity extends BaseDemoActivity {
   @Override protected void onDestroy() {
     styleSpinner.setOnItemSelectedListener(null);
     updateBtn.setOnClickListener(null);
-    mapzenMap.setMyLocationEnabled(false);
+    if (mapzenMap != null) {
+        mapzenMap.setMyLocationEnabled(false);
+    }
     super.onDestroy();
   }
 


### PR DESCRIPTION
### Overview
When rotating the sample fast, its possible that `onDestroy` is called before we have a `MapzenMap`

### Proposed Changes
- Checks map is not null before calling method in `onDestroy`

Closes #470 