### PR TITLE
Lost 3.0.3

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
   compile "com.mapzen.tangram:tangram:$tangram_version"
   compile 'com.mapzen.android:pelias-android-sdk:1.2.0'
-  compile 'com.mapzen.android:lost:3.0.0'
+  compile 'com.mapzen.android:lost:3.0.3'
 
   compile 'com.google.dagger:dagger:2.0'
   compile 'javax.annotation:javax.annotation-api:1.2'


### PR DESCRIPTION
### Overview
Upgrades Lost dependency from 3.0.0 to 3.0.3. 

This upgrade includes stability and bug fixes. It also removes (https://github.com/mapzen/lost/releases/tag/lost-3.0.2) throwing of `IllegalStateException`s and instead logs the `RemoteException` thrown (more work will be done to fully support error handling https://github.com/mapzen/lost/issues/229)

Closes #469 