### PR TITLE
Remove listener when map view destroyed

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -1,9 +1,9 @@
 package com.mapzen.android.graphics;
 
 import com.mapzen.android.core.MapzenManager;
+import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.MapStyle;
-import com.mapzen.android.graphics.model.BitmapMarkerManager;
 import com.mapzen.android.graphics.model.ThemedMapStyle;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.SceneError;
@@ -38,6 +38,8 @@ public class MapInitializer {
   private BitmapMarkerManager bitmapMarkerManager;
 
   private ImportYamlGenerator yamlGenerator;
+
+  MapController controller;
 
   /**
    * Creates a new instance.
@@ -105,7 +107,7 @@ public class MapInitializer {
     final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
         mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled(),
         mapStateManager.isPathOverlayEnabled());
-    MapController controller = mapView.getTangramMapView().getMap(
+    controller = mapView.getTangramMapView().getMap(
         new MapController.SceneLoadListener() {
       @Override public void onSceneReady(int sceneId, SceneError sceneError) {
         mapReadyInitializer.onMapReady(mapView, mapzenMapHttpHandler, callback, mapDataManager,
@@ -120,5 +122,13 @@ public class MapInitializer {
     } else {
       controller.loadSceneFileAsync(mapStyle.getSceneFile(), sceneUpdates);
     }
+  }
+
+  /**
+   * Called my {@link MapView} when the view has been destroyed. Use this method to prevent scene
+   * updates and other future interaction with {@link MapController}.
+   */
+  public void takeDown() {
+    controller.setSceneLoadListener(null);
   }
 }

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -242,6 +242,8 @@ public class MapView extends RelativeLayout {
    * You must call this method from the parent Activity/Fragment's corresponding method.
    */
   public void onDestroy() {
+    mapInitializer.takeDown();
+
     if (mapzenMap != null) {
       mapzenMap.onDestroy();
     }

--- a/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapzenMap.java
@@ -1088,6 +1088,18 @@ public class MapzenMap {
     mapStateManager.setTilt(mapController.getTilt());
 
     mapzenManager.removeApiKeyChangeListener(apiKeyChangeListener);
+
+    mapController.setSceneLoadListener(null);
+    mapController.setRotateResponder(null);
+    mapController.setPanResponder(null);
+    mapController.setDoubleTapResponder(null);
+    mapController.setTapResponder(null);
+    mapController.setLongPressResponder(null);
+    mapController.setScaleResponder(null);
+    mapController.setShoveResponder(null);
+    mapController.setLabelPickListener(null);
+    mapController.setMarkerPickListener(null);
+    mapController.setFeaturePickListener(null);
   }
 
   private void postFeaturePickRunnable(final Map<String, String> properties, final float positionX,

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -217,4 +217,11 @@ public class MapInitializerTest {
     mapInitializer.init(mapView, style, new TestCallback());
     assertThat(mapStateManager.getThemeColor()).isEqualTo(style.getDefaultColor());
   }
+
+  @Test public void takedown_shouldResetListener() throws Exception {
+    MapController controller = mock(MapController.class);
+    mapInitializer.controller = controller;
+    mapInitializer.takeDown();
+    verify(controller).setSceneLoadListener(null);
+  }
 }

--- a/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapViewTest.java
@@ -105,8 +105,16 @@ public class MapViewTest {
   @Test public void onDestroy_shouldDestroyMapzenMap() throws Exception {
     MapzenMap map = mock(MapzenMap.class);
     mapView.setMapzenMap(map);
+    mapView.mapInitializer = mock(MapInitializer.class);
     mapView.onDestroy();
     verify(map).onDestroy();
+  }
+
+  @Test public void onDestroy_shouldTakedownInitializer() throws Exception {
+    MapInitializer initializer = mock(MapInitializer.class);
+    mapView.mapInitializer = initializer;
+    mapView.onDestroy();
+    verify(initializer).takeDown();
   }
 
   private void initMockAttributes(Context context, TypedArray typedArray,

--- a/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapzenMapTest.java
@@ -637,6 +637,61 @@ public class MapzenMapTest {
     verify(mapzenManager).removeApiKeyChangeListener(map.apiKeyChangeListener);
   }
 
+  @Test public void onDestroy_shouldUnregisterSceneLoadListener() throws Exception {
+    map.onDestroy();
+    verify(mapController).setSceneLoadListener(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterRotateResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setRotateResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterPanResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setPanResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterDoubleTapResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setDoubleTapResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterTapResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setTapResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterLongPressResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setLongPressResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterScaleResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setScaleResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterShoveResponder() throws Exception {
+    map.onDestroy();
+    verify(mapController).setShoveResponder(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterLabelPickListener() throws Exception {
+    map.onDestroy();
+    verify(mapController).setLabelPickListener(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterMarkerPickListener() throws Exception {
+    map.onDestroy();
+    verify(mapController).setMarkerPickListener(null);
+  }
+
+  @Test public void onDestroy_shouldUnregisterFeaturePickListener() throws Exception {
+    map.onDestroy();
+    verify(mapController).setFeaturePickListener(null);
+  }
+
   @Test public void restoreMapState_shouldPersistPosition() throws Exception {
     verify(mapController).setPosition(new LngLat(0, 0));
   }


### PR DESCRIPTION
### Overview
Resets the `setSceneLoadListener` when the `MapView` is destroyed

### Proposed Changes
- Adds more test coverage

Closes #471 