### PR TITLE
Fix Custom Marker and Overlay Samples

### DIFF
--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/CustomMarkerActivity.java
@@ -11,11 +11,12 @@ import android.widget.Toast;
 /**
  * Custom marker demo.
  */
-public class CustomMarkerActivity extends SwitchStyleActivity implements MarkerPickListener {
+public class CustomMarkerActivity extends SimpleStyleSwitcherActivity implements
+    MarkerPickListener {
 
   private static BitmapMarker bitmapMarker;
 
-  int getLayoutId() {
+  @Override int getLayoutId() {
     return R.layout.activity_custom_marker;
   }
 

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/LabelPickListenerActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/LabelPickListenerActivity.java
@@ -32,7 +32,7 @@ public class LabelPickListenerActivity extends BaseDemoActivity {
 
       Map<String, String> properties = result.getProperties();
       String name = properties.get("name");
-      if (!name.isEmpty()) {
+      if (name != null && !name.isEmpty()) {
         Toast.makeText(LabelPickListenerActivity.this, name, Toast.LENGTH_SHORT).show();
       }
     }

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/OverlayActivity.java
@@ -9,7 +9,7 @@ import android.widget.Spinner;
 /**
  * Example activity for toggling transit, bike, and path overlays.
  */
-public class OverlayActivity extends SwitchStyleActivity {
+public class OverlayActivity extends SimpleStyleSwitcherActivity {
 
   private AdapterView.OnItemSelectedListener itemSelectedListener =
       new AdapterView.OnItemSelectedListener() {
@@ -40,6 +40,10 @@ public class OverlayActivity extends SwitchStyleActivity {
     }
   };
 
+  @Override int getLayoutId() {
+    return R.layout.activity_overlay;
+  }
+
   @Override public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
@@ -52,7 +56,7 @@ public class OverlayActivity extends SwitchStyleActivity {
   }
 
   @Override void configureMap() {
-    super.configureMap();
+    mapzenMap.setPersistMapState(true);
     mapzenMap.setMyLocationEnabled(true);
   }
 
@@ -61,10 +65,6 @@ public class OverlayActivity extends SwitchStyleActivity {
         mapzenMap.setMyLocationEnabled(false);
     }
     super.onDestroy();
-  }
-
-  int getLayoutId() {
-    return R.layout.activity_overlay;
   }
 
   /**

--- a/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SimpleStyleSwitcherActivity.java
+++ b/samples/mapzen-android-sdk-sample/src/main/java/com/mapzen/android/sdk/sample/SimpleStyleSwitcherActivity.java
@@ -1,0 +1,98 @@
+package com.mapzen.android.sdk.sample;
+
+import com.mapzen.android.graphics.MapFragment;
+import com.mapzen.android.graphics.MapzenMap;
+import com.mapzen.android.graphics.OnMapReadyCallback;
+import com.mapzen.android.graphics.model.BubbleWrapStyle;
+import com.mapzen.android.graphics.model.CinnabarStyle;
+import com.mapzen.android.graphics.model.RefillStyle;
+import com.mapzen.android.graphics.model.ThemedMapStyle;
+import com.mapzen.android.graphics.model.WalkaboutStyle;
+import com.mapzen.android.graphics.model.ZincStyle;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+
+/**
+ * Simple activity to display spinner of all available styles. Super class for
+ * {@link CustomMarkerActivity} and {@link OverlayActivity}.
+ */
+public abstract class SimpleStyleSwitcherActivity extends BaseDemoActivity {
+
+  MapzenMap mapzenMap;
+
+  /**
+   * Layout must have a {@link MapFragment} with id "fragment" and {@link Spinner} with id
+   * "spinner".
+   * @return
+   */
+  abstract int getLayoutId();
+
+  /**
+   * Called after {@link MapFragment#getMapAsync(OnMapReadyCallback)} completes.
+   */
+  abstract void configureMap();
+
+  private AdapterView.OnItemSelectedListener styleSelectedListener =
+      new AdapterView.OnItemSelectedListener() {
+        @Override public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+          handleStyleSelected(i);
+        }
+
+        @Override public void onNothingSelected(AdapterView<?> adapterView) {
+
+        }
+      };
+
+  @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(getLayoutId());
+
+    Spinner spinner = findViewById(R.id.spinner);
+    ArrayAdapter<CharSequence> adapter =
+        ArrayAdapter.createFromResource(this, R.array.style_array, R.layout.simple_spinner_item);
+    adapter.setDropDownViewResource(R.layout.simple_spinner_dropdown_item);
+    spinner.setAdapter(adapter);
+    spinner.setOnItemSelectedListener(styleSelectedListener);
+
+    MapFragment fragment = (MapFragment) getSupportFragmentManager().findFragmentById(
+        R.id.fragment);
+    fragment.getMapAsync(new OnMapReadyCallback() {
+      @Override public void onMapReady(MapzenMap mapzenMap) {
+        SimpleStyleSwitcherActivity.this.mapzenMap = mapzenMap;
+        configureMap();
+      }
+    });
+  }
+
+  private void handleStyleSelected(int position) {
+    ThemedMapStyle style;
+    switch (position) {
+      case 0:
+        style = new BubbleWrapStyle();
+        break;
+      case 1:
+        style = new CinnabarStyle();
+        break;
+      case 2:
+        style = new RefillStyle();
+        break;
+      case 3:
+        style = new WalkaboutStyle();
+        break;
+      case 4:
+        style = new ZincStyle();
+        break;
+      default:
+        style = new BubbleWrapStyle();
+        break;
+    }
+    if (mapzenMap != null) {
+      mapzenMap.setStyleAsync(style, null);
+    }
+  }
+}


### PR DESCRIPTION
### Overview
A recent PR (https://github.com/mapzen/android/pull/465) broke the samples for custom markers and overlays. This creates a new class for those samples to extend from which provides a spinner populated with map styles and handles updating the map when one is selected

### Proposed Changes
- Adds new `Activity` for custom marker and overlay samples to extend from
- Fixes NPE in `LabelPickListenerActivity` observed when name property not present

