### PR TITLE
Multiple Map Instances

### DIFF
--- a/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
+++ b/core/src/main/java/com/mapzen/android/graphics/GraphicsModule.java
@@ -19,16 +19,8 @@ import dagger.Provides;
    * {@link MapzenMap}.
    * @return
    */
-  @Provides @Singleton public MapDataManager providesMapDataManager() {
-    return new MapDataManager();
-  }
-
-  /**
-   * Returns the object used to persist map position/zoom/tilt on a {@link MapzenMap}.
-   * @return
-   */
-  @Provides @Singleton public MapStateManager providesMapStateManager() {
-    return new MapStateManager();
+  @Provides @Singleton public PersistDataManagers providesPersistDataManagers() {
+    return PersistDataManagers.instance();
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
@@ -98,7 +98,8 @@ public class MapFragment extends Fragment {
    *
    * Also sets {@link Locale} used to determine default language when rendering map labels.
    */
-  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale, final OnMapReadyCallback callback) {
+  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale,
+      final OnMapReadyCallback callback) {
     mapView.getMapAsync(mapStyle, mapId, locale, callback);
   }
 

--- a/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapFragment.java
@@ -56,6 +56,14 @@ public class MapFragment extends Fragment {
 
   /**
    * Asynchronously creates the map and configures the vector tiles API key using the string
+   * resource declared in the client application. Uses default stylesheet (bubble wrap).
+   */
+  public void getMapAsync(String mapId, final OnMapReadyCallback callback) {
+    mapView.getMapAsync(mapId, callback);
+  }
+
+  /**
+   * Asynchronously creates the map and configures the vector tiles API key using the string
    * resource declared in the client application. Configures the stylesheet using the stylesheet
    * parameter.
    */
@@ -67,11 +75,31 @@ public class MapFragment extends Fragment {
    * Asynchronously creates the map and configures the vector tiles API key using the string
    * resource declared in the client application. Configures the stylesheet using the stylesheet
    * parameter.
+   */
+  public void getMapAsync(String mapId, MapStyle mapStyle, final OnMapReadyCallback callback) {
+    mapView.getMapAsync(mapId, mapStyle, callback);
+  }
+
+  /**
+   * Asynchronously creates the map and configures the vector tiles API key using the string
+   * resource declared in the client application. Configures the stylesheet using the stylesheet
+   * parameter.
    *
    * Also sets {@link Locale} used to determine default language when rendering map labels.
    */
   public void getMapAsync(MapStyle mapStyle, Locale locale, final OnMapReadyCallback callback) {
     mapView.getMapAsync(mapStyle, locale, callback);
+  }
+
+  /**
+   * Asynchronously creates the map and configures the vector tiles API key using the string
+   * resource declared in the client application. Configures the stylesheet using the stylesheet
+   * parameter.
+   *
+   * Also sets {@link Locale} used to determine default language when rendering map labels.
+   */
+  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale, final OnMapReadyCallback callback) {
+    mapView.getMapAsync(mapStyle, mapId, locale, callback);
   }
 
   @Override public void onDestroy() {

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -126,17 +126,17 @@ public class MapInitializer {
     loadMap(mapView, mapId, mapStyle, callback);
   }
 
-  private void loadMap(final MapView mapView, String mapId, MapStyle mapStyle,
+  private void loadMap(final MapView mapView, final String mapId, MapStyle mapStyle,
       final OnMapReadyCallback callback) {
     final MapStateManager mapStateManager = persistDataManagers.getMapStateManager(mapId);
     final String apiKey = MapzenManager.instance(context).getApiKey();
     final List<SceneUpdate> sceneUpdates = sceneUpdateManager.getUpdatesFor(apiKey, locale,
         mapStateManager.isTransitOverlayEnabled(), mapStateManager.isBikeOverlayEnabled(),
         mapStateManager.isPathOverlayEnabled());
+    final MapDataManager mapDataManager = persistDataManagers.getMapDataManager(mapId);
     controller = mapView.getTangramMapView().getMap(
         new MapController.SceneLoadListener() {
       @Override public void onSceneReady(int sceneId, SceneError sceneError) {
-        MapDataManager mapDataManager = persistDataManagers.getMapDataManager(null);
         mapReadyInitializer.onMapReady(mapView, mapzenMapHttpHandler, callback, mapDataManager,
             mapStateManager, sceneUpdateManager, locale, bitmapMarkerManager, yamlGenerator);
       }

--- a/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapInitializer.java
@@ -6,7 +6,6 @@ import com.mapzen.android.graphics.model.BubbleWrapStyle;
 import com.mapzen.android.graphics.model.MapStyle;
 import com.mapzen.android.graphics.model.ThemedMapStyle;
 import com.mapzen.tangram.MapController;
-import com.mapzen.tangram.MapData;
 import com.mapzen.tangram.SceneError;
 import com.mapzen.tangram.SceneUpdate;
 
@@ -81,7 +80,8 @@ public class MapInitializer {
    * Initialize map for current {@link MapView} and {@link MapStyle} before notifying via
    * {@link OnMapReadyCallback}.
    */
-  public void init(final MapView mapView, String mapId, MapStyle mapStyle, final OnMapReadyCallback callback) {
+  public void init(final MapView mapView, String mapId, MapStyle mapStyle,
+      final OnMapReadyCallback callback) {
     loadMap(mapView, mapId, mapStyle, true, callback);
   }
 

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -124,6 +124,16 @@ public class MapView extends RelativeLayout {
    * Load map asynchronously using APK key declared in XML resources. For example:
    * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
    *
+   * @param callback listener to be invoked when map is initialized and ready to use.
+   */
+  public void getMapAsync(@NonNull String mapId, @NonNull OnMapReadyCallback callback) {
+    mapInitializer.init(this, mapId, callback);
+  }
+
+  /**
+   * Load map asynchronously using APK key declared in XML resources. For example:
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
+   *
    * @param mapStyle mapStyle that should be set.
    * @param callback listener to be invoked when map is initialized and ready to use.
    */
@@ -136,11 +146,34 @@ public class MapView extends RelativeLayout {
    * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
    *
    * @param mapStyle mapStyle that should be set.
+   * @param callback listener to be invoked when map is initialized and ready to use.
+   */
+  public void getMapAsync(String mapId, MapStyle mapStyle, @NonNull OnMapReadyCallback callback) {
+    mapInitializer.init(this, mapId, mapStyle, callback);
+  }
+
+  /**
+   * Load map asynchronously using APK key declared in XML resources. For example:
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
+   *
+   * @param mapStyle mapStyle that should be set.
    * @param locale used to determine language that should be used for map labels.
    * @param callback listener to be invoked when map is initialized and ready to use.
    */
   public void getMapAsync(MapStyle mapStyle, Locale locale, @NonNull OnMapReadyCallback callback) {
     mapInitializer.init(this, mapStyle, locale, callback);
+  }
+
+  /**
+   * Load map asynchronously using APK key declared in XML resources. For example:
+   * {@code <string name="mapzen_api_key">[YOUR_API_KEY]</string>}
+   *
+   * @param mapStyle mapStyle that should be set.
+   * @param locale used to determine language that should be used for map labels.
+   * @param callback listener to be invoked when map is initialized and ready to use.
+   */
+  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale, @NonNull OnMapReadyCallback callback) {
+    mapInitializer.init(this, mapId, mapStyle, locale, callback);
   }
 
   /**

--- a/core/src/main/java/com/mapzen/android/graphics/MapView.java
+++ b/core/src/main/java/com/mapzen/android/graphics/MapView.java
@@ -172,7 +172,8 @@ public class MapView extends RelativeLayout {
    * @param locale used to determine language that should be used for map labels.
    * @param callback listener to be invoked when map is initialized and ready to use.
    */
-  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale, @NonNull OnMapReadyCallback callback) {
+  public void getMapAsync(MapStyle mapStyle, String mapId, Locale locale,
+      @NonNull OnMapReadyCallback callback) {
     mapInitializer.init(this, mapId, mapStyle, locale, callback);
   }
 

--- a/core/src/main/java/com/mapzen/android/graphics/PersistDataManagers.java
+++ b/core/src/main/java/com/mapzen/android/graphics/PersistDataManagers.java
@@ -1,0 +1,60 @@
+package com.mapzen.android.graphics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Singleton to manage restoring {@link MapzenMap} state after orientation changes.
+ */
+public class PersistDataManagers {
+
+  private static PersistDataManagers instance;
+
+  private Map<String, MapStateManager> mapStateManagers = new HashMap<>();
+  private MapStateManager defaultMapStateManager = new MapStateManager();
+  private Map<String, MapDataManager> mapDataManagers = new HashMap<>();
+  private MapDataManager defaultMapDataManager = new MapDataManager();
+
+  /**
+   * Get singleton instance.
+   */
+  public static PersistDataManagers instance() {
+    if (instance == null) {
+      instance = new PersistDataManagers();
+    }
+
+    return instance;
+  }
+
+  public MapStateManager getMapStateManager(String mapId) {
+    if (mapId == null) {
+      return defaultMapStateManager;
+    }
+    MapStateManager manager = mapStateManagers.get(mapId);
+    if (manager == null) {
+      manager = new MapStateManager();
+      mapStateManagers.put(mapId, manager);
+    }
+    return manager;
+  }
+
+  public MapStateManager getDefaultMapStateManager() {
+    return defaultMapStateManager;
+  }
+
+  public MapDataManager getMapDataManager(String mapId) {
+    if (mapId == null) {
+      return defaultMapDataManager;
+    }
+    MapDataManager manager = mapDataManagers.get(mapId);
+    if (manager == null) {
+      manager = new MapDataManager();
+      mapDataManagers.put(mapId, manager);
+    }
+    return manager;
+  }
+
+  public MapDataManager getDefaultMapDataManager() {
+    return defaultMapDataManager;
+  }
+}

--- a/core/src/main/java/com/mapzen/android/graphics/PersistDataManagers.java
+++ b/core/src/main/java/com/mapzen/android/graphics/PersistDataManagers.java
@@ -26,6 +26,12 @@ public class PersistDataManagers {
     return instance;
   }
 
+  /**
+   * Returns the manager for a given map id. If the id passed is null, the global default manager
+   * is returned.
+   * @param mapId
+   * @return
+   */
   public MapStateManager getMapStateManager(String mapId) {
     if (mapId == null) {
       return defaultMapStateManager;
@@ -38,10 +44,21 @@ public class PersistDataManagers {
     return manager;
   }
 
+  /**
+   * Returns the global default manager.
+   * is returned.
+   * @return
+   */
   public MapStateManager getDefaultMapStateManager() {
     return defaultMapStateManager;
   }
 
+  /**
+   * Returns the manager for a given map id. If the id passed is null, the global default manager
+   * is returned.
+   * @param mapId
+   * @return
+   */
   public MapDataManager getMapDataManager(String mapId) {
     if (mapId == null) {
       return defaultMapDataManager;
@@ -54,6 +71,11 @@ public class PersistDataManagers {
     return manager;
   }
 
+  /**
+   * Returns the global default manager.
+   * is returned.
+   * @return
+   */
   public MapDataManager getDefaultMapDataManager() {
     return defaultMapDataManager;
   }

--- a/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
+++ b/core/src/test/java/com/mapzen/android/graphics/MapInitializerTest.java
@@ -47,9 +47,10 @@ public class MapInitializerTest {
 
   @Before public void setUp() throws Exception {
     CoreDI.init(getMockContext());
-    mapStateManager = new MapStateManager();
+    PersistDataManagers persistDataManagers = new PersistDataManagers();
+    mapStateManager = persistDataManagers.getDefaultMapStateManager();
     mapInitializer = new MapInitializer(mock(Context.class), mock(MapzenMapHttpHandler.class),
-        new MapDataManager(), mapStateManager, new SceneUpdateManager(),
+        persistDataManagers, new SceneUpdateManager(),
         new BitmapMarkerManager(null, null), new ImportYamlGenerator());
   }
 


### PR DESCRIPTION
### Overview
Internal marker manager singletons are now scoped to map instances allowing support for multiple `MapzenMap` instances within a single application. 

### Proposed Changes
- Adds new parameter to pass a unique map id
- If no parameter is passed, the global map is used (same behavior as before)

Closes #436 