### PR TITLE
Upgrade Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ An [open source](https://github.com/mapzen/eraser-map) privacy-focused reference
 ![screenshot](assets/eraser-map.png)
 
 Beta builds of Eraser Map (plus the SDK demo apps and other science projects) are available on the [Mapzen Android download page](http://android.mapzen.com/).
+
+# Building From Source
+
+If you would like to build the Mapzen Android SDK directly from master, we recommend using Android Studio 3.0. We upgraded our gradle build scripts to take advantage of the [new dependency configurations](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations) in gradle which means that if you would like to use earlier versions of Android Studio, you will have to revert to the deprecated configuration.

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.0'
     classpath 'net.researchgate:gradle-release:2.4.0'
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -143,12 +143,6 @@
             <property name="severity" value="ignore"/>
         </module>
         <module name="MissingSwitchDefault"/>
-        <!-- Problem with finding exception types... -->
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-            <property name="severity" value="info"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,24 +77,24 @@ assemble.doFirst {
 }
 
 dependencies {
-  compile 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:appcompat-v7:26.1.0'
 
-  compile project(':bubble-wrap')
-  compile project(':cinnabar')
-  compile project(':refill')
-  compile project(':walkabout')
-  compile "com.mapzen.tangram:tangram:$tangram_version"
-  compile 'com.mapzen.android:pelias-android-sdk:1.2.0'
-  compile 'com.mapzen.android:lost:3.0.3'
+  implementation project(':bubble-wrap')
+  implementation project(':cinnabar')
+  implementation project(':refill')
+  implementation project(':walkabout')
+  api "com.mapzen.tangram:tangram:$tangram_version"
+  api 'com.mapzen.android:pelias-android-sdk:1.2.0'
+  api 'com.mapzen.android:lost:3.0.3'
 
-  compile 'com.google.dagger:dagger:2.0'
-  compile 'javax.annotation:javax.annotation-api:1.2'
+  api 'com.google.dagger:dagger:2.0'
+  api 'javax.annotation:javax.annotation-api:1.2'
 
   annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.assertj:assertj-core:1.7.1'
-  testCompile 'org.powermock:powermock:1.6.4'
-  testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-  testCompile 'org.powermock:powermock-api-mockito:1.6.4'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.assertj:assertj-core:1.7.1'
+  testImplementation 'org.powermock:powermock:1.6.4'
+  testImplementation 'org.powermock:powermock-module-junit4:1.6.4'
+  testImplementation 'org.powermock:powermock-api-mockito:1.6.4'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 11:34:03 PDT 2015
+#Thu Oct 26 16:45:08 MDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/mapzen-android-sdk/build.gradle
+++ b/mapzen-android-sdk/build.gradle
@@ -5,9 +5,7 @@ buildscript {
     maven {
       url 'https://plugins.gradle.org/m2/'
     }
-    maven {
-      url "https://maven.google.com"
-    }
+    google()
   }
   dependencies {
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
@@ -60,18 +58,18 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile project(':core')
-  compile ('com.mapzen:on-the-road:1.3.0') {
+  api project(':core')
+  api ('com.mapzen:on-the-road:1.3.0') {
     exclude group: 'com.squareup.retrofit2', module: 'converter-gson'
   }
 
   annotationProcessor 'com.google.dagger:dagger-compiler:2.0'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.assertj:assertj-core:1.7.1'
-  testCompile 'org.powermock:powermock:1.6.4'
-  testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-  testCompile 'org.powermock:powermock-api-mockito:1.6.4'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.assertj:assertj-core:1.7.1'
+  testImplementation 'org.powermock:powermock:1.6.4'
+  testImplementation 'org.powermock:powermock-module-junit4:1.6.4'
+  testImplementation 'org.powermock:powermock-api-mockito:1.6.4'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
+++ b/mapzen-android-sdk/src/main/java/com/mapzen/android/routing/MapzenRouter.java
@@ -167,8 +167,8 @@ public class MapzenRouter {
    * Units of distance.
    */
   public enum DistanceUnits {
-    MILES ("miles"),
-    KILOMETERS ("kilometers");
+    MILES("miles"),
+    KILOMETERS("kilometers");
 
     private final String name;
 

--- a/mapzen-places-api/build.gradle
+++ b/mapzen-places-api/build.gradle
@@ -54,14 +54,14 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile project(':core')
-  compile 'com.android.support:appcompat-v7:26.1.0'
+  api project(':core')
+  implementation 'com.android.support:appcompat-v7:26.1.0'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.assertj:assertj-core:1.7.1'
-  testCompile 'org.powermock:powermock:1.6.4'
-  testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-  testCompile 'org.powermock:powermock-api-mockito:1.6.4'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.assertj:assertj-core:1.7.1'
+  testImplementation 'org.powermock:powermock:1.6.4'
+  testImplementation 'org.powermock:powermock-module-junit4:1.6.4'
+  testImplementation 'org.powermock:powermock-api-mockito:1.6.4'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/samples/mapzen-android-sdk-sample/build.gradle
+++ b/samples/mapzen-android-sdk-sample/build.gradle
@@ -37,8 +37,8 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile(project(':mapzen-android-sdk'))
-  compile(project(':tron'))
-  compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.android.support:design:26.1.0'
+  implementation(project(':mapzen-android-sdk'))
+  implementation(project(':tron'))
+  implementation 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:design:26.1.0'
 }

--- a/samples/mapzen-places-api-sample/build.gradle
+++ b/samples/mapzen-places-api-sample/build.gradle
@@ -33,9 +33,7 @@ task checkstyle(type: Checkstyle) {
 }
 
 dependencies {
-  compile(project(':mapzen-places-api')) {
-    transitive = true;
-  }
-  compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.android.support:design:26.1.0'
+  implementation(project(':mapzen-places-api'))
+  implementation 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:design:26.1.0'
 }

--- a/samples/mapzen-sample/build.gradle
+++ b/samples/mapzen-sample/build.gradle
@@ -61,18 +61,18 @@ ktlint {
 }
 
 dependencies {
-  compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-  compile 'com.android.support:appcompat-v7:26.1.0'
-  compile 'com.android.support:design:26.1.0'
-  compile(project(':mapzen-android-sdk'))
-  compile(project(':tron'))
-  compile 'com.jakewharton:kotterknife:0.1.0-SNAPSHOT'
-  compile 'com.google.dagger:dagger:2.0'
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+  implementation 'com.android.support:appcompat-v7:26.1.0'
+  implementation 'com.android.support:design:26.1.0'
+  implementation(project(':mapzen-android-sdk'))
+  implementation(project(':tron'))
+  implementation 'com.jakewharton:kotterknife:0.1.0-SNAPSHOT'
+  implementation 'com.google.dagger:dagger:2.0'
 
   kapt 'com.google.dagger:dagger-compiler:2.0'
 
-  testCompile 'junit:junit:4.12'
-  testCompile 'org.assertj:assertj-core:3.8.0'
-  testCompile 'org.mockito:mockito-core:2.10.0'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.assertj:assertj-core:3.8.0'
+  testImplementation 'org.mockito:mockito-core:2.10.0'
 }


### PR DESCRIPTION
### Overview
Upgrades to Gradle 4.1/Gradle Plugin 3.0.0 for use with Android Studio 3.0

### Proposed Changes
- Follows the migration guide to take advantage of build performance increases (https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html)
- Updates README to note that developers who wish to build the SDK from source will have to revert build scripts to use deprecated methods
- Removes deprecated checkstyle rule (https://github.com/checkstyle/checkstyle/issues/473)

Closes #504 